### PR TITLE
fix: add limits to most UPDATE and DELETE queries

### DIFF
--- a/pkg/access/jobs.go
+++ b/pkg/access/jobs.go
@@ -88,7 +88,8 @@ func (a *Jobs[U, T, V]) Clear(ctx context.Context, tx qrm.DB, targetId int64) (T
 		DELETE().
 		WHERE(
 			a.columns.TargetID.EQ(mysql.Int64(targetId)),
-		)
+		).
+		LIMIT(100)
 
 	var dest T
 	if err := stmt.QueryContext(ctx, tx, &dest); err != nil {

--- a/pkg/access/jobs_entry.go
+++ b/pkg/access/jobs_entry.go
@@ -83,7 +83,8 @@ func (a *Jobs[U, T, AccessLevel]) UpdateEntry(
 		WHERE(mysql.AND(
 			a.columns.ID.EQ(mysql.Int64(entry.GetId())),
 			a.columns.TargetID.EQ(mysql.Int64(targetId)),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return err

--- a/pkg/access/qualifications.go
+++ b/pkg/access/qualifications.go
@@ -147,7 +147,8 @@ func (a *Qualifications[U, T, V]) Clear(
 		DELETE().
 		WHERE(
 			a.columns.TargetID.EQ(mysql.Int64(targetId)),
-		)
+		).
+		LIMIT(100)
 
 	var dest T
 	if err := stmt.QueryContext(ctx, tx, &dest); err != nil {

--- a/pkg/access/qualifications_entry.go
+++ b/pkg/access/qualifications_entry.go
@@ -92,7 +92,8 @@ func (a *Qualifications[U, T, AccessLevel]) UpdateEntry(
 		WHERE(mysql.AND(
 			a.columns.ID.EQ(mysql.Int64(entry.GetId())),
 			a.columns.TargetID.EQ(mysql.Int64(targetId)),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return err

--- a/pkg/access/users.go
+++ b/pkg/access/users.go
@@ -97,7 +97,8 @@ func (a *Users[U, T, V]) Clear(ctx context.Context, tx qrm.DB, targetId int64) (
 		DELETE().
 		WHERE(
 			a.columns.TargetID.EQ(mysql.Int64(targetId)),
-		)
+		).
+		LIMIT(100)
 
 	var dest T
 	if err := stmt.QueryContext(ctx, tx, &dest); err != nil {

--- a/pkg/access/users_entry.go
+++ b/pkg/access/users_entry.go
@@ -93,7 +93,8 @@ func (a *Users[U, T, AccessLevel]) UpdateEntry(
 		WHERE(mysql.AND(
 			a.columns.ID.EQ(mysql.Int64(entry.GetId())),
 			a.columns.TargetID.EQ(mysql.Int64(targetId)),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return err

--- a/pkg/demo/fake_users.go
+++ b/pkg/demo/fake_users.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	colleaguesactivity "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/jobs/colleagues/activity"
 	"github.com/fivenet-app/fivenet/v2026/services/sync"
 	"github.com/go-jet/jet/v2/mysql"
@@ -244,12 +245,24 @@ func (d *Demo) lookupTargetJobUsersForActivity(
 }
 
 func (d *Demo) clearDemoColleagueActivity(ctx context.Context, tx *sql.Tx, job string) error {
+	condition := mysql.AND(
+		tJobColleagueActivity.Job.EQ(mysql.String(job)),
+		tJobColleagueActivity.Reason.LIKE(mysql.String(demoColleagueActivityReasonPrefix+"%")),
+	)
+
+	var count database.DataCount
+	countStmt := tJobColleagueActivity.
+		SELECT(mysql.COUNT(tJobColleagueActivity.Job).AS("data_count.total")).
+		FROM(tJobColleagueActivity).
+		WHERE(condition)
+	if err := countStmt.QueryContext(ctx, tx, &count); err != nil {
+		return fmt.Errorf("failed to count demo colleague activity rows for job %s. %w", job, err)
+	}
+
 	stmt := tJobColleagueActivity.
 		DELETE().
-		WHERE(mysql.AND(
-			tJobColleagueActivity.Job.EQ(mysql.String(job)),
-			tJobColleagueActivity.Reason.LIKE(mysql.String(demoColleagueActivityReasonPrefix+"%")),
-		))
+		WHERE(condition).
+		LIMIT(count.Total)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return fmt.Errorf("failed to clear demo colleague activity rows for job %s. %w", job, err)

--- a/pkg/demo/fake_vehicles.go
+++ b/pkg/demo/fake_vehicles.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	"github.com/go-jet/jet/v2/mysql"
 	"github.com/go-jet/jet/v2/qrm"
 	"go.uber.org/zap"
@@ -160,16 +161,38 @@ func (d *Demo) lookupVehicleOwners(
 }
 
 func (d *Demo) clearDemoVehicles(ctx context.Context, tx *sql.Tx) error {
+	propsCondition := tVehicleProps.Plate.LIKE(mysql.String(demoVehiclePlatePrefix + "%"))
+	var propsCount database.DataCount
+	propsCountStmt := tVehicleProps.
+		SELECT(mysql.COUNT(tVehicleProps.Plate).AS("data_count.total")).
+		FROM(tVehicleProps).
+		WHERE(propsCondition)
+	if err := propsCountStmt.QueryContext(ctx, tx, &propsCount); err != nil {
+		return fmt.Errorf("failed to count demo vehicle props. %w", err)
+	}
+
 	propsStmt := tVehicleProps.
 		DELETE().
-		WHERE(tVehicleProps.Plate.LIKE(mysql.String(demoVehiclePlatePrefix + "%")))
+		WHERE(propsCondition).
+		LIMIT(propsCount.Total)
 	if _, err := propsStmt.ExecContext(ctx, tx); err != nil {
 		return fmt.Errorf("failed to clear demo vehicle props. %w", err)
 	}
 
+	vehiclesCondition := tOwnedVehicles.Plate.LIKE(mysql.String(demoVehiclePlatePrefix + "%"))
+	var vehiclesCount database.DataCount
+	vehiclesCountStmt := tOwnedVehicles.
+		SELECT(mysql.COUNT(tOwnedVehicles.Plate).AS("data_count.total")).
+		FROM(tOwnedVehicles).
+		WHERE(vehiclesCondition)
+	if err := vehiclesCountStmt.QueryContext(ctx, tx, &vehiclesCount); err != nil {
+		return fmt.Errorf("failed to count demo vehicles. %w", err)
+	}
+
 	vehiclesStmt := tOwnedVehicles.
 		DELETE().
-		WHERE(tOwnedVehicles.Plate.LIKE(mysql.String(demoVehiclePlatePrefix + "%")))
+		WHERE(vehiclesCondition).
+		LIMIT(vehiclesCount.Total)
 	if _, err := vehiclesStmt.ExecContext(ctx, tx); err != nil {
 		return fmt.Errorf("failed to clear demo vehicles. %w", err)
 	}

--- a/pkg/discord/guild.go
+++ b/pkg/discord/guild.go
@@ -426,7 +426,8 @@ func (g *Guild) setLastSyncInterval(
 		).
 		WHERE(
 			tJobProps.Job.EQ(mysql.String(job)),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, g.bot.db); err != nil {
 		return fmt.Errorf("failed to update job last sync data. %w", err)

--- a/pkg/filestore/embed.go
+++ b/pkg/filestore/embed.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/file"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pbfilestore "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/filestore"
@@ -281,6 +282,7 @@ func (h *Handler[P]) deleteJoinRow(
 				h.parentColBoolExp(parentID),
 				h.fileCol.EQ(mysql.Int64(fileID)),
 			)).
+			LIMIT(1).
 			ExecContext(ctx, tx)
 		return err
 	}
@@ -291,6 +293,7 @@ func (h *Handler[P]) deleteJoinRow(
 			h.parentColBoolExp(parentID),
 			h.fileCol.EQ(mysql.Int64(fileID)),
 		)).
+		LIMIT(1).
 		ExecContext(ctx, tx)
 	return err
 }
@@ -413,6 +416,7 @@ func upsertFileRow(ctx context.Context, tx *sql.Tx, key, ctype string, size int6
 				tFiles.DeletedAt.SET(mysql.TimestampExp(mysql.NULL)), // Revive if file was soft-deleted
 			).
 			WHERE(tFiles.ID.EQ(mysql.Int64(fileId.ID))).
+			LIMIT(1).
 			ExecContext(ctx, tx); err != nil {
 			return 0, err
 		}
@@ -498,18 +502,16 @@ func putToStorage(
 // CountFilesForParentID returns the number of files associated with a given parent ID.
 func (h *Handler[P]) CountFilesForParentID(ctx context.Context, parentID P) (int64, error) {
 	stmt := h.joinTable.
-		SELECT(mysql.COUNT(h.fileCol).AS("count")).
+		SELECT(mysql.COUNT(h.fileCol).AS("data_count.total")).
 		FROM(h.joinTable).
 		WHERE(h.parentColBoolExp(parentID))
 
-	var count struct {
-		Count int64 `jet:"count"`
-	}
+	var count database.DataCount
 	if err := stmt.QueryContext(ctx, h.db, &count); err != nil {
 		return 0, err
 	}
 
-	return count.Count, nil
+	return count.Total, nil
 }
 
 // ListFilesForParentID returns a list of files associated with a given parent ID.

--- a/pkg/filestore/housekeeper.go
+++ b/pkg/filestore/housekeeper.go
@@ -245,6 +245,7 @@ func (h *Housekeeper) Run(ctx context.Context) (int64, error) {
 			if _, err := tFiles.
 				DELETE().
 				WHERE(tFiles.ID.EQ(mysql.Int64(c.GetId()))).
+				LIMIT(1).
 				ExecContext(ctx, tx); err != nil {
 				if err := tx.Rollback(); err != nil {
 					h.logger.Error(

--- a/pkg/perms/attrs.go
+++ b/pkg/perms/attrs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"slices"
 
+	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	permissionsattributes "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/permissions/attributes"
 	permissionsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/permissions/events"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
@@ -262,7 +263,8 @@ func (ps *Perms) updateAttribute(
 		).
 		WHERE(
 			tAttrs.ID.EQ(mysql.Int64(attrId)),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, ps.db); err != nil {
 		return fmt.Errorf("failed to execute update statement. %w", err)
@@ -911,7 +913,8 @@ func (ps *Perms) RemoveAttributesFromRole(
 		WHERE(mysql.AND(
 			tRoleAttrs.RoleID.EQ(mysql.Int64(roleId)),
 			tRoleAttrs.AttrID.IN(ids...),
-		))
+		)).
+		LIMIT(int64(len(ids)))
 
 	if _, err := stmt.ExecContext(ctx, ps.db); err != nil {
 		return fmt.Errorf("failed to execute delete statement for role attributes. %w", err)
@@ -1017,9 +1020,19 @@ func (ps *Perms) UpdateJobAttributes(
 }
 
 func (ps *Perms) ClearJobAttributes(ctx context.Context, job string) error {
+	var count database.DataCount
+	countStmt := tJobAttrs.
+		SELECT(mysql.COUNT(tJobAttrs.AttrID).AS("data_count.total")).
+		FROM(tJobAttrs).
+		WHERE(tJobAttrs.Job.EQ(mysql.String(job)))
+	if err := countStmt.QueryContext(ctx, ps.db, &count); err != nil {
+		return fmt.Errorf("failed to execute count statement for job attributes. %w", err)
+	}
+
 	stmt := tJobAttrs.
 		DELETE().
-		WHERE(tJobAttrs.Job.EQ(mysql.String(job)))
+		WHERE(tJobAttrs.Job.EQ(mysql.String(job))).
+		LIMIT(count.Total)
 
 	if _, err := stmt.ExecContext(ctx, ps.db); err != nil {
 		return fmt.Errorf("failed to execute delete statement for job attributes. %w", err)

--- a/pkg/perms/roles.go
+++ b/pkg/perms/roles.go
@@ -648,11 +648,21 @@ func (p *Perms) UpdateJobPermissions(
 }
 
 func (ps *Perms) ClearJobPermissions(ctx context.Context, job string) error {
+	var count database.DataCount
+	countStmt := tJobPerms.
+		SELECT(mysql.COUNT(tJobPerms.PermissionID).AS("data_count.total")).
+		FROM(tJobPerms).
+		WHERE(tJobPerms.Job.EQ(mysql.String(job)))
+	if err := countStmt.QueryContext(ctx, ps.db, &count); err != nil {
+		return fmt.Errorf("failed to count job permissions for job %s. %w", job, err)
+	}
+
 	stmt := tJobPerms.
 		DELETE().
 		WHERE(
 			tJobPerms.Job.EQ(mysql.String(job)),
-		)
+		).
+		LIMIT(count.Total)
 
 	if _, err := stmt.ExecContext(ctx, ps.db); err != nil {
 		if !dbutils.IsDuplicateError(err) {

--- a/pkg/stats/service.go
+++ b/pkg/stats/service.go
@@ -123,12 +123,15 @@ func (s *Service) RebuildDocumentMetricsTx(
 
 	tMetric := table.FivenetDocumentsStatsMetric
 	for _, source := range sources {
+		deleteCondition := mysql.AND(
+			tMetric.DocumentID.EQ(mysql.Int64(doc.GetId())),
+			tMetric.SourceKey.EQ(mysql.String(source)),
+		)
+
 		if _, err := tMetric.
 			DELETE().
-			WHERE(mysql.AND(
-				tMetric.DocumentID.EQ(mysql.Int64(doc.GetId())),
-				tMetric.SourceKey.EQ(mysql.String(source)),
-			)).
+			WHERE(deleteCondition).
+			LIMIT(10000).
 			ExecContext(ctx, tx); err != nil {
 			return err
 		}
@@ -665,6 +668,7 @@ func (s *Service) clearDocumentMetrics(ctx context.Context, tx qrm.DB, documentI
 	_, err := tMetric.
 		DELETE().
 		WHERE(tMetric.DocumentID.EQ(mysql.Int64(documentID))).
+		LIMIT(10000).
 		ExecContext(ctx, tx)
 	return err
 }

--- a/pkg/stats/service_jobs.go
+++ b/pkg/stats/service_jobs.go
@@ -30,17 +30,20 @@ func (s *Service) BuildEmployeeCountMetrics(ctx context.Context) error {
 	}
 	defer tx.Rollback()
 
+	rollupCondition := mysql.AND(
+		tRollup.Day.EQ(mysql.DateT(day)),
+		tRollup.SourceKind.EQ(mysql.String(SourceKindEmployeeCount)),
+		tRollup.SourceKey.EQ(mysql.String("fivenet_user_jobs")),
+		tRollup.MetricKey.IN(
+			mysql.String("employee_count"),
+			mysql.String("on_vacation_count"),
+		),
+	)
+
 	if _, err := tRollup.
 		DELETE().
-		WHERE(mysql.AND(
-			tRollup.Day.EQ(mysql.DateT(day)),
-			tRollup.SourceKind.EQ(mysql.String(SourceKindEmployeeCount)),
-			tRollup.SourceKey.EQ(mysql.String("fivenet_user_jobs")),
-			tRollup.MetricKey.IN(
-				mysql.String("employee_count"),
-				mysql.String("on_vacation_count"),
-			),
-		)).
+		WHERE(rollupCondition).
+		LIMIT(10000).
 		ExecContext(ctx, tx); err != nil {
 		return err
 	}

--- a/pkg/tracker/manager/manager_test.go
+++ b/pkg/tracker/manager/manager_test.go
@@ -288,7 +288,8 @@ func insertCitizenLocations(
 func removeUserLocations(ctx context.Context, db *sql.DB) error {
 	stmt := tLocs.
 		DELETE().
-		WHERE(tLocs.UserID.IS_NOT_NULL().OR(tLocs.UserID.IS_NULL()))
+		WHERE(tLocs.UserID.IS_NOT_NULL().OR(tLocs.UserID.IS_NULL())).
+		LIMIT(10000)
 
 	_, err := stmt.ExecContext(ctx, db)
 

--- a/services/calendar/calendar.go
+++ b/services/calendar/calendar.go
@@ -8,9 +8,11 @@ import (
 	calendar "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/calendar"
 	calendaraccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/calendar/access"
 	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	pbcalendar "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/calendar"
 	permscalendar "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/calendar/perms"
+	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/errswrap"
 	grpc_audit "github.com/fivenet-app/fivenet/v2026/pkg/grpc/interceptors/audit"
@@ -550,9 +552,12 @@ func (s *Server) DeleteCalendar(
 		return nil, errorscalendar.ErrNoPerms
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if calendar.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if calendar.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	stmt := tCalendar.
@@ -560,7 +565,7 @@ func (s *Server) DeleteCalendar(
 			tCalendar.DeletedAt,
 		).
 		SET(
-			tCalendar.DeletedAt.SET(deletedAtTime),
+			tCalendar.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(tCalendar.ID.EQ(mysql.Int64(req.GetCalendarId()))).
 		LIMIT(1)

--- a/services/calendar/entries.go
+++ b/services/calendar/entries.go
@@ -8,8 +8,10 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/audit"
 	calendaraccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/calendar/access"
 	calendarentries "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/calendar/entries"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	pbcalendar "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/calendar"
+	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/errswrap"
 	grpc_audit "github.com/fivenet-app/fivenet/v2026/pkg/grpc/interceptors/audit"
@@ -401,9 +403,12 @@ func (s *Server) DeleteCalendarEntry(
 		return nil, errorscalendar.ErrNoPerms
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if entry.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if entry.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	stmt := tCalendarEntry.
@@ -411,7 +416,7 @@ func (s *Server) DeleteCalendarEntry(
 			tCalendarEntry.DeletedAt,
 		).
 		SET(
-			tCalendarEntry.DeletedAt.SET(deletedAtTime),
+			tCalendarEntry.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(mysql.AND(
 			tCalendarEntry.CalendarID.EQ(mysql.Int64(entry.GetCalendarId())),
@@ -422,8 +427,6 @@ func (s *Server) DeleteCalendarEntry(
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorscalendar.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbcalendar.DeleteCalendarEntryResponse{}, nil
 }

--- a/services/centrum/dispatches/dispatches.go
+++ b/services/centrum/dispatches/dispatches.go
@@ -820,7 +820,8 @@ func (s *DispatchDB) UpdateAssignments(
 			WHERE(mysql.AND(
 				tDispatchUnit.DispatchID.EQ(mysql.Int64(dspId)),
 				tDispatchUnit.UnitID.IN(removeIds...),
-			))
+			)).
+			LIMIT(int64(len(removeIds)))
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return err

--- a/services/centrum/units/units.go
+++ b/services/centrum/units/units.go
@@ -559,7 +559,8 @@ func (s *UnitDB) UpdateUnitAssignments(
 			WHERE(mysql.AND(
 				tUnitUser.UnitID.EQ(mysql.Int64(unitId)),
 				tUnitUser.UserID.IN(removeIds...),
-			))
+			)).
+			LIMIT(int64(len(removeIds)))
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return err
@@ -858,7 +859,8 @@ func (s *UnitDB) Update(ctx context.Context, unit *centrumunits.Unit) (*centrumu
 		).
 		WHERE(mysql.AND(
 			tUnits.ID.EQ(mysql.Int64(unit.GetId())),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, err

--- a/services/citizens/labels.go
+++ b/services/citizens/labels.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/audit"
 	citizenslabels "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/citizens/labels"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	pbcitizens "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/citizens"
 	permscitizens "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/citizens/perms"
@@ -361,9 +362,12 @@ func (s *Server) DeleteLabel(
 		return nil, errorscitizens.ErrFailedQuery
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if label.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if label.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	stmt := tCitizensLabelsJob.
@@ -371,7 +375,7 @@ func (s *Server) DeleteLabel(
 			tCitizensLabelsJob.DeletedAt,
 		).
 		SET(
-			tCitizensLabelsJob.DeletedAt.SET(deletedAtTime),
+			tCitizensLabelsJob.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(mysql.AND(
 			tCitizensLabelsJob.ID.EQ(mysql.Int64(req.GetId())),
@@ -382,8 +386,6 @@ func (s *Server) DeleteLabel(
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorscitizens.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbcitizens.DeleteLabelResponse{}, nil
 }

--- a/services/documents/approval.go
+++ b/services/documents/approval.go
@@ -1007,6 +1007,7 @@ func (s *Server) DeleteApprovalTasks(
 		tApprovalTasks.DocumentID.EQ(mysql.Int64(pol.GetDocumentId())),
 		tApprovalTasks.SnapshotDate.EQ(mysql.DateTimeT(snap)),
 	)
+	deleteLimit := int64(1)
 
 	// Delete all pending?
 	if req.GetDeleteAllPending() {
@@ -1017,6 +1018,7 @@ func (s *Server) DeleteApprovalTasks(
 				),
 			),
 		)
+		deleteLimit = int64(max(1, int(pol.GetPendingCount())))
 	} else if len(req.GetTaskIds()) > 0 {
 		ids := make([]mysql.Expression, 0, len(req.GetTaskIds()))
 		for _, id := range req.GetTaskIds() {
@@ -1024,6 +1026,7 @@ func (s *Server) DeleteApprovalTasks(
 		}
 
 		condition = condition.AND(tApprovalTasks.ID.IN(ids...))
+		deleteLimit = int64(len(ids))
 	} else {
 		return &pbdocuments.DeleteApprovalTasksResponse{}, nil
 	}
@@ -1037,6 +1040,7 @@ func (s *Server) DeleteApprovalTasks(
 	if _, err := tApprovalTasks.
 		DELETE().
 		WHERE(condition).
+		LIMIT(deleteLimit).
 		ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
 	}

--- a/services/documents/category.go
+++ b/services/documents/category.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/audit"
 	documentscategory "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/category"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pbdocuments "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/documents"
+	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/errswrap"
 	grpc_audit "github.com/fivenet-app/fivenet/v2026/pkg/grpc/interceptors/audit"
@@ -154,7 +156,8 @@ func (s *Server) CreateOrUpdateCategory(
 			WHERE(mysql.AND(
 				tDCategory.ID.EQ(mysql.Int64(req.GetCategory().GetId())),
 				tDCategory.Job.EQ(mysql.String(userInfo.GetJob())),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
@@ -186,9 +189,12 @@ func (s *Server) DeleteCategory(
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if category.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if category.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	tDCategory := table.FivenetDocumentsCategories
@@ -197,7 +203,7 @@ func (s *Server) DeleteCategory(
 			tDCategory.DeletedAt,
 		).
 		SET(
-			tDCategory.DeletedAt.SET(deletedAtTime),
+			tDCategory.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(mysql.AND(
 			tDCategory.Job.EQ(mysql.String(userInfo.GetJob())),
@@ -208,8 +214,6 @@ func (s *Server) DeleteCategory(
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbdocuments.DeleteCategoryResponse{}, nil
 }

--- a/services/documents/comments.go
+++ b/services/documents/comments.go
@@ -317,7 +317,8 @@ func (s *Server) EditComment(
 		WHERE(mysql.AND(
 			tDComments.ID.EQ(mysql.Int64(req.GetComment().GetId())),
 			tDComments.DeletedAt.IS_NULL(),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
@@ -470,7 +471,8 @@ func (s *Server) DeleteComment(
 		WHERE(mysql.AND(
 			tDComments.ID.EQ(mysql.Int64(req.GetCommentId())),
 			tDComments.DeletedAt.IS_NULL(),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)

--- a/services/documents/documents.go
+++ b/services/documents/documents.go
@@ -642,7 +642,8 @@ func (s *Server) UpdateDocument(
 			).
 			WHERE(
 				tDocument.ID.EQ(mysql.Int64(oldDoc.GetId())),
-			)
+			).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
@@ -931,9 +932,12 @@ func (s *Server) DeleteDocument(
 		return nil, errorsdocuments.ErrDocDeleteDenied
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if doc.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if doc.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	stmt := tDocument.
@@ -941,7 +945,7 @@ func (s *Server) DeleteDocument(
 			tDocument.DeletedAt,
 		).
 		SET(
-			tDocument.DeletedAt.SET(deletedAtTime),
+			tDocument.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(
 			tDocument.ID.EQ(mysql.Int64(req.GetDocumentId())),
@@ -960,8 +964,6 @@ func (s *Server) DeleteDocument(
 	}); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbdocuments.DeleteDocumentResponse{}, nil
 }
@@ -1040,7 +1042,8 @@ func (s *Server) ToggleDocument(
 		).
 		WHERE(
 			tDocument.ID.EQ(mysql.Int64(doc.GetId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)

--- a/services/documents/relref.go
+++ b/services/documents/relref.go
@@ -370,7 +370,8 @@ func (s *Server) RemoveDocumentReference(
 		).
 		WHERE(
 			tDocRef.ID.EQ(mysql.Int64(req.GetId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
@@ -571,7 +572,8 @@ func (s *Server) RemoveDocumentRelation(
 		).
 		WHERE(
 			tDocRel.ID.EQ(mysql.Int64(req.GetId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)

--- a/services/documents/requests.go
+++ b/services/documents/requests.go
@@ -627,7 +627,8 @@ func (s *Server) updateDocumentReq(
 		).
 		WHERE(
 			tDocRequest.ID.EQ(mysql.Int64(id)),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		if !dbutils.IsDuplicateError(err) {

--- a/services/documents/templates.go
+++ b/services/documents/templates.go
@@ -445,7 +445,8 @@ func (s *Server) UpdateTemplate(
 		).
 		WHERE(
 			tDTemplates.ID.EQ(mysql.Int64(req.GetTemplate().GetId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)

--- a/services/documents/workflow_state.go
+++ b/services/documents/workflow_state.go
@@ -461,7 +461,8 @@ func (w *Workflow) autoCloseDocument(
 		).
 		WHERE(mysql.AND(
 			tDocument.ID.EQ(mysql.Int64(state.DocumentId)),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return err

--- a/services/jobs/conduct.go
+++ b/services/jobs/conduct.go
@@ -9,6 +9,7 @@ import (
 	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	jobsconduct "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/jobs/conduct"
 	notificationsclientview "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/clientview"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pbjobs "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/jobs"
 	permsjobs "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/jobs/perms"
 	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
@@ -553,9 +554,12 @@ func (s *Server) DeleteConductEntry(
 		return nil, errswrap.NewError(err, errorsjobs.ErrFailedQuery)
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if entry != nil && entry.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if entry == nil || entry.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	tConduct := table.FivenetJobConduct
@@ -564,18 +568,17 @@ func (s *Server) DeleteConductEntry(
 			tConduct.DeletedAt,
 		).
 		SET(
-			tConduct.DeletedAt.SET(deletedAtTime),
+			tConduct.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(mysql.AND(
 			tConduct.Job.EQ(mysql.String(userInfo.GetJob())),
 			tConduct.ID.EQ(mysql.Int64(req.GetId())),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsjobs.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbjobs.DeleteConductEntryResponse{}, nil
 }

--- a/services/jobs/labels.go
+++ b/services/jobs/labels.go
@@ -193,7 +193,8 @@ func (s *Server) ManageLabels(
 					WHERE(mysql.AND(
 						tJobLabels.ID.EQ(mysql.Int64(label.GetId())),
 						tJobLabels.Job.EQ(mysql.String(label.GetJob())),
-					))
+					)).
+					LIMIT(1)
 
 				if _, err := updateStmt.ExecContext(ctx, s.db); err != nil {
 					return nil, errswrap.NewError(err, errorscitizens.ErrFailedQuery)

--- a/services/livemap/markers.go
+++ b/services/livemap/markers.go
@@ -136,7 +136,8 @@ func (s *Server) CreateOrUpdateMarker(
 			WHERE(mysql.AND(
 				tMarkers.Job.EQ(mysql.String(userInfo.GetJob())),
 				tMarkers.ID.EQ(mysql.Int64(req.GetMarker().GetId())),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)

--- a/services/mailer/email.go
+++ b/services/mailer/email.go
@@ -12,6 +12,7 @@ import (
 	maileremails "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/emails"
 	mailerevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/events"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/qualifications"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	pbmailer "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/mailer"
 	permsmailer "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/mailer/perms"
@@ -531,7 +532,8 @@ func (s *Server) CreateOrUpdateEmail(
 			WHERE(mysql.AND(
 				tEmails.ID.EQ(mysql.Int64(req.GetEmail().GetId())),
 				condition,
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)
@@ -696,26 +698,28 @@ func (s *Server) DeleteEmail(
 		req.GetId(),
 	)
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if email != nil && email.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if email == nil || email.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	tEmails := table.FivenetMailerEmails
 	stmt := tEmails.
 		UPDATE().
 		SET(
-			tEmails.DeletedAt.SET(deletedAtTime),
+			tEmails.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(mysql.AND(
 			tEmails.ID.EQ(mysql.Int64(req.GetId())),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbmailer.DeleteEmailResponse{}, nil
 }

--- a/services/mailer/message.go
+++ b/services/mailer/message.go
@@ -11,6 +11,7 @@ import (
 	mailerevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/events"
 	mailermessages "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/messages"
 	mailerthreads "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/threads"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pbmailer "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/mailer"
 	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
@@ -333,9 +334,12 @@ func (s *Server) DeleteMessage(
 		return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if message != nil && message.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if message == nil || message.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	tMessages := table.FivenetMailerMessages
@@ -344,12 +348,13 @@ func (s *Server) DeleteMessage(
 			tMessages.DeletedAt,
 		).
 		SET(
-			tMessages.DeletedAt.SET(deletedAtTime),
+			tMessages.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(mysql.AND(
 			tMessages.ThreadID.EQ(mysql.Int64(req.GetThreadId())),
 			tMessages.ID.EQ(mysql.Int64(req.GetMessageId())),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)
@@ -372,8 +377,6 @@ func (s *Server) DeleteMessage(
 			},
 		}, emailIds...)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbmailer.DeleteMessageResponse{}, nil
 }

--- a/services/mailer/settings.go
+++ b/services/mailer/settings.go
@@ -177,7 +177,8 @@ func (s *Server) SetEmailSettings(
 		if len(settings.GetBlockedEmails()) > 0 {
 			stmt := tSettingsBlocks.
 				DELETE().
-				WHERE(tSettingsBlocks.EmailID.EQ(mysql.Int32(userInfo.GetUserId())))
+				WHERE(tSettingsBlocks.EmailID.EQ(mysql.Int32(userInfo.GetUserId()))).
+				LIMIT(int64(len(settings.GetBlockedEmails())))
 
 			if _, err := stmt.ExecContext(ctx, tx); err != nil {
 				return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)

--- a/services/mailer/templates.go
+++ b/services/mailer/templates.go
@@ -239,7 +239,8 @@ func (s *Server) CreateOrUpdateTemplate(
 			).
 			WHERE(mysql.AND(
 				tTemplates.ID.EQ(mysql.Int64(req.GetTemplate().GetId())),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)
@@ -284,7 +285,8 @@ func (s *Server) DeleteTemplate(
 		).
 		WHERE(mysql.AND(
 			tTemplates.ID.EQ(mysql.Int64(req.GetId())),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, err

--- a/services/mailer/thread.go
+++ b/services/mailer/thread.go
@@ -9,8 +9,10 @@ import (
 	maileraccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/access"
 	mailerevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/events"
 	mailerthreads "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/threads"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	pbmailer "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/mailer"
+	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/errswrap"
 	grpc_audit "github.com/fivenet-app/fivenet/v2026/pkg/grpc/interceptors/audit"
@@ -458,7 +460,8 @@ func (s *Server) updateThreadTime(ctx context.Context, tx qrm.DB, threadId int64
 		).
 		WHERE(
 			tThreads.ID.EQ(mysql.Int64(threadId)),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return err
@@ -484,9 +487,12 @@ func (s *Server) DeleteThread(
 		return nil, err
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if thread != nil && thread.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if thread == nil || thread.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	tThreads := table.FivenetMailerThreads
@@ -495,11 +501,12 @@ func (s *Server) DeleteThread(
 			tThreads.DeletedAt,
 		).
 		SET(
-			tThreads.DeletedAt.SET(deletedAtTime),
+			tThreads.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(
 			tThreads.ID.EQ(mysql.Int64(req.GetThreadId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsmailer.ErrFailedQuery)
@@ -520,8 +527,6 @@ func (s *Server) DeleteThread(
 			},
 		}, emailIds...)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbmailer.DeleteThreadResponse{}, nil
 }

--- a/services/qualifications/exam_questions.go
+++ b/services/qualifications/exam_questions.go
@@ -178,7 +178,8 @@ func (s *Server) handleExamQuestionsChanges(
 			WHERE(mysql.AND(
 				tExamQuestions.ID.EQ(mysql.Int64(question.GetId())),
 				tExamQuestions.QualificationID.EQ(mysql.Int64(qualificationId)),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return nil, err
@@ -196,7 +197,8 @@ func (s *Server) handleExamQuestionsChanges(
 			WHERE(mysql.AND(
 				tExamQuestions.ID.IN(questionIds...),
 				tExamQuestions.QualificationID.EQ(mysql.Int64(qualificationId)),
-			))
+			)).
+			LIMIT(int64(len(questionIds)))
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return nil, err

--- a/services/qualifications/qualifications.go
+++ b/services/qualifications/qualifications.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/qualifications"
 	qualificationsaccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/qualifications/access"
 	qualificationsexam "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/qualifications/exam"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pbqualifications "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/qualifications"
 	permsqualifications "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/qualifications/perms"
 	"github.com/fivenet-app/fivenet/v2026/pkg/access"
@@ -462,7 +463,8 @@ func (s *Server) UpdateQualification(
 		).
 		WHERE(
 			tQuali.ID.EQ(mysql.Int64(req.GetQualification().GetId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsqualifications.ErrFailedQuery)
@@ -570,9 +572,12 @@ func (s *Server) DeleteQualification(
 		return nil, errorsqualifications.ErrFailedQuery
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if quali.GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	var deletedAtTime *timestamp.Timestamp
+	if quali.GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
 	}
 
 	tQuali := table.FivenetQualifications
@@ -581,17 +586,16 @@ func (s *Server) DeleteQualification(
 			tQuali.DeletedAt,
 		).
 		SET(
-			tQuali.DeletedAt.SET(deletedAtTime),
+			tQuali.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
 		WHERE(
 			tQuali.ID.EQ(mysql.Int64(req.GetQualificationId())),
-		)
+		).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorsqualifications.ErrFailedQuery)
 	}
-
-	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
 
 	return &pbqualifications.DeleteQualificationResponse{}, nil
 }

--- a/services/qualifications/qualifications_requests.go
+++ b/services/qualifications/qualifications_requests.go
@@ -333,7 +333,8 @@ func (s *Server) CreateOrUpdateQualificationRequest(
 					mysql.Int64(req.GetRequest().GetQualificationId()),
 				),
 				tQualiRequests.UserID.EQ(mysql.Int32(req.GetRequest().GetUserId())),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return nil, errswrap.NewError(err, errorsqualifications.ErrFailedQuery)
@@ -613,7 +614,8 @@ func (s *Server) deleteQualificationRequest(
 		WHERE(mysql.AND(
 			tQualiRequests.QualificationID.EQ(mysql.Int64(qualificationId)),
 			tQualiRequests.UserID.EQ(mysql.Int32(userId)),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return err

--- a/services/qualifications/qualifications_results.go
+++ b/services/qualifications/qualifications_results.go
@@ -434,7 +434,8 @@ func (s *Server) createOrUpdateQualificationResult(
 			WHERE(mysql.AND(
 				tQualiResults.ID.EQ(mysql.Int64(resultId)),
 				tQualiResults.DeletedAt.IS_NULL(),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return 0, err
@@ -454,7 +455,8 @@ func (s *Server) createOrUpdateQualificationResult(
 			WHERE(mysql.AND(
 				tExamResponses.QualificationID.EQ(mysql.Int64(quali.GetId())),
 				tExamResponses.UserID.EQ(mysql.Int32(userId)),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return 0, err
@@ -680,7 +682,8 @@ func (s *Server) DeleteQualificationResult(
 		WHERE(mysql.AND(
 			tQualiResults.ID.EQ(mysql.Int64(result.GetId())),
 			tQualiResults.ID.EQ(mysql.Int64(req.GetResultId())),
-		))
+		)).
+		LIMIT(1)
 
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return nil, errswrap.NewError(err, errorsqualifications.ErrFailedQuery)

--- a/services/settings/accounts.go
+++ b/services/settings/accounts.go
@@ -231,7 +231,8 @@ func (s *Server) UpdateAccount(
 		stmt = stmt.
 			WHERE(
 				tAccounts.ID.EQ(mysql.Int64(req.GetId())),
-			)
+			).
+			LIMIT(1)
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return nil, errswrap.NewError(err, errorssettings.ErrFailedQuery)
 		}

--- a/services/sync/activity.go
+++ b/services/sync/activity.go
@@ -331,7 +331,8 @@ func (s *Server) handleTimeclockEntry(
 				tTimeClock.UserID.EQ(mysql.Int32(data.GetUserId())),
 				tTimeClock.StartTime.IS_NOT_NULL(),
 				tTimeClock.EndTime.IS_NULL(),
-			))
+			)).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return fmt.Errorf("failed to update timeclock entry. %w", err)
@@ -394,7 +395,8 @@ func (s *Server) handleUserUpdate(
 		stmt := tUser.
 			UPDATE().
 			SET(updateSets[0]).
-			WHERE(tUser.ID.EQ(mysql.Int32(data.GetUserId())))
+			WHERE(tUser.ID.EQ(mysql.Int32(data.GetUserId()))).
+			LIMIT(1)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return fmt.Errorf("failed to update user. %w", err)

--- a/services/sync/jobs.go
+++ b/services/sync/jobs.go
@@ -207,7 +207,8 @@ func (s *Server) handleJobGrades(ctx context.Context, job *jobs.Job) (int64, err
 				WHERE(mysql.AND(
 					tJobsGrades.JobName.EQ(mysql.String(job.GetName())),
 					tJobsGrades.Grade.EQ(mysql.Int32(grade.GetGrade())),
-				))
+				)).
+				LIMIT(1)
 
 			res, err := stmt.ExecContext(ctx, s.db)
 			if err != nil {

--- a/services/sync/locations.go
+++ b/services/sync/locations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
 	"github.com/fivenet-app/fivenet/v2026/query/fivenet/table"
@@ -37,9 +38,22 @@ func (s *Server) handleUserLocations(
 
 	// Handle clear all
 	if clearAll {
+		var count database.DataCount
+
+		countStmt := tLocations.
+			SELECT(
+				mysql.COUNT(tLocations.UserID).AS("data_count.total"),
+			).
+			FROM(tLocations).
+			WHERE(tLocations.UserID.IS_NOT_NULL().OR(tLocations.UserID.IS_NULL()))
+		if err := countStmt.QueryContext(ctx, s.db, &count); err != nil {
+			return 0, fmt.Errorf("failed to execute user locations clear all count statement. %w", err)
+		}
+
 		stmt := tLocations.
 			DELETE().
-			WHERE(tLocations.UserID.IS_NOT_NULL().OR(tLocations.UserID.IS_NULL()))
+			WHERE(tLocations.UserID.IS_NOT_NULL().OR(tLocations.UserID.IS_NULL())).
+			LIMIT(count.Total)
 
 		if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 			return 0, fmt.Errorf("failed to execute user locations clear all statement. %w", err)

--- a/services/wiki/wiki.go
+++ b/services/wiki/wiki.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/content"
 	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
 	notificationsclientview "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/clientview"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/wiki"
 	wikiaccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/wiki/access"
@@ -872,15 +873,18 @@ func (s *Server) DeletePage(
 		return nil, errswrap.NewError(err, errorswiki.ErrFailedQuery)
 	}
 
+	// Check if page has any un-deleted child pages
 	tPage := table.FivenetWikiPages
-
-	// Ensure page has no children
 	countStmt := tPage.
 		SELECT(
 			mysql.COUNT(tPage.ID).AS("data_count.total"),
 		).
 		FROM(tPage).
-		WHERE(tPage.ParentID.EQ(mysql.Int64(page.GetId())))
+		WHERE(mysql.AND(
+			tPage.ParentID.EQ(mysql.Int64(page.GetId())),
+			tPage.DeletedAt.IS_NULL(),
+		)).
+		LIMIT(1)
 
 	var count database.DataCount
 	if err := countStmt.QueryContext(ctx, s.db, &count); err != nil {
@@ -893,9 +897,21 @@ func (s *Server) DeletePage(
 		return nil, errorswiki.ErrPageHasChildren
 	}
 
-	deletedAtTime := mysql.CURRENT_TIMESTAMP()
-	if page.GetMeta() != nil && page.GetMeta().GetDeletedAt() != nil && userInfo.GetSuperuser() {
-		deletedAtTime = mysql.TimestampExp(mysql.NULL)
+	condition := tPage.ID.EQ(mysql.Int64(req.GetId()))
+
+	var deletedAtTime *timestamp.Timestamp
+	if page.GetMeta() == nil || page.GetMeta().GetDeletedAt() == nil || !userInfo.GetSuperuser() {
+		deletedAtTime = timestamp.Now()
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_DELETED)
+	} else {
+		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_RESTORED)
+
+		// Restore the page's parent page if any
+		if page.GetParentId() > 0 {
+			condition = condition.OR(
+				tPage.ID.EQ(mysql.Int64(page.GetParentId())),
+			)
+		}
 	}
 
 	stmt := tPage.
@@ -903,12 +919,10 @@ func (s *Server) DeletePage(
 			tPage.DeletedAt,
 		).
 		SET(
-			tPage.DeletedAt.SET(deletedAtTime),
+			tPage.DeletedAt.SET(dbutils.TimestampToMySQL(deletedAtTime)),
 		).
-		WHERE(mysql.AND(
-			tPage.ID.EQ(mysql.Int64(req.GetId())),
-		)).
-		LIMIT(1)
+		WHERE(condition).
+		LIMIT(2)
 
 	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
 		return nil, errswrap.NewError(err, errorswiki.ErrFailedQuery)


### PR DESCRIPTION
**Description of changes:**

Add `LIMIT` to `DELETE` AND `UPDATE` queries.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [CONTRIBUTING.md](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Reviewed the contributor guide [here (CONTRIBUTING.md)](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated, if necessary. Please open a PR in the [website repository](https://github.com/fivenet-app/fivenet-app.github.io) and add a link to the PR here.
- [x] Tests have been added, if necessary.
