### PR TITLE
feat: add centrum units reorder api

### DIFF
--- a/app/components/centrum/dispatchers/DispatcherDrawer.vue
+++ b/app/components/centrum/dispatchers/DispatcherDrawer.vue
@@ -9,7 +9,10 @@ defineEmits<{
     (e: 'close', v: boolean): void;
 }>();
 
+const { activeChar, can } = useAuth();
+
 const centrumStore = useCentrumStore();
+const { updateDispatchers } = centrumStore;
 const { dispatchers, anyDispatchersActive, getCurrentMode } = storeToRefs(centrumStore);
 </script>
 
@@ -41,9 +44,13 @@ const { dispatchers, anyDispatchersActive, getCurrentMode } = storeToRefs(centru
                     :type="$t('common.dispatcher')"
                 />
                 <template v-else>
-                    <div v-for="dispas in dispatchers" :key="dispas.job" class="gap-4 p-4" :cols="2">
+                    <div
+                        v-for="dispas in dispatchers.sort((a, b) => a.dispatchers.length - b.dispatchers.length)"
+                        :key="dispas.job"
+                        class="gap-4 p-4"
+                    >
                         <h3 class="mb-4 text-lg font-semibold">
-                            {{ dispas.jobLabel ?? dispas.job }}
+                            {{ dispas.jobLabel ?? dispas.job }} ({{ $t('common.count') }}: {{ dispas.dispatchers.length }})
                         </h3>
 
                         <UPageGrid class="lg:grid-cols-2 xl:grid-cols-2">
@@ -52,10 +59,34 @@ const { dispatchers, anyDispatchersActive, getCurrentMode } = storeToRefs(centru
                                 :key="dispatcher.userId"
                                 :title="`${dispatcher.firstname} ${dispatcher.lastname}`"
                                 icon="i-mdi-account"
+                                :highlight="dispatcher.userId === activeChar?.userId"
                                 :ui="{
-                                    title: 'text-highlighted text-base font-semibold flex items-center gap-1.5 line-clamp-2 whitespace-break-spaces',
+                                    title: 'w-full flex items-center gap-1.5',
+                                    body: 'w-full',
                                 }"
                             >
+                                <template #title>
+                                    <span
+                                        class="line-clamp-2 flex-1 text-base font-semibold whitespace-break-spaces text-highlighted"
+                                        >{{ `${dispatcher.firstname} ${dispatcher.lastname}` }}</span
+                                    >
+
+                                    <UTooltip
+                                        v-if="
+                                            dispatcher.job === activeChar?.job &&
+                                            can('centrum.CentrumService/UpdateDispatchers')
+                                        "
+                                        :text="$t('common.remove')"
+                                    >
+                                        <UButton
+                                            color="red"
+                                            icon="i-mdi-remove"
+                                            variant="link"
+                                            @click="() => updateDispatchers([dispatcher.userId])"
+                                        />
+                                    </UTooltip>
+                                </template>
+
                                 <template #default>
                                     <PhoneNumberBlock :number="dispatcher.phoneNumber" />
                                 </template>

--- a/app/components/centrum/livemap/JoinUnitSlideover.vue
+++ b/app/components/centrum/livemap/JoinUnitSlideover.vue
@@ -53,7 +53,7 @@ const filteredUnits = computed(() => ({
                     u.initials.toLowerCase().includes(queryUnit.value.toLowerCase())) &&
                 checkUnitAccess(u.access, UnitAccessLevel.JOIN),
         )
-        .sort((a, b) => a.name.localeCompare(b.name)),
+        .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name)),
     unavailable: getSortedUnits.value
         .filter(
             (u) =>
@@ -61,7 +61,7 @@ const filteredUnits = computed(() => ({
                     u.initials.toLowerCase().includes(queryUnit.value.toLowerCase())) &&
                 !checkUnitAccess(u.access, UnitAccessLevel.JOIN),
         )
-        .sort((a, b) => a.name.localeCompare(b.name)),
+        .sort((a, b) => a.sortOrder - b.sortOrder || a.name.localeCompare(b.name)),
 }));
 </script>
 

--- a/app/components/centrum/settings/UnitCreateOrUpdateModal.vue
+++ b/app/components/centrum/settings/UnitCreateOrUpdateModal.vue
@@ -86,6 +86,7 @@ async function createOrUpdateUnit(values: Schema): Promise<void> {
                 users: [],
                 homePostal: values.homePostal,
                 access: values.access,
+                sortOrder: props.unit?.sortOrder ?? 0,
             },
         });
         const { response } = await call;
@@ -138,9 +139,7 @@ const formRef = useTemplateRef('formRef');
 </script>
 
 <template>
-    <USlideover
-        :title="unit && unit?.id ? $t('components.centrum.units.update_unit') : $t('components.centrum.units.create_unit')"
-    >
+    <UModal :title="unit?.id ? $t('components.centrum.units.update_unit') : $t('components.centrum.units.create_unit')">
         <template #body>
             <UForm ref="formRef" :schema="schema" :state="state" @submit="onSubmitThrottle">
                 <UFormField class="flex-1" name="name" :label="$t('common.name')">
@@ -186,7 +185,7 @@ const formRef = useTemplateRef('formRef');
                 </UFormField>
 
                 <UFormField class="flex-1" name="color" :label="$t('common.color')">
-                    <ColorPicker v-model="state.color" />
+                    <ColorPicker v-model="state.color" class="w-full" />
                 </UFormField>
 
                 <UFormField class="flex-1" name="icon" :label="$t('common.icon')">
@@ -239,5 +238,5 @@ const formRef = useTemplateRef('formRef');
                 />
             </UFieldGroup>
         </template>
-    </USlideover>
+    </UModal>
 </template>

--- a/app/components/centrum/settings/UnitList.vue
+++ b/app/components/centrum/settings/UnitList.vue
@@ -1,19 +1,19 @@
 <script lang="ts" setup>
-import { UButton, UTooltip } from '#components';
+import { UButton, UFieldGroup, UIcon, UTooltip } from '#components';
 import type { TableColumn } from '@nuxt/ui';
 import { h } from 'vue';
 import UnitAttributes from '~/components/centrum/partials/UnitAttributes.vue';
-import UnitCreateOrUpdateSlideover from '~/components/centrum/settings/UnitCreateOrUpdateSlideover.vue';
+import UnitCreateOrUpdateModal from '~/components/centrum/settings/UnitCreateOrUpdateModal.vue';
 import ColorPicker from '~/components/partials/ColorPicker.vue';
 import ConfirmModal from '~/components/partials/ConfirmModal.vue';
 import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
-import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import { availableIcons, fallbackIcon } from '~/components/partials/icons';
 import Pagination from '~/components/partials/Pagination.vue';
 import { getCentrumUnitsClient } from '~~/gen/ts/clients';
 import type { Unit } from '~~/gen/ts/resources/centrum/units/units';
 import { NotificationType } from '~~/gen/ts/resources/notifications/notifications';
 import type { ListUnitsResponse } from '~~/gen/ts/services/centrum/units';
+import { useDraggable } from 'vue-draggable-plus';
 
 const { t } = useI18n();
 
@@ -59,13 +59,65 @@ async function deleteUnit(id: number): Promise<void> {
     }
 }
 
+async function reorderUnits(units: Unit[]): Promise<void> {
+    try {
+        const call = centrumUnitsClient.reorderUnits({
+            unitIds: units.map((item) => item.id),
+        });
+        await call;
+
+        orderChanged.value = false;
+
+        notifications.add({
+            title: { key: 'notifications.action_successful.title', parameters: {} },
+            description: { key: 'notifications.action_successful.content', parameters: {} },
+            type: NotificationType.SUCCESS,
+        });
+    } catch (e) {
+        handleGRPCError(e as RpcError);
+        throw e;
+    }
+}
+
 const appConfig = useAppConfig();
+const unitList = computed<Unit[]>(() => units.value?.units ?? []);
+const { moveUp, moveDown } = useListReorder(unitList, {
+    onMove: () => (orderChanged.value = true),
+});
 
 const columns = computed<TableColumn<Unit>[]>(() => [
     {
         id: 'actions',
         cell: ({ row }) =>
             h('div', [
+                h(
+                    'div',
+                    {
+                        class: 'inline-flex items-center gap-1',
+                    },
+                    [
+                        h(UTooltip, { text: t('common.draggable') }, [
+                            h(UIcon, {
+                                class: 'handle-choice size-6 cursor-move',
+                                name: 'i-mdi-drag-horizontal',
+                            }),
+                        ]),
+                        h(UFieldGroup, { orientation: 'vertical' }, [
+                            h(UButton, {
+                                size: 'xs',
+                                variant: 'link',
+                                icon: 'i-mdi-arrow-up',
+                                onClick: () => moveUp(row.index),
+                            }),
+                            h(UButton, {
+                                size: 'xs',
+                                variant: 'link',
+                                icon: 'i-mdi-arrow-down',
+                                onClick: () => moveDown(row.index),
+                            }),
+                        ]),
+                    ],
+                ),
                 h(
                     UTooltip,
                     {
@@ -77,7 +129,7 @@ const columns = computed<TableColumn<Unit>[]>(() => [
                             variant: 'link',
                             icon: 'i-mdi-pencil',
                             onClick: () => {
-                                unitCreateOrUpdateSlideover.open({
+                                unitCreateOrUpdate.open({
                                     unit: row.original,
                                     onUpdated: async () => refresh(),
                                 });
@@ -182,8 +234,15 @@ const columns = computed<TableColumn<Unit>[]>(() => [
     },
 ]);
 
-const unitCreateOrUpdateSlideover = overlay.create(UnitCreateOrUpdateSlideover);
+const unitCreateOrUpdate = overlay.create(UnitCreateOrUpdateModal);
 const confirmModal = overlay.create(ConfirmModal);
+
+const orderChanged = ref(false);
+useDraggable<Unit>('.unit-list-table', unitList, {
+    animation: 150,
+    handle: '.handle-choice',
+    onSort: () => (orderChanged.value = true),
+});
 </script>
 
 <template>
@@ -192,6 +251,10 @@ const confirmModal = overlay.create(ConfirmModal);
             <UDashboardNavbar :title="$t('common.unit', 2)">
                 <template #right>
                     <PartialsBackButton fallback-to="/centrum" />
+
+                    <UTooltip v-if="orderChanged" :text="$t('common.save', 1)">
+                        <UButton color="primary" variant="outline" icon="i-mdi-content-save" @click="reorderUnits(unitList)" />
+                    </UTooltip>
 
                     <UTooltip v-if="can('centrum.CentrumService/Stream').value" :text="$t('common.setting', 2)">
                         <UButton icon="i-mdi-settings" to="/centrum/settings">
@@ -207,7 +270,7 @@ const confirmModal = overlay.create(ConfirmModal);
                         variant="outline"
                         trailing-icon="i-mdi-plus"
                         @click="
-                            unitCreateOrUpdateSlideover.open({
+                            unitCreateOrUpdate.open({
                                 onCreated: async () => refresh(),
                                 onUpdated: async () => refresh(),
                             })
@@ -228,17 +291,17 @@ const confirmModal = overlay.create(ConfirmModal);
                 :error="error"
                 :retry="refresh"
             />
-            <DataPendingBlock v-else-if="isRequestPending(status)" :message="$t('common.loading', [$t('common.unit', 2)])" />
 
             <UTable
                 v-else
                 class="flex-1"
                 :loading="isRequestPending(status)"
                 :columns="columns"
-                :data="units?.units"
+                :data="unitList"
                 :empty="$t('common.not_found', [$t('common.unit', 2)])"
                 :sorting-options="{ manualSorting: true }"
                 :pagination-options="{ manualPagination: true }"
+                :ui="{ tbody: 'unit-list-table' }"
             />
         </template>
 

--- a/app/components/centrum/settings/UnitList.vue
+++ b/app/components/centrum/settings/UnitList.vue
@@ -249,6 +249,10 @@ useDraggable<Unit>('.unit-list-table', unitList, {
     <UDashboardPanel :ui="{ body: 'p-0 sm:p-0 gap-0 sm:gap-0' }">
         <template #header>
             <UDashboardNavbar :title="$t('common.unit', 2)">
+                <template #leading>
+                    <UDashboardSidebarCollapse />
+                </template>
+
                 <template #right>
                     <PartialsBackButton fallback-to="/centrum" />
 

--- a/app/components/centrum/units/UnitList.vue
+++ b/app/components/centrum/units/UnitList.vue
@@ -28,15 +28,14 @@ const grouped = computedAsync(async () => {
         .sort((a, b) => statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status))
         .forEach((group) =>
             group.units.sort((a, b) => {
-                if (a.users.length === b.users.length) {
-                    return 0;
-                } else if (a.users.length === 0) {
-                    return 1;
-                } else if (b.users.length === 0) {
-                    return -1;
-                } else {
-                    return a.name.localeCompare(b.name);
+                const aHasUsers = a.users.length > 0;
+                const bHasUsers = b.users.length > 0;
+
+                if (aHasUsers !== bHasUsers) {
+                    return aHasUsers ? -1 : 1;
                 }
+
+                return (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.name.localeCompare(b.name);
             }),
         );
 

--- a/app/components/citizens/labels/List.vue
+++ b/app/components/citizens/labels/List.vue
@@ -194,9 +194,8 @@ const columns = computed<TableColumn<Label>[]>(() => [
         </template>
 
         <template #body>
-            <DataPendingBlock v-if="isRequestPending(status)" :message="$t('common.loading', [$t('common.label', 2)])" />
             <DataErrorBlock
-                v-else-if="error"
+                v-if="error"
                 :title="$t('common.unable_to_load', [$t('components.citizens.citizen_labels.title')])"
                 :error="error"
                 :retry="refresh"
@@ -208,7 +207,7 @@ const columns = computed<TableColumn<Label>[]>(() => [
                 :loading="isRequestPending(status)"
                 :columns="columns"
                 :data="labels"
-                :empty="$t('common.not_found', [$t('common.label', 2)])"
+                :empty="$t('common.not_found', [$t('components.citizens.citizen_labels.title')])"
                 sticky
             />
         </template>

--- a/app/components/citizens/labels/List.vue
+++ b/app/components/citizens/labels/List.vue
@@ -9,7 +9,6 @@ import { getCitizensLabelsClient } from '~~/gen/ts/clients';
 import type { Label } from '~~/gen/ts/resources/citizens/labels/labels';
 import { NotificationType } from '~~/gen/ts/resources/notifications/notifications';
 import DataErrorBlock from '../../partials/data/DataErrorBlock.vue';
-import DataPendingBlock from '../../partials/data/DataPendingBlock.vue';
 import CreateOrUpdateModal from './CreateOrUpdateModal.vue';
 
 const { can } = useAuth();

--- a/app/components/settings/CronList.vue
+++ b/app/components/settings/CronList.vue
@@ -8,7 +8,6 @@ import { type Cronjob, CronjobState, GenericCronData } from '~~/gen/ts/resources
 import { NotificationType } from '~~/gen/ts/resources/notifications/notifications';
 import type { ListCronjobsResponse } from '~~/gen/ts/services/settings/cron';
 import DataErrorBlock from '../partials/data/DataErrorBlock.vue';
-import DataPendingBlock from '../partials/data/DataPendingBlock.vue';
 import GenericTime from '../partials/elements/GenericTime.vue';
 import Pagination from '../partials/Pagination.vue';
 

--- a/app/components/settings/CronList.vue
+++ b/app/components/settings/CronList.vue
@@ -162,9 +162,8 @@ const columns = computed(
         </template>
 
         <template #body>
-            <DataPendingBlock v-if="isRequestPending(status)" :message="$t('common.loading', [$t('common.cronjob', 2)])" />
             <DataErrorBlock
-                v-else-if="error"
+                v-if="error"
                 :title="$t('common.unable_to_load', [$t('common.cronjob', 2)])"
                 :error="error"
                 :retry="refresh"

--- a/app/components/settings/jobs/JobList.vue
+++ b/app/components/settings/jobs/JobList.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 import { UButton } from '#components';
 import type { TableColumn } from '@nuxt/ui';
+import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
 import DataNoDataBlock from '~/components/partials/data/DataNoDataBlock.vue';
 import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import Pagination from '~/components/partials/Pagination.vue';
@@ -120,7 +121,6 @@ const expanded = ref({});
                     :error="error"
                     :retry="refresh"
                 />
-                <DataPendingBlock v-else-if="isRequestPending(status)" :message="$t('common.loading', [$t('common.job', 2)])" />
 
                 <UTable
                     v-else

--- a/app/components/settings/jobs/JobList.vue
+++ b/app/components/settings/jobs/JobList.vue
@@ -3,7 +3,6 @@ import { UButton } from '#components';
 import type { TableColumn } from '@nuxt/ui';
 import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
 import DataNoDataBlock from '~/components/partials/data/DataNoDataBlock.vue';
-import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import Pagination from '~/components/partials/Pagination.vue';
 import type { Job } from '~~/gen/ts/resources/jobs/jobs';
 

--- a/app/composables/useListReorder.ts
+++ b/app/composables/useListReorder.ts
@@ -1,4 +1,4 @@
-export function useListReorder<T>(list: Ref<T[]>) {
+export function useListReorder<T>(list: Ref<T[]>, options?: { onMove?: () => void }) {
     function move(from: number, to: number) {
         if (from === to) return;
         if (from < 0 || from >= list.value.length) return;
@@ -7,6 +7,7 @@ export function useListReorder<T>(list: Ref<T[]>) {
         const temp = list.value[from];
         list.value[from] = list.value[to]!;
         list.value[to] = temp!;
+        options?.onMove?.();
     }
 
     function moveUp(index: number) {

--- a/gen/go/proto/perms_remap.go
+++ b/gen/go/proto/perms_remap.go
@@ -149,6 +149,9 @@ var PermsRemap = map[string][]perms.PermissionRef{
 	"centrum.UnitsService/ListUnits": {
 		permscentrum.CentrumService.Stream.Perm,
 	},
+	"centrum.UnitsService/ReorderUnits": {
+		permscentrum.UnitsService.CreateOrUpdateUnit.Perm,
+	},
 	"centrum.UnitsService/UpdateUnitStatus": {
 		permscentrum.DispatchesService.TakeDispatch.Perm,
 	},

--- a/gen/go/proto/resources/centrum/units/units.go
+++ b/gen/go/proto/resources/centrum/units/units.go
@@ -34,6 +34,10 @@ func (x *Unit) Merge(in *Unit) *Unit {
 		x.Job = in.GetJob()
 	}
 
+	if x.GetSortOrder() != in.GetSortOrder() {
+		x.SortOrder = in.GetSortOrder()
+	}
+
 	if x.GetName() != in.GetName() {
 		x.Name = in.GetName()
 	}

--- a/gen/go/proto/resources/centrum/units/units.pb.go
+++ b/gen/go/proto/resources/centrum/units/units.pb.go
@@ -138,6 +138,7 @@ type Unit struct {
 	UpdatedAt     *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=updated_at,json=updatedAt,proto3,oneof" json:"updated_at,omitempty"`
 	Job           string                 `protobuf:"bytes,4,opt,name=job,proto3" json:"job,omitempty"`
 	JobLabel      *string                `protobuf:"bytes,15,opt,name=job_label,json=jobLabel,proto3,oneof" json:"job_label,omitempty"`
+	SortOrder     int32                  `protobuf:"varint,17,opt,name=sort_order,json=sortOrder,proto3" json:"sort_order,omitempty" alias:"sort_order"`
 	Name          string                 `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
 	Initials      string                 `protobuf:"bytes,6,opt,name=initials,proto3" json:"initials,omitempty"`
 	Color         string                 `protobuf:"bytes,7,opt,name=color,proto3" json:"color,omitempty"`
@@ -210,6 +211,13 @@ func (x *Unit) GetJobLabel() string {
 		return *x.JobLabel
 	}
 	return ""
+}
+
+func (x *Unit) GetSortOrder() int32 {
+	if x != nil {
+		return x.SortOrder
+	}
+	return 0
 }
 
 func (x *Unit) GetName() string {
@@ -300,6 +308,10 @@ func (x *Unit) SetJob(v string) {
 
 func (x *Unit) SetJobLabel(v string) {
 	x.JobLabel = &v
+}
+
+func (x *Unit) SetSortOrder(v int32) {
+	x.SortOrder = v
 }
 
 func (x *Unit) SetName(v string) {
@@ -449,6 +461,7 @@ type Unit_builder struct {
 	UpdatedAt   *timestamp.Timestamp
 	Job         string
 	JobLabel    *string
+	SortOrder   int32
 	Name        string
 	Initials    string
 	Color       string
@@ -470,6 +483,7 @@ func (b0 Unit_builder) Build() *Unit {
 	x.UpdatedAt = b.UpdatedAt
 	x.Job = b.Job
 	x.JobLabel = b.JobLabel
+	x.SortOrder = b.SortOrder
 	x.Name = b.Name
 	x.Initials = b.Initials
 	x.Color = b.Color
@@ -1110,7 +1124,7 @@ var File_resources_centrum_units_units_proto protoreflect.FileDescriptor
 
 const file_resources_centrum_units_units_proto_rawDesc = "" +
 	"\n" +
-	"#resources/centrum/units/units.proto\x12\x17resources.centrum.units\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a+resources/centrum/units/access/access.proto\x1a*resources/jobs/colleagues/colleagues.proto\x1a#resources/timestamp/timestamp.proto\x1a\x13tagger/tagger.proto\"\xcf\x06\n" +
+	"#resources/centrum/units/units.proto\x12\x17resources.centrum.units\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a+resources/centrum/units/access/access.proto\x1a*resources/jobs/colleagues/colleagues.proto\x1a#resources/timestamp/timestamp.proto\x1a\x13tagger/tagger.proto\"\x87\a\n" +
 	"\x04Unit\x121\n" +
 	"\x02id\x18\x01 \x01(\x03B!\x9a\x84\x9e\x03\x1csql:\"primary_key\" alias:\"id\"R\x02id\x12B\n" +
 	"\n" +
@@ -1118,7 +1132,9 @@ const file_resources_centrum_units_units_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18\x03 \x01(\v2\x1e.resources.timestamp.TimestampH\x01R\tupdatedAt\x88\x01\x01\x12\x10\n" +
 	"\x03job\x18\x04 \x01(\tR\x03job\x12 \n" +
-	"\tjob_label\x18\x0f \x01(\tH\x02R\bjobLabel\x88\x01\x01\x12\x1a\n" +
+	"\tjob_label\x18\x0f \x01(\tH\x02R\bjobLabel\x88\x01\x01\x126\n" +
+	"\n" +
+	"sort_order\x18\x11 \x01(\x05B\x17\x9a\x84\x9e\x03\x12alias:\"sort_order\"R\tsortOrder\x12\x1a\n" +
 	"\x04name\x18\x05 \x01(\tB\x06\xda\xf3\x18\x02\b\x01R\x04name\x12\"\n" +
 	"\binitials\x18\x06 \x01(\tB\x06\xda\xf3\x18\x02\b\x01R\binitials\x12\x1e\n" +
 	"\x05color\x18\a \x01(\tB\b\xda\xf3\x18\x04\b\x01\x18\x01R\x05color\x12!\n" +

--- a/gen/go/proto/resources/centrum/units/units_protoopaque.pb.go
+++ b/gen/go/proto/resources/centrum/units/units_protoopaque.pb.go
@@ -138,6 +138,7 @@ type Unit struct {
 	xxx_hidden_UpdatedAt   *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=updated_at,json=updatedAt,proto3,oneof"`
 	xxx_hidden_Job         string                 `protobuf:"bytes,4,opt,name=job,proto3"`
 	xxx_hidden_JobLabel    *string                `protobuf:"bytes,15,opt,name=job_label,json=jobLabel,proto3,oneof"`
+	xxx_hidden_SortOrder   int32                  `protobuf:"varint,17,opt,name=sort_order,json=sortOrder,proto3"`
 	xxx_hidden_Name        string                 `protobuf:"bytes,5,opt,name=name,proto3"`
 	xxx_hidden_Initials    string                 `protobuf:"bytes,6,opt,name=initials,proto3"`
 	xxx_hidden_Color       string                 `protobuf:"bytes,7,opt,name=color,proto3"`
@@ -215,6 +216,13 @@ func (x *Unit) GetJobLabel() string {
 		return ""
 	}
 	return ""
+}
+
+func (x *Unit) GetSortOrder() int32 {
+	if x != nil {
+		return x.xxx_hidden_SortOrder
+	}
+	return 0
 }
 
 func (x *Unit) GetName() string {
@@ -316,7 +324,11 @@ func (x *Unit) SetJob(v string) {
 
 func (x *Unit) SetJobLabel(v string) {
 	x.xxx_hidden_JobLabel = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 15)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 16)
+}
+
+func (x *Unit) SetSortOrder(v int32) {
+	x.xxx_hidden_SortOrder = v
 }
 
 func (x *Unit) SetName(v string) {
@@ -333,12 +345,12 @@ func (x *Unit) SetColor(v string) {
 
 func (x *Unit) SetIcon(v string) {
 	x.xxx_hidden_Icon = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 8, 15)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 16)
 }
 
 func (x *Unit) SetDescription(v string) {
 	x.xxx_hidden_Description = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 15)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 10, 16)
 }
 
 func (x *Unit) SetStatus(v *UnitStatus) {
@@ -355,7 +367,7 @@ func (x *Unit) SetAttributes(v *UnitAttributes) {
 
 func (x *Unit) SetHomePostal(v string) {
 	x.xxx_hidden_HomePostal = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 13, 15)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 14, 16)
 }
 
 func (x *Unit) SetAccess(v *access.UnitAccess) {
@@ -387,14 +399,14 @@ func (x *Unit) HasIcon() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 8)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 9)
 }
 
 func (x *Unit) HasDescription() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 9)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 10)
 }
 
 func (x *Unit) HasStatus() bool {
@@ -415,7 +427,7 @@ func (x *Unit) HasHomePostal() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 13)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 14)
 }
 
 func (x *Unit) HasAccess() bool {
@@ -439,12 +451,12 @@ func (x *Unit) ClearJobLabel() {
 }
 
 func (x *Unit) ClearIcon() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 8)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 9)
 	x.xxx_hidden_Icon = nil
 }
 
 func (x *Unit) ClearDescription() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 9)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 10)
 	x.xxx_hidden_Description = nil
 }
 
@@ -457,7 +469,7 @@ func (x *Unit) ClearAttributes() {
 }
 
 func (x *Unit) ClearHomePostal() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 13)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 14)
 	x.xxx_hidden_HomePostal = nil
 }
 
@@ -473,6 +485,7 @@ type Unit_builder struct {
 	UpdatedAt   *timestamp.Timestamp
 	Job         string
 	JobLabel    *string
+	SortOrder   int32
 	Name        string
 	Initials    string
 	Color       string
@@ -494,25 +507,26 @@ func (b0 Unit_builder) Build() *Unit {
 	x.xxx_hidden_UpdatedAt = b.UpdatedAt
 	x.xxx_hidden_Job = b.Job
 	if b.JobLabel != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 15)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 16)
 		x.xxx_hidden_JobLabel = b.JobLabel
 	}
+	x.xxx_hidden_SortOrder = b.SortOrder
 	x.xxx_hidden_Name = b.Name
 	x.xxx_hidden_Initials = b.Initials
 	x.xxx_hidden_Color = b.Color
 	if b.Icon != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 8, 15)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 16)
 		x.xxx_hidden_Icon = b.Icon
 	}
 	if b.Description != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 15)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 10, 16)
 		x.xxx_hidden_Description = b.Description
 	}
 	x.xxx_hidden_Status = b.Status
 	x.xxx_hidden_Users = &b.Users
 	x.xxx_hidden_Attributes = b.Attributes
 	if b.HomePostal != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 13, 15)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 14, 16)
 		x.xxx_hidden_HomePostal = b.HomePostal
 	}
 	x.xxx_hidden_Access = b.Access
@@ -1202,7 +1216,7 @@ var File_resources_centrum_units_units_proto protoreflect.FileDescriptor
 
 const file_resources_centrum_units_units_proto_rawDesc = "" +
 	"\n" +
-	"#resources/centrum/units/units.proto\x12\x17resources.centrum.units\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a+resources/centrum/units/access/access.proto\x1a*resources/jobs/colleagues/colleagues.proto\x1a#resources/timestamp/timestamp.proto\x1a\x13tagger/tagger.proto\"\xcf\x06\n" +
+	"#resources/centrum/units/units.proto\x12\x17resources.centrum.units\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a+resources/centrum/units/access/access.proto\x1a*resources/jobs/colleagues/colleagues.proto\x1a#resources/timestamp/timestamp.proto\x1a\x13tagger/tagger.proto\"\x87\a\n" +
 	"\x04Unit\x121\n" +
 	"\x02id\x18\x01 \x01(\x03B!\x9a\x84\x9e\x03\x1csql:\"primary_key\" alias:\"id\"R\x02id\x12B\n" +
 	"\n" +
@@ -1210,7 +1224,9 @@ const file_resources_centrum_units_units_proto_rawDesc = "" +
 	"\n" +
 	"updated_at\x18\x03 \x01(\v2\x1e.resources.timestamp.TimestampH\x01R\tupdatedAt\x88\x01\x01\x12\x10\n" +
 	"\x03job\x18\x04 \x01(\tR\x03job\x12 \n" +
-	"\tjob_label\x18\x0f \x01(\tH\x02R\bjobLabel\x88\x01\x01\x12\x1a\n" +
+	"\tjob_label\x18\x0f \x01(\tH\x02R\bjobLabel\x88\x01\x01\x126\n" +
+	"\n" +
+	"sort_order\x18\x11 \x01(\x05B\x17\x9a\x84\x9e\x03\x12alias:\"sort_order\"R\tsortOrder\x12\x1a\n" +
 	"\x04name\x18\x05 \x01(\tB\x06\xda\xf3\x18\x02\b\x01R\x04name\x12\"\n" +
 	"\binitials\x18\x06 \x01(\tB\x06\xda\xf3\x18\x02\b\x01R\binitials\x12\x1e\n" +
 	"\x05color\x18\a \x01(\tB\b\xda\xf3\x18\x04\b\x01\x18\x01R\x05color\x12!\n" +

--- a/gen/go/proto/services/centrum/units.pb.go
+++ b/gen/go/proto/services/centrum/units.pb.go
@@ -277,6 +277,170 @@ func (b0 ListUnitsResponse_builder) Build() *ListUnitsResponse {
 	return m0
 }
 
+type ListUnitActivityRequest struct {
+	state         protoimpl.MessageState      `protogen:"hybrid.v1"`
+	Pagination    *database.PaginationRequest `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
+	Id            int64                       `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListUnitActivityRequest) Reset() {
+	*x = ListUnitActivityRequest{}
+	mi := &file_services_centrum_units_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUnitActivityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUnitActivityRequest) ProtoMessage() {}
+
+func (x *ListUnitActivityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListUnitActivityRequest) GetPagination() *database.PaginationRequest {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+func (x *ListUnitActivityRequest) GetId() int64 {
+	if x != nil {
+		return x.Id
+	}
+	return 0
+}
+
+func (x *ListUnitActivityRequest) SetPagination(v *database.PaginationRequest) {
+	x.Pagination = v
+}
+
+func (x *ListUnitActivityRequest) SetId(v int64) {
+	x.Id = v
+}
+
+func (x *ListUnitActivityRequest) HasPagination() bool {
+	if x == nil {
+		return false
+	}
+	return x.Pagination != nil
+}
+
+func (x *ListUnitActivityRequest) ClearPagination() {
+	x.Pagination = nil
+}
+
+type ListUnitActivityRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Pagination *database.PaginationRequest
+	Id         int64
+}
+
+func (b0 ListUnitActivityRequest_builder) Build() *ListUnitActivityRequest {
+	m0 := &ListUnitActivityRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Pagination = b.Pagination
+	x.Id = b.Id
+	return m0
+}
+
+type ListUnitActivityResponse struct {
+	state         protoimpl.MessageState       `protogen:"hybrid.v1"`
+	Pagination    *database.PaginationResponse `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
+	Activity      []*units.UnitStatus          `protobuf:"bytes,2,rep,name=activity,proto3" json:"activity,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListUnitActivityResponse) Reset() {
+	*x = ListUnitActivityResponse{}
+	mi := &file_services_centrum_units_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUnitActivityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUnitActivityResponse) ProtoMessage() {}
+
+func (x *ListUnitActivityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListUnitActivityResponse) GetPagination() *database.PaginationResponse {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+func (x *ListUnitActivityResponse) GetActivity() []*units.UnitStatus {
+	if x != nil {
+		return x.Activity
+	}
+	return nil
+}
+
+func (x *ListUnitActivityResponse) SetPagination(v *database.PaginationResponse) {
+	x.Pagination = v
+}
+
+func (x *ListUnitActivityResponse) SetActivity(v []*units.UnitStatus) {
+	x.Activity = v
+}
+
+func (x *ListUnitActivityResponse) HasPagination() bool {
+	if x == nil {
+		return false
+	}
+	return x.Pagination != nil
+}
+
+func (x *ListUnitActivityResponse) ClearPagination() {
+	x.Pagination = nil
+}
+
+type ListUnitActivityResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Pagination *database.PaginationResponse
+	Activity   []*units.UnitStatus
+}
+
+func (b0 ListUnitActivityResponse_builder) Build() *ListUnitActivityResponse {
+	m0 := &ListUnitActivityResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Pagination = b.Pagination
+	x.Activity = b.Activity
+	return m0
+}
+
 type CreateOrUpdateUnitRequest struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	Unit          *units.Unit            `protobuf:"bytes,1,opt,name=unit,proto3" json:"unit,omitempty"`
@@ -286,7 +450,7 @@ type CreateOrUpdateUnitRequest struct {
 
 func (x *CreateOrUpdateUnitRequest) Reset() {
 	*x = CreateOrUpdateUnitRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[4]
+	mi := &file_services_centrum_units_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -298,7 +462,7 @@ func (x *CreateOrUpdateUnitRequest) String() string {
 func (*CreateOrUpdateUnitRequest) ProtoMessage() {}
 
 func (x *CreateOrUpdateUnitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[4]
+	mi := &file_services_centrum_units_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -354,7 +518,7 @@ type CreateOrUpdateUnitResponse struct {
 
 func (x *CreateOrUpdateUnitResponse) Reset() {
 	*x = CreateOrUpdateUnitResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[5]
+	mi := &file_services_centrum_units_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -366,7 +530,7 @@ func (x *CreateOrUpdateUnitResponse) String() string {
 func (*CreateOrUpdateUnitResponse) ProtoMessage() {}
 
 func (x *CreateOrUpdateUnitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[5]
+	mi := &file_services_centrum_units_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -422,7 +586,7 @@ type DeleteUnitRequest struct {
 
 func (x *DeleteUnitRequest) Reset() {
 	*x = DeleteUnitRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[6]
+	mi := &file_services_centrum_units_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -434,7 +598,7 @@ func (x *DeleteUnitRequest) String() string {
 func (*DeleteUnitRequest) ProtoMessage() {}
 
 func (x *DeleteUnitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[6]
+	mi := &file_services_centrum_units_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -478,7 +642,7 @@ type DeleteUnitResponse struct {
 
 func (x *DeleteUnitResponse) Reset() {
 	*x = DeleteUnitResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[7]
+	mi := &file_services_centrum_units_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -490,7 +654,7 @@ func (x *DeleteUnitResponse) String() string {
 func (*DeleteUnitResponse) ProtoMessage() {}
 
 func (x *DeleteUnitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[7]
+	mi := &file_services_centrum_units_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -513,6 +677,234 @@ func (b0 DeleteUnitResponse_builder) Build() *DeleteUnitResponse {
 	return m0
 }
 
+type ReorderUnitsRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	UnitIds       []int64                `protobuf:"varint,1,rep,packed,name=unit_ids,json=unitIds,proto3" json:"unit_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReorderUnitsRequest) Reset() {
+	*x = ReorderUnitsRequest{}
+	mi := &file_services_centrum_units_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReorderUnitsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReorderUnitsRequest) ProtoMessage() {}
+
+func (x *ReorderUnitsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ReorderUnitsRequest) GetUnitIds() []int64 {
+	if x != nil {
+		return x.UnitIds
+	}
+	return nil
+}
+
+func (x *ReorderUnitsRequest) SetUnitIds(v []int64) {
+	x.UnitIds = v
+}
+
+type ReorderUnitsRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	UnitIds []int64
+}
+
+func (b0 ReorderUnitsRequest_builder) Build() *ReorderUnitsRequest {
+	m0 := &ReorderUnitsRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.UnitIds = b.UnitIds
+	return m0
+}
+
+type ReorderUnitsResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReorderUnitsResponse) Reset() {
+	*x = ReorderUnitsResponse{}
+	mi := &file_services_centrum_units_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReorderUnitsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReorderUnitsResponse) ProtoMessage() {}
+
+func (x *ReorderUnitsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type ReorderUnitsResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 ReorderUnitsResponse_builder) Build() *ReorderUnitsResponse {
+	m0 := &ReorderUnitsResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type AssignUnitRequest struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	UnitId        int64                  `protobuf:"varint,1,opt,name=unit_id,json=unitId,proto3" json:"unit_id,omitempty"`
+	ToAdd         []int32                `protobuf:"varint,2,rep,packed,name=to_add,json=toAdd,proto3" json:"to_add,omitempty"`
+	ToRemove      []int32                `protobuf:"varint,3,rep,packed,name=to_remove,json=toRemove,proto3" json:"to_remove,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssignUnitRequest) Reset() {
+	*x = AssignUnitRequest{}
+	mi := &file_services_centrum_units_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssignUnitRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssignUnitRequest) ProtoMessage() {}
+
+func (x *AssignUnitRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *AssignUnitRequest) GetUnitId() int64 {
+	if x != nil {
+		return x.UnitId
+	}
+	return 0
+}
+
+func (x *AssignUnitRequest) GetToAdd() []int32 {
+	if x != nil {
+		return x.ToAdd
+	}
+	return nil
+}
+
+func (x *AssignUnitRequest) GetToRemove() []int32 {
+	if x != nil {
+		return x.ToRemove
+	}
+	return nil
+}
+
+func (x *AssignUnitRequest) SetUnitId(v int64) {
+	x.UnitId = v
+}
+
+func (x *AssignUnitRequest) SetToAdd(v []int32) {
+	x.ToAdd = v
+}
+
+func (x *AssignUnitRequest) SetToRemove(v []int32) {
+	x.ToRemove = v
+}
+
+type AssignUnitRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	UnitId   int64
+	ToAdd    []int32
+	ToRemove []int32
+}
+
+func (b0 AssignUnitRequest_builder) Build() *AssignUnitRequest {
+	m0 := &AssignUnitRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.UnitId = b.UnitId
+	x.ToAdd = b.ToAdd
+	x.ToRemove = b.ToRemove
+	return m0
+}
+
+type AssignUnitResponse struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssignUnitResponse) Reset() {
+	*x = AssignUnitResponse{}
+	mi := &file_services_centrum_units_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssignUnitResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssignUnitResponse) ProtoMessage() {}
+
+func (x *AssignUnitResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type AssignUnitResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 AssignUnitResponse_builder) Build() *AssignUnitResponse {
+	m0 := &AssignUnitResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 type UpdateUnitStatusRequest struct {
 	state         protoimpl.MessageState `protogen:"hybrid.v1"`
 	UnitId        int64                  `protobuf:"varint,1,opt,name=unit_id,json=unitId,proto3" json:"unit_id,omitempty"`
@@ -525,7 +917,7 @@ type UpdateUnitStatusRequest struct {
 
 func (x *UpdateUnitStatusRequest) Reset() {
 	*x = UpdateUnitStatusRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[8]
+	mi := &file_services_centrum_units_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -537,7 +929,7 @@ func (x *UpdateUnitStatusRequest) String() string {
 func (*UpdateUnitStatusRequest) ProtoMessage() {}
 
 func (x *UpdateUnitStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[8]
+	mi := &file_services_centrum_units_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -642,7 +1034,7 @@ type UpdateUnitStatusResponse struct {
 
 func (x *UpdateUnitStatusResponse) Reset() {
 	*x = UpdateUnitStatusResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[9]
+	mi := &file_services_centrum_units_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -654,7 +1046,7 @@ func (x *UpdateUnitStatusResponse) String() string {
 func (*UpdateUnitStatusResponse) ProtoMessage() {}
 
 func (x *UpdateUnitStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[9]
+	mi := &file_services_centrum_units_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -677,298 +1069,6 @@ func (b0 UpdateUnitStatusResponse_builder) Build() *UpdateUnitStatusResponse {
 	return m0
 }
 
-type AssignUnitRequest struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	UnitId        int64                  `protobuf:"varint,1,opt,name=unit_id,json=unitId,proto3" json:"unit_id,omitempty"`
-	ToAdd         []int32                `protobuf:"varint,2,rep,packed,name=to_add,json=toAdd,proto3" json:"to_add,omitempty"`
-	ToRemove      []int32                `protobuf:"varint,3,rep,packed,name=to_remove,json=toRemove,proto3" json:"to_remove,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AssignUnitRequest) Reset() {
-	*x = AssignUnitRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[10]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AssignUnitRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AssignUnitRequest) ProtoMessage() {}
-
-func (x *AssignUnitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[10]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *AssignUnitRequest) GetUnitId() int64 {
-	if x != nil {
-		return x.UnitId
-	}
-	return 0
-}
-
-func (x *AssignUnitRequest) GetToAdd() []int32 {
-	if x != nil {
-		return x.ToAdd
-	}
-	return nil
-}
-
-func (x *AssignUnitRequest) GetToRemove() []int32 {
-	if x != nil {
-		return x.ToRemove
-	}
-	return nil
-}
-
-func (x *AssignUnitRequest) SetUnitId(v int64) {
-	x.UnitId = v
-}
-
-func (x *AssignUnitRequest) SetToAdd(v []int32) {
-	x.ToAdd = v
-}
-
-func (x *AssignUnitRequest) SetToRemove(v []int32) {
-	x.ToRemove = v
-}
-
-type AssignUnitRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	UnitId   int64
-	ToAdd    []int32
-	ToRemove []int32
-}
-
-func (b0 AssignUnitRequest_builder) Build() *AssignUnitRequest {
-	m0 := &AssignUnitRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.UnitId = b.UnitId
-	x.ToAdd = b.ToAdd
-	x.ToRemove = b.ToRemove
-	return m0
-}
-
-type AssignUnitResponse struct {
-	state         protoimpl.MessageState `protogen:"hybrid.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AssignUnitResponse) Reset() {
-	*x = AssignUnitResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[11]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AssignUnitResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AssignUnitResponse) ProtoMessage() {}
-
-func (x *AssignUnitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[11]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-type AssignUnitResponse_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-}
-
-func (b0 AssignUnitResponse_builder) Build() *AssignUnitResponse {
-	m0 := &AssignUnitResponse{}
-	b, x := &b0, m0
-	_, _ = b, x
-	return m0
-}
-
-type ListUnitActivityRequest struct {
-	state         protoimpl.MessageState      `protogen:"hybrid.v1"`
-	Pagination    *database.PaginationRequest `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
-	Id            int64                       `protobuf:"varint,2,opt,name=id,proto3" json:"id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ListUnitActivityRequest) Reset() {
-	*x = ListUnitActivityRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[12]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ListUnitActivityRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ListUnitActivityRequest) ProtoMessage() {}
-
-func (x *ListUnitActivityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[12]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *ListUnitActivityRequest) GetPagination() *database.PaginationRequest {
-	if x != nil {
-		return x.Pagination
-	}
-	return nil
-}
-
-func (x *ListUnitActivityRequest) GetId() int64 {
-	if x != nil {
-		return x.Id
-	}
-	return 0
-}
-
-func (x *ListUnitActivityRequest) SetPagination(v *database.PaginationRequest) {
-	x.Pagination = v
-}
-
-func (x *ListUnitActivityRequest) SetId(v int64) {
-	x.Id = v
-}
-
-func (x *ListUnitActivityRequest) HasPagination() bool {
-	if x == nil {
-		return false
-	}
-	return x.Pagination != nil
-}
-
-func (x *ListUnitActivityRequest) ClearPagination() {
-	x.Pagination = nil
-}
-
-type ListUnitActivityRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	Pagination *database.PaginationRequest
-	Id         int64
-}
-
-func (b0 ListUnitActivityRequest_builder) Build() *ListUnitActivityRequest {
-	m0 := &ListUnitActivityRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.Pagination = b.Pagination
-	x.Id = b.Id
-	return m0
-}
-
-type ListUnitActivityResponse struct {
-	state         protoimpl.MessageState       `protogen:"hybrid.v1"`
-	Pagination    *database.PaginationResponse `protobuf:"bytes,1,opt,name=pagination,proto3" json:"pagination,omitempty"`
-	Activity      []*units.UnitStatus          `protobuf:"bytes,2,rep,name=activity,proto3" json:"activity,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ListUnitActivityResponse) Reset() {
-	*x = ListUnitActivityResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[13]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ListUnitActivityResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ListUnitActivityResponse) ProtoMessage() {}
-
-func (x *ListUnitActivityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[13]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *ListUnitActivityResponse) GetPagination() *database.PaginationResponse {
-	if x != nil {
-		return x.Pagination
-	}
-	return nil
-}
-
-func (x *ListUnitActivityResponse) GetActivity() []*units.UnitStatus {
-	if x != nil {
-		return x.Activity
-	}
-	return nil
-}
-
-func (x *ListUnitActivityResponse) SetPagination(v *database.PaginationResponse) {
-	x.Pagination = v
-}
-
-func (x *ListUnitActivityResponse) SetActivity(v []*units.UnitStatus) {
-	x.Activity = v
-}
-
-func (x *ListUnitActivityResponse) HasPagination() bool {
-	if x == nil {
-		return false
-	}
-	return x.Pagination != nil
-}
-
-func (x *ListUnitActivityResponse) ClearPagination() {
-	x.Pagination = nil
-}
-
-type ListUnitActivityResponse_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	Pagination *database.PaginationResponse
-	Activity   []*units.UnitStatus
-}
-
-func (b0 ListUnitActivityResponse_builder) Build() *ListUnitActivityResponse {
-	m0 := &ListUnitActivityResponse{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.Pagination = b.Pagination
-	x.Activity = b.Activity
-	return m0
-}
-
 var File_services_centrum_units_proto protoreflect.FileDescriptor
 
 const file_services_centrum_units_proto_rawDesc = "" +
@@ -983,27 +1083,7 @@ const file_services_centrum_units_proto_rawDesc = "" +
 	"\x10ListUnitsRequest\x12;\n" +
 	"\x06status\x18\x01 \x03(\x0e2#.resources.centrum.units.StatusUnitR\x06status\"N\n" +
 	"\x11ListUnitsResponse\x129\n" +
-	"\x05units\x18\x01 \x03(\v2\x1d.resources.centrum.units.UnitB\x04\xc8\xf3\x18\x01R\x05units\"N\n" +
-	"\x19CreateOrUpdateUnitRequest\x121\n" +
-	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\"O\n" +
-	"\x1aCreateOrUpdateUnitResponse\x121\n" +
-	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\",\n" +
-	"\x11DeleteUnitRequest\x12\x17\n" +
-	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\"\x14\n" +
-	"\x12DeleteUnitResponse\"\xc9\x01\n" +
-	"\x17UpdateUnitStatusRequest\x12\x17\n" +
-	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12;\n" +
-	"\x06status\x18\x02 \x01(\x0e2#.resources.centrum.units.StatusUnitR\x06status\x12#\n" +
-	"\x06reason\x18\x03 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x00R\x06reason\x88\x01\x01\x12\x1f\n" +
-	"\x04code\x18\x04 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x01R\x04code\x88\x01\x01B\t\n" +
-	"\a_reasonB\a\n" +
-	"\x05_code\"\x1a\n" +
-	"\x18UpdateUnitStatusResponse\"`\n" +
-	"\x11AssignUnitRequest\x12\x17\n" +
-	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12\x15\n" +
-	"\x06to_add\x18\x02 \x03(\x05R\x05toAdd\x12\x1b\n" +
-	"\tto_remove\x18\x03 \x03(\x05R\btoRemove\"\x14\n" +
-	"\x12AssignUnitResponse\"w\n" +
+	"\x05units\x18\x01 \x03(\v2\x1d.resources.centrum.units.UnitB\x04\xc8\xf3\x18\x01R\x05units\"w\n" +
 	"\x17ListUnitActivityRequest\x12L\n" +
 	"\n" +
 	"pagination\x18\x01 \x01(\v2,.resources.common.database.PaginationRequestR\n" +
@@ -1013,66 +1093,94 @@ const file_services_centrum_units_proto_rawDesc = "" +
 	"\n" +
 	"pagination\x18\x01 \x01(\v2-.resources.common.database.PaginationResponseR\n" +
 	"pagination\x12E\n" +
-	"\bactivity\x18\x02 \x03(\v2#.resources.centrum.units.UnitStatusB\x04\xc8\xf3\x18\x01R\bactivity2\xbb\a\n" +
+	"\bactivity\x18\x02 \x03(\v2#.resources.centrum.units.UnitStatusB\x04\xc8\xf3\x18\x01R\bactivity\"N\n" +
+	"\x19CreateOrUpdateUnitRequest\x121\n" +
+	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\"O\n" +
+	"\x1aCreateOrUpdateUnitResponse\x121\n" +
+	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\",\n" +
+	"\x11DeleteUnitRequest\x12\x17\n" +
+	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\"\x14\n" +
+	"\x12DeleteUnitResponse\"0\n" +
+	"\x13ReorderUnitsRequest\x12\x19\n" +
+	"\bunit_ids\x18\x01 \x03(\x03R\aunitIds\"\x16\n" +
+	"\x14ReorderUnitsResponse\"`\n" +
+	"\x11AssignUnitRequest\x12\x17\n" +
+	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12\x15\n" +
+	"\x06to_add\x18\x02 \x03(\x05R\x05toAdd\x12\x1b\n" +
+	"\tto_remove\x18\x03 \x03(\x05R\btoRemove\"\x14\n" +
+	"\x12AssignUnitResponse\"\xc9\x01\n" +
+	"\x17UpdateUnitStatusRequest\x12\x17\n" +
+	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12;\n" +
+	"\x06status\x18\x02 \x01(\x0e2#.resources.centrum.units.StatusUnitR\x06status\x12#\n" +
+	"\x06reason\x18\x03 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x00R\x06reason\x88\x01\x01\x12\x1f\n" +
+	"\x04code\x18\x04 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x01R\x04code\x88\x01\x01B\t\n" +
+	"\a_reasonB\a\n" +
+	"\x05_code\"\x1a\n" +
+	"\x18UpdateUnitStatusResponse2\xb6\b\n" +
 	"\fUnitsService\x12z\n" +
 	"\bJoinUnit\x12!.services.centrum.JoinUnitRequest\x1a\".services.centrum.JoinUnitResponse\"'\xd2\xf3\x18#\b\x01\x12\acentrum\x1a\x0eCentrumService\"\x06Stream\x12}\n" +
 	"\tListUnits\x12\".services.centrum.ListUnitsRequest\x1a#.services.centrum.ListUnitsResponse\"'\xd2\xf3\x18#\b\x01\x12\acentrum\x1a\x0eCentrumService\"\x06Stream\x12\x92\x01\n" +
 	"\x10ListUnitActivity\x12).services.centrum.ListUnitActivityRequest\x1a*.services.centrum.ListUnitActivityResponse\"'\xd2\xf3\x18#\b\x01\x12\acentrum\x1a\x0eCentrumService\"\x06Stream\x12w\n" +
 	"\x12CreateOrUpdateUnit\x12+.services.centrum.CreateOrUpdateUnitRequest\x1a,.services.centrum.CreateOrUpdateUnitResponse\"\x06\xd2\xf3\x18\x02\b\x01\x12_\n" +
 	"\n" +
-	"DeleteUnit\x12#.services.centrum.DeleteUnitRequest\x1a$.services.centrum.DeleteUnitResponse\"\x06\xd2\xf3\x18\x02\b\x01\x12\x85\x01\n" +
+	"DeleteUnit\x12#.services.centrum.DeleteUnitRequest\x1a$.services.centrum.DeleteUnitResponse\"\x06\xd2\xf3\x18\x02\b\x01\x12y\n" +
+	"\fReorderUnits\x12%.services.centrum.ReorderUnitsRequest\x1a&.services.centrum.ReorderUnitsResponse\"\x1a\xd2\xf3\x18\x16\b\x01\"\x12CreateOrUpdateUnit\x12\x85\x01\n" +
 	"\n" +
 	"AssignUnit\x12#.services.centrum.AssignUnitRequest\x1a$.services.centrum.AssignUnitResponse\",\xd2\xf3\x18(\b\x01\x12\acentrum\x1a\x0eCentrumService\"\vTakeControl\x12\x9b\x01\n" +
 	"\x10UpdateUnitStatus\x12).services.centrum.UpdateUnitStatusRequest\x1a*.services.centrum.UpdateUnitStatusResponse\"0\xd2\xf3\x18,\b\x01\x12\acentrum\x1a\x11DispatchesService\"\fTakeDispatch\x1a\x1b\xea\xf3\x18\x17\bn\x12\x13i-mdi-account-groupBLZJgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/services/centrum;centrumb\x06proto3"
 
-var file_services_centrum_units_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_services_centrum_units_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_services_centrum_units_proto_goTypes = []any{
 	(*JoinUnitRequest)(nil),             // 0: services.centrum.JoinUnitRequest
 	(*JoinUnitResponse)(nil),            // 1: services.centrum.JoinUnitResponse
 	(*ListUnitsRequest)(nil),            // 2: services.centrum.ListUnitsRequest
 	(*ListUnitsResponse)(nil),           // 3: services.centrum.ListUnitsResponse
-	(*CreateOrUpdateUnitRequest)(nil),   // 4: services.centrum.CreateOrUpdateUnitRequest
-	(*CreateOrUpdateUnitResponse)(nil),  // 5: services.centrum.CreateOrUpdateUnitResponse
-	(*DeleteUnitRequest)(nil),           // 6: services.centrum.DeleteUnitRequest
-	(*DeleteUnitResponse)(nil),          // 7: services.centrum.DeleteUnitResponse
-	(*UpdateUnitStatusRequest)(nil),     // 8: services.centrum.UpdateUnitStatusRequest
-	(*UpdateUnitStatusResponse)(nil),    // 9: services.centrum.UpdateUnitStatusResponse
-	(*AssignUnitRequest)(nil),           // 10: services.centrum.AssignUnitRequest
-	(*AssignUnitResponse)(nil),          // 11: services.centrum.AssignUnitResponse
-	(*ListUnitActivityRequest)(nil),     // 12: services.centrum.ListUnitActivityRequest
-	(*ListUnitActivityResponse)(nil),    // 13: services.centrum.ListUnitActivityResponse
-	(*units.Unit)(nil),                  // 14: resources.centrum.units.Unit
-	(units.StatusUnit)(0),               // 15: resources.centrum.units.StatusUnit
-	(*database.PaginationRequest)(nil),  // 16: resources.common.database.PaginationRequest
-	(*database.PaginationResponse)(nil), // 17: resources.common.database.PaginationResponse
-	(*units.UnitStatus)(nil),            // 18: resources.centrum.units.UnitStatus
+	(*ListUnitActivityRequest)(nil),     // 4: services.centrum.ListUnitActivityRequest
+	(*ListUnitActivityResponse)(nil),    // 5: services.centrum.ListUnitActivityResponse
+	(*CreateOrUpdateUnitRequest)(nil),   // 6: services.centrum.CreateOrUpdateUnitRequest
+	(*CreateOrUpdateUnitResponse)(nil),  // 7: services.centrum.CreateOrUpdateUnitResponse
+	(*DeleteUnitRequest)(nil),           // 8: services.centrum.DeleteUnitRequest
+	(*DeleteUnitResponse)(nil),          // 9: services.centrum.DeleteUnitResponse
+	(*ReorderUnitsRequest)(nil),         // 10: services.centrum.ReorderUnitsRequest
+	(*ReorderUnitsResponse)(nil),        // 11: services.centrum.ReorderUnitsResponse
+	(*AssignUnitRequest)(nil),           // 12: services.centrum.AssignUnitRequest
+	(*AssignUnitResponse)(nil),          // 13: services.centrum.AssignUnitResponse
+	(*UpdateUnitStatusRequest)(nil),     // 14: services.centrum.UpdateUnitStatusRequest
+	(*UpdateUnitStatusResponse)(nil),    // 15: services.centrum.UpdateUnitStatusResponse
+	(*units.Unit)(nil),                  // 16: resources.centrum.units.Unit
+	(units.StatusUnit)(0),               // 17: resources.centrum.units.StatusUnit
+	(*database.PaginationRequest)(nil),  // 18: resources.common.database.PaginationRequest
+	(*database.PaginationResponse)(nil), // 19: resources.common.database.PaginationResponse
+	(*units.UnitStatus)(nil),            // 20: resources.centrum.units.UnitStatus
 }
 var file_services_centrum_units_proto_depIdxs = []int32{
-	14, // 0: services.centrum.JoinUnitResponse.unit:type_name -> resources.centrum.units.Unit
-	15, // 1: services.centrum.ListUnitsRequest.status:type_name -> resources.centrum.units.StatusUnit
-	14, // 2: services.centrum.ListUnitsResponse.units:type_name -> resources.centrum.units.Unit
-	14, // 3: services.centrum.CreateOrUpdateUnitRequest.unit:type_name -> resources.centrum.units.Unit
-	14, // 4: services.centrum.CreateOrUpdateUnitResponse.unit:type_name -> resources.centrum.units.Unit
-	15, // 5: services.centrum.UpdateUnitStatusRequest.status:type_name -> resources.centrum.units.StatusUnit
-	16, // 6: services.centrum.ListUnitActivityRequest.pagination:type_name -> resources.common.database.PaginationRequest
-	17, // 7: services.centrum.ListUnitActivityResponse.pagination:type_name -> resources.common.database.PaginationResponse
-	18, // 8: services.centrum.ListUnitActivityResponse.activity:type_name -> resources.centrum.units.UnitStatus
+	16, // 0: services.centrum.JoinUnitResponse.unit:type_name -> resources.centrum.units.Unit
+	17, // 1: services.centrum.ListUnitsRequest.status:type_name -> resources.centrum.units.StatusUnit
+	16, // 2: services.centrum.ListUnitsResponse.units:type_name -> resources.centrum.units.Unit
+	18, // 3: services.centrum.ListUnitActivityRequest.pagination:type_name -> resources.common.database.PaginationRequest
+	19, // 4: services.centrum.ListUnitActivityResponse.pagination:type_name -> resources.common.database.PaginationResponse
+	20, // 5: services.centrum.ListUnitActivityResponse.activity:type_name -> resources.centrum.units.UnitStatus
+	16, // 6: services.centrum.CreateOrUpdateUnitRequest.unit:type_name -> resources.centrum.units.Unit
+	16, // 7: services.centrum.CreateOrUpdateUnitResponse.unit:type_name -> resources.centrum.units.Unit
+	17, // 8: services.centrum.UpdateUnitStatusRequest.status:type_name -> resources.centrum.units.StatusUnit
 	0,  // 9: services.centrum.UnitsService.JoinUnit:input_type -> services.centrum.JoinUnitRequest
 	2,  // 10: services.centrum.UnitsService.ListUnits:input_type -> services.centrum.ListUnitsRequest
-	12, // 11: services.centrum.UnitsService.ListUnitActivity:input_type -> services.centrum.ListUnitActivityRequest
-	4,  // 12: services.centrum.UnitsService.CreateOrUpdateUnit:input_type -> services.centrum.CreateOrUpdateUnitRequest
-	6,  // 13: services.centrum.UnitsService.DeleteUnit:input_type -> services.centrum.DeleteUnitRequest
-	10, // 14: services.centrum.UnitsService.AssignUnit:input_type -> services.centrum.AssignUnitRequest
-	8,  // 15: services.centrum.UnitsService.UpdateUnitStatus:input_type -> services.centrum.UpdateUnitStatusRequest
-	1,  // 16: services.centrum.UnitsService.JoinUnit:output_type -> services.centrum.JoinUnitResponse
-	3,  // 17: services.centrum.UnitsService.ListUnits:output_type -> services.centrum.ListUnitsResponse
-	13, // 18: services.centrum.UnitsService.ListUnitActivity:output_type -> services.centrum.ListUnitActivityResponse
-	5,  // 19: services.centrum.UnitsService.CreateOrUpdateUnit:output_type -> services.centrum.CreateOrUpdateUnitResponse
-	7,  // 20: services.centrum.UnitsService.DeleteUnit:output_type -> services.centrum.DeleteUnitResponse
-	11, // 21: services.centrum.UnitsService.AssignUnit:output_type -> services.centrum.AssignUnitResponse
-	9,  // 22: services.centrum.UnitsService.UpdateUnitStatus:output_type -> services.centrum.UpdateUnitStatusResponse
-	16, // [16:23] is the sub-list for method output_type
-	9,  // [9:16] is the sub-list for method input_type
+	4,  // 11: services.centrum.UnitsService.ListUnitActivity:input_type -> services.centrum.ListUnitActivityRequest
+	6,  // 12: services.centrum.UnitsService.CreateOrUpdateUnit:input_type -> services.centrum.CreateOrUpdateUnitRequest
+	8,  // 13: services.centrum.UnitsService.DeleteUnit:input_type -> services.centrum.DeleteUnitRequest
+	10, // 14: services.centrum.UnitsService.ReorderUnits:input_type -> services.centrum.ReorderUnitsRequest
+	12, // 15: services.centrum.UnitsService.AssignUnit:input_type -> services.centrum.AssignUnitRequest
+	14, // 16: services.centrum.UnitsService.UpdateUnitStatus:input_type -> services.centrum.UpdateUnitStatusRequest
+	1,  // 17: services.centrum.UnitsService.JoinUnit:output_type -> services.centrum.JoinUnitResponse
+	3,  // 18: services.centrum.UnitsService.ListUnits:output_type -> services.centrum.ListUnitsResponse
+	5,  // 19: services.centrum.UnitsService.ListUnitActivity:output_type -> services.centrum.ListUnitActivityResponse
+	7,  // 20: services.centrum.UnitsService.CreateOrUpdateUnit:output_type -> services.centrum.CreateOrUpdateUnitResponse
+	9,  // 21: services.centrum.UnitsService.DeleteUnit:output_type -> services.centrum.DeleteUnitResponse
+	11, // 22: services.centrum.UnitsService.ReorderUnits:output_type -> services.centrum.ReorderUnitsResponse
+	13, // 23: services.centrum.UnitsService.AssignUnit:output_type -> services.centrum.AssignUnitResponse
+	15, // 24: services.centrum.UnitsService.UpdateUnitStatus:output_type -> services.centrum.UpdateUnitStatusResponse
+	17, // [17:25] is the sub-list for method output_type
+	9,  // [9:17] is the sub-list for method input_type
 	9,  // [9:9] is the sub-list for extension type_name
 	9,  // [9:9] is the sub-list for extension extendee
 	0,  // [0:9] is the sub-list for field type_name
@@ -1084,14 +1192,14 @@ func file_services_centrum_units_proto_init() {
 		return
 	}
 	file_services_centrum_units_proto_msgTypes[0].OneofWrappers = []any{}
-	file_services_centrum_units_proto_msgTypes[8].OneofWrappers = []any{}
+	file_services_centrum_units_proto_msgTypes[14].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_services_centrum_units_proto_rawDesc), len(file_services_centrum_units_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/go/proto/services/centrum/units_grpc.pb.go
+++ b/gen/go/proto/services/centrum/units_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	UnitsService_ListUnitActivity_FullMethodName   = "/services.centrum.UnitsService/ListUnitActivity"
 	UnitsService_CreateOrUpdateUnit_FullMethodName = "/services.centrum.UnitsService/CreateOrUpdateUnit"
 	UnitsService_DeleteUnit_FullMethodName         = "/services.centrum.UnitsService/DeleteUnit"
+	UnitsService_ReorderUnits_FullMethodName       = "/services.centrum.UnitsService/ReorderUnits"
 	UnitsService_AssignUnit_FullMethodName         = "/services.centrum.UnitsService/AssignUnit"
 	UnitsService_UpdateUnitStatus_FullMethodName   = "/services.centrum.UnitsService/UpdateUnitStatus"
 )
@@ -37,6 +38,7 @@ type UnitsServiceClient interface {
 	ListUnitActivity(ctx context.Context, in *ListUnitActivityRequest, opts ...grpc.CallOption) (*ListUnitActivityResponse, error)
 	CreateOrUpdateUnit(ctx context.Context, in *CreateOrUpdateUnitRequest, opts ...grpc.CallOption) (*CreateOrUpdateUnitResponse, error)
 	DeleteUnit(ctx context.Context, in *DeleteUnitRequest, opts ...grpc.CallOption) (*DeleteUnitResponse, error)
+	ReorderUnits(ctx context.Context, in *ReorderUnitsRequest, opts ...grpc.CallOption) (*ReorderUnitsResponse, error)
 	AssignUnit(ctx context.Context, in *AssignUnitRequest, opts ...grpc.CallOption) (*AssignUnitResponse, error)
 	UpdateUnitStatus(ctx context.Context, in *UpdateUnitStatusRequest, opts ...grpc.CallOption) (*UpdateUnitStatusResponse, error)
 }
@@ -99,6 +101,16 @@ func (c *unitsServiceClient) DeleteUnit(ctx context.Context, in *DeleteUnitReque
 	return out, nil
 }
 
+func (c *unitsServiceClient) ReorderUnits(ctx context.Context, in *ReorderUnitsRequest, opts ...grpc.CallOption) (*ReorderUnitsResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ReorderUnitsResponse)
+	err := c.cc.Invoke(ctx, UnitsService_ReorderUnits_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *unitsServiceClient) AssignUnit(ctx context.Context, in *AssignUnitRequest, opts ...grpc.CallOption) (*AssignUnitResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(AssignUnitResponse)
@@ -128,6 +140,7 @@ type UnitsServiceServer interface {
 	ListUnitActivity(context.Context, *ListUnitActivityRequest) (*ListUnitActivityResponse, error)
 	CreateOrUpdateUnit(context.Context, *CreateOrUpdateUnitRequest) (*CreateOrUpdateUnitResponse, error)
 	DeleteUnit(context.Context, *DeleteUnitRequest) (*DeleteUnitResponse, error)
+	ReorderUnits(context.Context, *ReorderUnitsRequest) (*ReorderUnitsResponse, error)
 	AssignUnit(context.Context, *AssignUnitRequest) (*AssignUnitResponse, error)
 	UpdateUnitStatus(context.Context, *UpdateUnitStatusRequest) (*UpdateUnitStatusResponse, error)
 	mustEmbedUnimplementedUnitsServiceServer()
@@ -154,6 +167,9 @@ func (UnimplementedUnitsServiceServer) CreateOrUpdateUnit(context.Context, *Crea
 }
 func (UnimplementedUnitsServiceServer) DeleteUnit(context.Context, *DeleteUnitRequest) (*DeleteUnitResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteUnit not implemented")
+}
+func (UnimplementedUnitsServiceServer) ReorderUnits(context.Context, *ReorderUnitsRequest) (*ReorderUnitsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ReorderUnits not implemented")
 }
 func (UnimplementedUnitsServiceServer) AssignUnit(context.Context, *AssignUnitRequest) (*AssignUnitResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method AssignUnit not implemented")
@@ -272,6 +288,24 @@ func _UnitsService_DeleteUnit_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _UnitsService_ReorderUnits_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ReorderUnitsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(UnitsServiceServer).ReorderUnits(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: UnitsService_ReorderUnits_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(UnitsServiceServer).ReorderUnits(ctx, req.(*ReorderUnitsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _UnitsService_AssignUnit_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(AssignUnitRequest)
 	if err := dec(in); err != nil {
@@ -334,6 +368,10 @@ var UnitsService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteUnit",
 			Handler:    _UnitsService_DeleteUnit_Handler,
+		},
+		{
+			MethodName: "ReorderUnits",
+			Handler:    _UnitsService_ReorderUnits_Handler,
 		},
 		{
 			MethodName: "AssignUnit",

--- a/gen/go/proto/services/centrum/units_protoopaque.pb.go
+++ b/gen/go/proto/services/centrum/units_protoopaque.pb.go
@@ -286,6 +286,172 @@ func (b0 ListUnitsResponse_builder) Build() *ListUnitsResponse {
 	return m0
 }
 
+type ListUnitActivityRequest struct {
+	state                 protoimpl.MessageState      `protogen:"opaque.v1"`
+	xxx_hidden_Pagination *database.PaginationRequest `protobuf:"bytes,1,opt,name=pagination,proto3"`
+	xxx_hidden_Id         int64                       `protobuf:"varint,2,opt,name=id,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *ListUnitActivityRequest) Reset() {
+	*x = ListUnitActivityRequest{}
+	mi := &file_services_centrum_units_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUnitActivityRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUnitActivityRequest) ProtoMessage() {}
+
+func (x *ListUnitActivityRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListUnitActivityRequest) GetPagination() *database.PaginationRequest {
+	if x != nil {
+		return x.xxx_hidden_Pagination
+	}
+	return nil
+}
+
+func (x *ListUnitActivityRequest) GetId() int64 {
+	if x != nil {
+		return x.xxx_hidden_Id
+	}
+	return 0
+}
+
+func (x *ListUnitActivityRequest) SetPagination(v *database.PaginationRequest) {
+	x.xxx_hidden_Pagination = v
+}
+
+func (x *ListUnitActivityRequest) SetId(v int64) {
+	x.xxx_hidden_Id = v
+}
+
+func (x *ListUnitActivityRequest) HasPagination() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Pagination != nil
+}
+
+func (x *ListUnitActivityRequest) ClearPagination() {
+	x.xxx_hidden_Pagination = nil
+}
+
+type ListUnitActivityRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Pagination *database.PaginationRequest
+	Id         int64
+}
+
+func (b0 ListUnitActivityRequest_builder) Build() *ListUnitActivityRequest {
+	m0 := &ListUnitActivityRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Pagination = b.Pagination
+	x.xxx_hidden_Id = b.Id
+	return m0
+}
+
+type ListUnitActivityResponse struct {
+	state                 protoimpl.MessageState       `protogen:"opaque.v1"`
+	xxx_hidden_Pagination *database.PaginationResponse `protobuf:"bytes,1,opt,name=pagination,proto3"`
+	xxx_hidden_Activity   *[]*units.UnitStatus         `protobuf:"bytes,2,rep,name=activity,proto3"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *ListUnitActivityResponse) Reset() {
+	*x = ListUnitActivityResponse{}
+	mi := &file_services_centrum_units_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListUnitActivityResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListUnitActivityResponse) ProtoMessage() {}
+
+func (x *ListUnitActivityResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ListUnitActivityResponse) GetPagination() *database.PaginationResponse {
+	if x != nil {
+		return x.xxx_hidden_Pagination
+	}
+	return nil
+}
+
+func (x *ListUnitActivityResponse) GetActivity() []*units.UnitStatus {
+	if x != nil {
+		if x.xxx_hidden_Activity != nil {
+			return *x.xxx_hidden_Activity
+		}
+	}
+	return nil
+}
+
+func (x *ListUnitActivityResponse) SetPagination(v *database.PaginationResponse) {
+	x.xxx_hidden_Pagination = v
+}
+
+func (x *ListUnitActivityResponse) SetActivity(v []*units.UnitStatus) {
+	x.xxx_hidden_Activity = &v
+}
+
+func (x *ListUnitActivityResponse) HasPagination() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Pagination != nil
+}
+
+func (x *ListUnitActivityResponse) ClearPagination() {
+	x.xxx_hidden_Pagination = nil
+}
+
+type ListUnitActivityResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Pagination *database.PaginationResponse
+	Activity   []*units.UnitStatus
+}
+
+func (b0 ListUnitActivityResponse_builder) Build() *ListUnitActivityResponse {
+	m0 := &ListUnitActivityResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Pagination = b.Pagination
+	x.xxx_hidden_Activity = &b.Activity
+	return m0
+}
+
 type CreateOrUpdateUnitRequest struct {
 	state           protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_Unit *units.Unit            `protobuf:"bytes,1,opt,name=unit,proto3"`
@@ -295,7 +461,7 @@ type CreateOrUpdateUnitRequest struct {
 
 func (x *CreateOrUpdateUnitRequest) Reset() {
 	*x = CreateOrUpdateUnitRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[4]
+	mi := &file_services_centrum_units_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -307,7 +473,7 @@ func (x *CreateOrUpdateUnitRequest) String() string {
 func (*CreateOrUpdateUnitRequest) ProtoMessage() {}
 
 func (x *CreateOrUpdateUnitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[4]
+	mi := &file_services_centrum_units_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -363,7 +529,7 @@ type CreateOrUpdateUnitResponse struct {
 
 func (x *CreateOrUpdateUnitResponse) Reset() {
 	*x = CreateOrUpdateUnitResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[5]
+	mi := &file_services_centrum_units_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -375,7 +541,7 @@ func (x *CreateOrUpdateUnitResponse) String() string {
 func (*CreateOrUpdateUnitResponse) ProtoMessage() {}
 
 func (x *CreateOrUpdateUnitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[5]
+	mi := &file_services_centrum_units_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -431,7 +597,7 @@ type DeleteUnitRequest struct {
 
 func (x *DeleteUnitRequest) Reset() {
 	*x = DeleteUnitRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[6]
+	mi := &file_services_centrum_units_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -443,7 +609,7 @@ func (x *DeleteUnitRequest) String() string {
 func (*DeleteUnitRequest) ProtoMessage() {}
 
 func (x *DeleteUnitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[6]
+	mi := &file_services_centrum_units_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -487,7 +653,7 @@ type DeleteUnitResponse struct {
 
 func (x *DeleteUnitResponse) Reset() {
 	*x = DeleteUnitResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[7]
+	mi := &file_services_centrum_units_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -499,7 +665,7 @@ func (x *DeleteUnitResponse) String() string {
 func (*DeleteUnitResponse) ProtoMessage() {}
 
 func (x *DeleteUnitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[7]
+	mi := &file_services_centrum_units_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -522,6 +688,234 @@ func (b0 DeleteUnitResponse_builder) Build() *DeleteUnitResponse {
 	return m0
 }
 
+type ReorderUnitsRequest struct {
+	state              protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_UnitIds []int64                `protobuf:"varint,1,rep,packed,name=unit_ids,json=unitIds,proto3"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *ReorderUnitsRequest) Reset() {
+	*x = ReorderUnitsRequest{}
+	mi := &file_services_centrum_units_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReorderUnitsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReorderUnitsRequest) ProtoMessage() {}
+
+func (x *ReorderUnitsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *ReorderUnitsRequest) GetUnitIds() []int64 {
+	if x != nil {
+		return x.xxx_hidden_UnitIds
+	}
+	return nil
+}
+
+func (x *ReorderUnitsRequest) SetUnitIds(v []int64) {
+	x.xxx_hidden_UnitIds = v
+}
+
+type ReorderUnitsRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	UnitIds []int64
+}
+
+func (b0 ReorderUnitsRequest_builder) Build() *ReorderUnitsRequest {
+	m0 := &ReorderUnitsRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_UnitIds = b.UnitIds
+	return m0
+}
+
+type ReorderUnitsResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReorderUnitsResponse) Reset() {
+	*x = ReorderUnitsResponse{}
+	mi := &file_services_centrum_units_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReorderUnitsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReorderUnitsResponse) ProtoMessage() {}
+
+func (x *ReorderUnitsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type ReorderUnitsResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 ReorderUnitsResponse_builder) Build() *ReorderUnitsResponse {
+	m0 := &ReorderUnitsResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
+type AssignUnitRequest struct {
+	state               protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_UnitId   int64                  `protobuf:"varint,1,opt,name=unit_id,json=unitId,proto3"`
+	xxx_hidden_ToAdd    []int32                `protobuf:"varint,2,rep,packed,name=to_add,json=toAdd,proto3"`
+	xxx_hidden_ToRemove []int32                `protobuf:"varint,3,rep,packed,name=to_remove,json=toRemove,proto3"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *AssignUnitRequest) Reset() {
+	*x = AssignUnitRequest{}
+	mi := &file_services_centrum_units_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssignUnitRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssignUnitRequest) ProtoMessage() {}
+
+func (x *AssignUnitRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *AssignUnitRequest) GetUnitId() int64 {
+	if x != nil {
+		return x.xxx_hidden_UnitId
+	}
+	return 0
+}
+
+func (x *AssignUnitRequest) GetToAdd() []int32 {
+	if x != nil {
+		return x.xxx_hidden_ToAdd
+	}
+	return nil
+}
+
+func (x *AssignUnitRequest) GetToRemove() []int32 {
+	if x != nil {
+		return x.xxx_hidden_ToRemove
+	}
+	return nil
+}
+
+func (x *AssignUnitRequest) SetUnitId(v int64) {
+	x.xxx_hidden_UnitId = v
+}
+
+func (x *AssignUnitRequest) SetToAdd(v []int32) {
+	x.xxx_hidden_ToAdd = v
+}
+
+func (x *AssignUnitRequest) SetToRemove(v []int32) {
+	x.xxx_hidden_ToRemove = v
+}
+
+type AssignUnitRequest_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	UnitId   int64
+	ToAdd    []int32
+	ToRemove []int32
+}
+
+func (b0 AssignUnitRequest_builder) Build() *AssignUnitRequest {
+	m0 := &AssignUnitRequest{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_UnitId = b.UnitId
+	x.xxx_hidden_ToAdd = b.ToAdd
+	x.xxx_hidden_ToRemove = b.ToRemove
+	return m0
+}
+
+type AssignUnitResponse struct {
+	state         protoimpl.MessageState `protogen:"opaque.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AssignUnitResponse) Reset() {
+	*x = AssignUnitResponse{}
+	mi := &file_services_centrum_units_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AssignUnitResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AssignUnitResponse) ProtoMessage() {}
+
+func (x *AssignUnitResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_services_centrum_units_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+type AssignUnitResponse_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+}
+
+func (b0 AssignUnitResponse_builder) Build() *AssignUnitResponse {
+	m0 := &AssignUnitResponse{}
+	b, x := &b0, m0
+	_, _ = b, x
+	return m0
+}
+
 type UpdateUnitStatusRequest struct {
 	state                  protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_UnitId      int64                  `protobuf:"varint,1,opt,name=unit_id,json=unitId,proto3"`
@@ -536,7 +930,7 @@ type UpdateUnitStatusRequest struct {
 
 func (x *UpdateUnitStatusRequest) Reset() {
 	*x = UpdateUnitStatusRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[8]
+	mi := &file_services_centrum_units_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -548,7 +942,7 @@ func (x *UpdateUnitStatusRequest) String() string {
 func (*UpdateUnitStatusRequest) ProtoMessage() {}
 
 func (x *UpdateUnitStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[8]
+	mi := &file_services_centrum_units_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -669,7 +1063,7 @@ type UpdateUnitStatusResponse struct {
 
 func (x *UpdateUnitStatusResponse) Reset() {
 	*x = UpdateUnitStatusResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[9]
+	mi := &file_services_centrum_units_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -681,7 +1075,7 @@ func (x *UpdateUnitStatusResponse) String() string {
 func (*UpdateUnitStatusResponse) ProtoMessage() {}
 
 func (x *UpdateUnitStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[9]
+	mi := &file_services_centrum_units_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -704,300 +1098,6 @@ func (b0 UpdateUnitStatusResponse_builder) Build() *UpdateUnitStatusResponse {
 	return m0
 }
 
-type AssignUnitRequest struct {
-	state               protoimpl.MessageState `protogen:"opaque.v1"`
-	xxx_hidden_UnitId   int64                  `protobuf:"varint,1,opt,name=unit_id,json=unitId,proto3"`
-	xxx_hidden_ToAdd    []int32                `protobuf:"varint,2,rep,packed,name=to_add,json=toAdd,proto3"`
-	xxx_hidden_ToRemove []int32                `protobuf:"varint,3,rep,packed,name=to_remove,json=toRemove,proto3"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
-}
-
-func (x *AssignUnitRequest) Reset() {
-	*x = AssignUnitRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[10]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AssignUnitRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AssignUnitRequest) ProtoMessage() {}
-
-func (x *AssignUnitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[10]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *AssignUnitRequest) GetUnitId() int64 {
-	if x != nil {
-		return x.xxx_hidden_UnitId
-	}
-	return 0
-}
-
-func (x *AssignUnitRequest) GetToAdd() []int32 {
-	if x != nil {
-		return x.xxx_hidden_ToAdd
-	}
-	return nil
-}
-
-func (x *AssignUnitRequest) GetToRemove() []int32 {
-	if x != nil {
-		return x.xxx_hidden_ToRemove
-	}
-	return nil
-}
-
-func (x *AssignUnitRequest) SetUnitId(v int64) {
-	x.xxx_hidden_UnitId = v
-}
-
-func (x *AssignUnitRequest) SetToAdd(v []int32) {
-	x.xxx_hidden_ToAdd = v
-}
-
-func (x *AssignUnitRequest) SetToRemove(v []int32) {
-	x.xxx_hidden_ToRemove = v
-}
-
-type AssignUnitRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	UnitId   int64
-	ToAdd    []int32
-	ToRemove []int32
-}
-
-func (b0 AssignUnitRequest_builder) Build() *AssignUnitRequest {
-	m0 := &AssignUnitRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.xxx_hidden_UnitId = b.UnitId
-	x.xxx_hidden_ToAdd = b.ToAdd
-	x.xxx_hidden_ToRemove = b.ToRemove
-	return m0
-}
-
-type AssignUnitResponse struct {
-	state         protoimpl.MessageState `protogen:"opaque.v1"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *AssignUnitResponse) Reset() {
-	*x = AssignUnitResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[11]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *AssignUnitResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*AssignUnitResponse) ProtoMessage() {}
-
-func (x *AssignUnitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[11]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-type AssignUnitResponse_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-}
-
-func (b0 AssignUnitResponse_builder) Build() *AssignUnitResponse {
-	m0 := &AssignUnitResponse{}
-	b, x := &b0, m0
-	_, _ = b, x
-	return m0
-}
-
-type ListUnitActivityRequest struct {
-	state                 protoimpl.MessageState      `protogen:"opaque.v1"`
-	xxx_hidden_Pagination *database.PaginationRequest `protobuf:"bytes,1,opt,name=pagination,proto3"`
-	xxx_hidden_Id         int64                       `protobuf:"varint,2,opt,name=id,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
-}
-
-func (x *ListUnitActivityRequest) Reset() {
-	*x = ListUnitActivityRequest{}
-	mi := &file_services_centrum_units_proto_msgTypes[12]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ListUnitActivityRequest) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ListUnitActivityRequest) ProtoMessage() {}
-
-func (x *ListUnitActivityRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[12]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *ListUnitActivityRequest) GetPagination() *database.PaginationRequest {
-	if x != nil {
-		return x.xxx_hidden_Pagination
-	}
-	return nil
-}
-
-func (x *ListUnitActivityRequest) GetId() int64 {
-	if x != nil {
-		return x.xxx_hidden_Id
-	}
-	return 0
-}
-
-func (x *ListUnitActivityRequest) SetPagination(v *database.PaginationRequest) {
-	x.xxx_hidden_Pagination = v
-}
-
-func (x *ListUnitActivityRequest) SetId(v int64) {
-	x.xxx_hidden_Id = v
-}
-
-func (x *ListUnitActivityRequest) HasPagination() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_Pagination != nil
-}
-
-func (x *ListUnitActivityRequest) ClearPagination() {
-	x.xxx_hidden_Pagination = nil
-}
-
-type ListUnitActivityRequest_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	Pagination *database.PaginationRequest
-	Id         int64
-}
-
-func (b0 ListUnitActivityRequest_builder) Build() *ListUnitActivityRequest {
-	m0 := &ListUnitActivityRequest{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.xxx_hidden_Pagination = b.Pagination
-	x.xxx_hidden_Id = b.Id
-	return m0
-}
-
-type ListUnitActivityResponse struct {
-	state                 protoimpl.MessageState       `protogen:"opaque.v1"`
-	xxx_hidden_Pagination *database.PaginationResponse `protobuf:"bytes,1,opt,name=pagination,proto3"`
-	xxx_hidden_Activity   *[]*units.UnitStatus         `protobuf:"bytes,2,rep,name=activity,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
-}
-
-func (x *ListUnitActivityResponse) Reset() {
-	*x = ListUnitActivityResponse{}
-	mi := &file_services_centrum_units_proto_msgTypes[13]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ListUnitActivityResponse) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ListUnitActivityResponse) ProtoMessage() {}
-
-func (x *ListUnitActivityResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_services_centrum_units_proto_msgTypes[13]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-func (x *ListUnitActivityResponse) GetPagination() *database.PaginationResponse {
-	if x != nil {
-		return x.xxx_hidden_Pagination
-	}
-	return nil
-}
-
-func (x *ListUnitActivityResponse) GetActivity() []*units.UnitStatus {
-	if x != nil {
-		if x.xxx_hidden_Activity != nil {
-			return *x.xxx_hidden_Activity
-		}
-	}
-	return nil
-}
-
-func (x *ListUnitActivityResponse) SetPagination(v *database.PaginationResponse) {
-	x.xxx_hidden_Pagination = v
-}
-
-func (x *ListUnitActivityResponse) SetActivity(v []*units.UnitStatus) {
-	x.xxx_hidden_Activity = &v
-}
-
-func (x *ListUnitActivityResponse) HasPagination() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_Pagination != nil
-}
-
-func (x *ListUnitActivityResponse) ClearPagination() {
-	x.xxx_hidden_Pagination = nil
-}
-
-type ListUnitActivityResponse_builder struct {
-	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
-
-	Pagination *database.PaginationResponse
-	Activity   []*units.UnitStatus
-}
-
-func (b0 ListUnitActivityResponse_builder) Build() *ListUnitActivityResponse {
-	m0 := &ListUnitActivityResponse{}
-	b, x := &b0, m0
-	_, _ = b, x
-	x.xxx_hidden_Pagination = b.Pagination
-	x.xxx_hidden_Activity = &b.Activity
-	return m0
-}
-
 var File_services_centrum_units_proto protoreflect.FileDescriptor
 
 const file_services_centrum_units_proto_rawDesc = "" +
@@ -1012,27 +1112,7 @@ const file_services_centrum_units_proto_rawDesc = "" +
 	"\x10ListUnitsRequest\x12;\n" +
 	"\x06status\x18\x01 \x03(\x0e2#.resources.centrum.units.StatusUnitR\x06status\"N\n" +
 	"\x11ListUnitsResponse\x129\n" +
-	"\x05units\x18\x01 \x03(\v2\x1d.resources.centrum.units.UnitB\x04\xc8\xf3\x18\x01R\x05units\"N\n" +
-	"\x19CreateOrUpdateUnitRequest\x121\n" +
-	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\"O\n" +
-	"\x1aCreateOrUpdateUnitResponse\x121\n" +
-	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\",\n" +
-	"\x11DeleteUnitRequest\x12\x17\n" +
-	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\"\x14\n" +
-	"\x12DeleteUnitResponse\"\xc9\x01\n" +
-	"\x17UpdateUnitStatusRequest\x12\x17\n" +
-	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12;\n" +
-	"\x06status\x18\x02 \x01(\x0e2#.resources.centrum.units.StatusUnitR\x06status\x12#\n" +
-	"\x06reason\x18\x03 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x00R\x06reason\x88\x01\x01\x12\x1f\n" +
-	"\x04code\x18\x04 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x01R\x04code\x88\x01\x01B\t\n" +
-	"\a_reasonB\a\n" +
-	"\x05_code\"\x1a\n" +
-	"\x18UpdateUnitStatusResponse\"`\n" +
-	"\x11AssignUnitRequest\x12\x17\n" +
-	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12\x15\n" +
-	"\x06to_add\x18\x02 \x03(\x05R\x05toAdd\x12\x1b\n" +
-	"\tto_remove\x18\x03 \x03(\x05R\btoRemove\"\x14\n" +
-	"\x12AssignUnitResponse\"w\n" +
+	"\x05units\x18\x01 \x03(\v2\x1d.resources.centrum.units.UnitB\x04\xc8\xf3\x18\x01R\x05units\"w\n" +
 	"\x17ListUnitActivityRequest\x12L\n" +
 	"\n" +
 	"pagination\x18\x01 \x01(\v2,.resources.common.database.PaginationRequestR\n" +
@@ -1042,66 +1122,94 @@ const file_services_centrum_units_proto_rawDesc = "" +
 	"\n" +
 	"pagination\x18\x01 \x01(\v2-.resources.common.database.PaginationResponseR\n" +
 	"pagination\x12E\n" +
-	"\bactivity\x18\x02 \x03(\v2#.resources.centrum.units.UnitStatusB\x04\xc8\xf3\x18\x01R\bactivity2\xbb\a\n" +
+	"\bactivity\x18\x02 \x03(\v2#.resources.centrum.units.UnitStatusB\x04\xc8\xf3\x18\x01R\bactivity\"N\n" +
+	"\x19CreateOrUpdateUnitRequest\x121\n" +
+	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\"O\n" +
+	"\x1aCreateOrUpdateUnitResponse\x121\n" +
+	"\x04unit\x18\x01 \x01(\v2\x1d.resources.centrum.units.UnitR\x04unit\",\n" +
+	"\x11DeleteUnitRequest\x12\x17\n" +
+	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\"\x14\n" +
+	"\x12DeleteUnitResponse\"0\n" +
+	"\x13ReorderUnitsRequest\x12\x19\n" +
+	"\bunit_ids\x18\x01 \x03(\x03R\aunitIds\"\x16\n" +
+	"\x14ReorderUnitsResponse\"`\n" +
+	"\x11AssignUnitRequest\x12\x17\n" +
+	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12\x15\n" +
+	"\x06to_add\x18\x02 \x03(\x05R\x05toAdd\x12\x1b\n" +
+	"\tto_remove\x18\x03 \x03(\x05R\btoRemove\"\x14\n" +
+	"\x12AssignUnitResponse\"\xc9\x01\n" +
+	"\x17UpdateUnitStatusRequest\x12\x17\n" +
+	"\aunit_id\x18\x01 \x01(\x03R\x06unitId\x12;\n" +
+	"\x06status\x18\x02 \x01(\x0e2#.resources.centrum.units.StatusUnitR\x06status\x12#\n" +
+	"\x06reason\x18\x03 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x00R\x06reason\x88\x01\x01\x12\x1f\n" +
+	"\x04code\x18\x04 \x01(\tB\x06\xda\xf3\x18\x02\b\x01H\x01R\x04code\x88\x01\x01B\t\n" +
+	"\a_reasonB\a\n" +
+	"\x05_code\"\x1a\n" +
+	"\x18UpdateUnitStatusResponse2\xb6\b\n" +
 	"\fUnitsService\x12z\n" +
 	"\bJoinUnit\x12!.services.centrum.JoinUnitRequest\x1a\".services.centrum.JoinUnitResponse\"'\xd2\xf3\x18#\b\x01\x12\acentrum\x1a\x0eCentrumService\"\x06Stream\x12}\n" +
 	"\tListUnits\x12\".services.centrum.ListUnitsRequest\x1a#.services.centrum.ListUnitsResponse\"'\xd2\xf3\x18#\b\x01\x12\acentrum\x1a\x0eCentrumService\"\x06Stream\x12\x92\x01\n" +
 	"\x10ListUnitActivity\x12).services.centrum.ListUnitActivityRequest\x1a*.services.centrum.ListUnitActivityResponse\"'\xd2\xf3\x18#\b\x01\x12\acentrum\x1a\x0eCentrumService\"\x06Stream\x12w\n" +
 	"\x12CreateOrUpdateUnit\x12+.services.centrum.CreateOrUpdateUnitRequest\x1a,.services.centrum.CreateOrUpdateUnitResponse\"\x06\xd2\xf3\x18\x02\b\x01\x12_\n" +
 	"\n" +
-	"DeleteUnit\x12#.services.centrum.DeleteUnitRequest\x1a$.services.centrum.DeleteUnitResponse\"\x06\xd2\xf3\x18\x02\b\x01\x12\x85\x01\n" +
+	"DeleteUnit\x12#.services.centrum.DeleteUnitRequest\x1a$.services.centrum.DeleteUnitResponse\"\x06\xd2\xf3\x18\x02\b\x01\x12y\n" +
+	"\fReorderUnits\x12%.services.centrum.ReorderUnitsRequest\x1a&.services.centrum.ReorderUnitsResponse\"\x1a\xd2\xf3\x18\x16\b\x01\"\x12CreateOrUpdateUnit\x12\x85\x01\n" +
 	"\n" +
 	"AssignUnit\x12#.services.centrum.AssignUnitRequest\x1a$.services.centrum.AssignUnitResponse\",\xd2\xf3\x18(\b\x01\x12\acentrum\x1a\x0eCentrumService\"\vTakeControl\x12\x9b\x01\n" +
 	"\x10UpdateUnitStatus\x12).services.centrum.UpdateUnitStatusRequest\x1a*.services.centrum.UpdateUnitStatusResponse\"0\xd2\xf3\x18,\b\x01\x12\acentrum\x1a\x11DispatchesService\"\fTakeDispatch\x1a\x1b\xea\xf3\x18\x17\bn\x12\x13i-mdi-account-groupBLZJgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/services/centrum;centrumb\x06proto3"
 
-var file_services_centrum_units_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_services_centrum_units_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_services_centrum_units_proto_goTypes = []any{
 	(*JoinUnitRequest)(nil),             // 0: services.centrum.JoinUnitRequest
 	(*JoinUnitResponse)(nil),            // 1: services.centrum.JoinUnitResponse
 	(*ListUnitsRequest)(nil),            // 2: services.centrum.ListUnitsRequest
 	(*ListUnitsResponse)(nil),           // 3: services.centrum.ListUnitsResponse
-	(*CreateOrUpdateUnitRequest)(nil),   // 4: services.centrum.CreateOrUpdateUnitRequest
-	(*CreateOrUpdateUnitResponse)(nil),  // 5: services.centrum.CreateOrUpdateUnitResponse
-	(*DeleteUnitRequest)(nil),           // 6: services.centrum.DeleteUnitRequest
-	(*DeleteUnitResponse)(nil),          // 7: services.centrum.DeleteUnitResponse
-	(*UpdateUnitStatusRequest)(nil),     // 8: services.centrum.UpdateUnitStatusRequest
-	(*UpdateUnitStatusResponse)(nil),    // 9: services.centrum.UpdateUnitStatusResponse
-	(*AssignUnitRequest)(nil),           // 10: services.centrum.AssignUnitRequest
-	(*AssignUnitResponse)(nil),          // 11: services.centrum.AssignUnitResponse
-	(*ListUnitActivityRequest)(nil),     // 12: services.centrum.ListUnitActivityRequest
-	(*ListUnitActivityResponse)(nil),    // 13: services.centrum.ListUnitActivityResponse
-	(*units.Unit)(nil),                  // 14: resources.centrum.units.Unit
-	(units.StatusUnit)(0),               // 15: resources.centrum.units.StatusUnit
-	(*database.PaginationRequest)(nil),  // 16: resources.common.database.PaginationRequest
-	(*database.PaginationResponse)(nil), // 17: resources.common.database.PaginationResponse
-	(*units.UnitStatus)(nil),            // 18: resources.centrum.units.UnitStatus
+	(*ListUnitActivityRequest)(nil),     // 4: services.centrum.ListUnitActivityRequest
+	(*ListUnitActivityResponse)(nil),    // 5: services.centrum.ListUnitActivityResponse
+	(*CreateOrUpdateUnitRequest)(nil),   // 6: services.centrum.CreateOrUpdateUnitRequest
+	(*CreateOrUpdateUnitResponse)(nil),  // 7: services.centrum.CreateOrUpdateUnitResponse
+	(*DeleteUnitRequest)(nil),           // 8: services.centrum.DeleteUnitRequest
+	(*DeleteUnitResponse)(nil),          // 9: services.centrum.DeleteUnitResponse
+	(*ReorderUnitsRequest)(nil),         // 10: services.centrum.ReorderUnitsRequest
+	(*ReorderUnitsResponse)(nil),        // 11: services.centrum.ReorderUnitsResponse
+	(*AssignUnitRequest)(nil),           // 12: services.centrum.AssignUnitRequest
+	(*AssignUnitResponse)(nil),          // 13: services.centrum.AssignUnitResponse
+	(*UpdateUnitStatusRequest)(nil),     // 14: services.centrum.UpdateUnitStatusRequest
+	(*UpdateUnitStatusResponse)(nil),    // 15: services.centrum.UpdateUnitStatusResponse
+	(*units.Unit)(nil),                  // 16: resources.centrum.units.Unit
+	(units.StatusUnit)(0),               // 17: resources.centrum.units.StatusUnit
+	(*database.PaginationRequest)(nil),  // 18: resources.common.database.PaginationRequest
+	(*database.PaginationResponse)(nil), // 19: resources.common.database.PaginationResponse
+	(*units.UnitStatus)(nil),            // 20: resources.centrum.units.UnitStatus
 }
 var file_services_centrum_units_proto_depIdxs = []int32{
-	14, // 0: services.centrum.JoinUnitResponse.unit:type_name -> resources.centrum.units.Unit
-	15, // 1: services.centrum.ListUnitsRequest.status:type_name -> resources.centrum.units.StatusUnit
-	14, // 2: services.centrum.ListUnitsResponse.units:type_name -> resources.centrum.units.Unit
-	14, // 3: services.centrum.CreateOrUpdateUnitRequest.unit:type_name -> resources.centrum.units.Unit
-	14, // 4: services.centrum.CreateOrUpdateUnitResponse.unit:type_name -> resources.centrum.units.Unit
-	15, // 5: services.centrum.UpdateUnitStatusRequest.status:type_name -> resources.centrum.units.StatusUnit
-	16, // 6: services.centrum.ListUnitActivityRequest.pagination:type_name -> resources.common.database.PaginationRequest
-	17, // 7: services.centrum.ListUnitActivityResponse.pagination:type_name -> resources.common.database.PaginationResponse
-	18, // 8: services.centrum.ListUnitActivityResponse.activity:type_name -> resources.centrum.units.UnitStatus
+	16, // 0: services.centrum.JoinUnitResponse.unit:type_name -> resources.centrum.units.Unit
+	17, // 1: services.centrum.ListUnitsRequest.status:type_name -> resources.centrum.units.StatusUnit
+	16, // 2: services.centrum.ListUnitsResponse.units:type_name -> resources.centrum.units.Unit
+	18, // 3: services.centrum.ListUnitActivityRequest.pagination:type_name -> resources.common.database.PaginationRequest
+	19, // 4: services.centrum.ListUnitActivityResponse.pagination:type_name -> resources.common.database.PaginationResponse
+	20, // 5: services.centrum.ListUnitActivityResponse.activity:type_name -> resources.centrum.units.UnitStatus
+	16, // 6: services.centrum.CreateOrUpdateUnitRequest.unit:type_name -> resources.centrum.units.Unit
+	16, // 7: services.centrum.CreateOrUpdateUnitResponse.unit:type_name -> resources.centrum.units.Unit
+	17, // 8: services.centrum.UpdateUnitStatusRequest.status:type_name -> resources.centrum.units.StatusUnit
 	0,  // 9: services.centrum.UnitsService.JoinUnit:input_type -> services.centrum.JoinUnitRequest
 	2,  // 10: services.centrum.UnitsService.ListUnits:input_type -> services.centrum.ListUnitsRequest
-	12, // 11: services.centrum.UnitsService.ListUnitActivity:input_type -> services.centrum.ListUnitActivityRequest
-	4,  // 12: services.centrum.UnitsService.CreateOrUpdateUnit:input_type -> services.centrum.CreateOrUpdateUnitRequest
-	6,  // 13: services.centrum.UnitsService.DeleteUnit:input_type -> services.centrum.DeleteUnitRequest
-	10, // 14: services.centrum.UnitsService.AssignUnit:input_type -> services.centrum.AssignUnitRequest
-	8,  // 15: services.centrum.UnitsService.UpdateUnitStatus:input_type -> services.centrum.UpdateUnitStatusRequest
-	1,  // 16: services.centrum.UnitsService.JoinUnit:output_type -> services.centrum.JoinUnitResponse
-	3,  // 17: services.centrum.UnitsService.ListUnits:output_type -> services.centrum.ListUnitsResponse
-	13, // 18: services.centrum.UnitsService.ListUnitActivity:output_type -> services.centrum.ListUnitActivityResponse
-	5,  // 19: services.centrum.UnitsService.CreateOrUpdateUnit:output_type -> services.centrum.CreateOrUpdateUnitResponse
-	7,  // 20: services.centrum.UnitsService.DeleteUnit:output_type -> services.centrum.DeleteUnitResponse
-	11, // 21: services.centrum.UnitsService.AssignUnit:output_type -> services.centrum.AssignUnitResponse
-	9,  // 22: services.centrum.UnitsService.UpdateUnitStatus:output_type -> services.centrum.UpdateUnitStatusResponse
-	16, // [16:23] is the sub-list for method output_type
-	9,  // [9:16] is the sub-list for method input_type
+	4,  // 11: services.centrum.UnitsService.ListUnitActivity:input_type -> services.centrum.ListUnitActivityRequest
+	6,  // 12: services.centrum.UnitsService.CreateOrUpdateUnit:input_type -> services.centrum.CreateOrUpdateUnitRequest
+	8,  // 13: services.centrum.UnitsService.DeleteUnit:input_type -> services.centrum.DeleteUnitRequest
+	10, // 14: services.centrum.UnitsService.ReorderUnits:input_type -> services.centrum.ReorderUnitsRequest
+	12, // 15: services.centrum.UnitsService.AssignUnit:input_type -> services.centrum.AssignUnitRequest
+	14, // 16: services.centrum.UnitsService.UpdateUnitStatus:input_type -> services.centrum.UpdateUnitStatusRequest
+	1,  // 17: services.centrum.UnitsService.JoinUnit:output_type -> services.centrum.JoinUnitResponse
+	3,  // 18: services.centrum.UnitsService.ListUnits:output_type -> services.centrum.ListUnitsResponse
+	5,  // 19: services.centrum.UnitsService.ListUnitActivity:output_type -> services.centrum.ListUnitActivityResponse
+	7,  // 20: services.centrum.UnitsService.CreateOrUpdateUnit:output_type -> services.centrum.CreateOrUpdateUnitResponse
+	9,  // 21: services.centrum.UnitsService.DeleteUnit:output_type -> services.centrum.DeleteUnitResponse
+	11, // 22: services.centrum.UnitsService.ReorderUnits:output_type -> services.centrum.ReorderUnitsResponse
+	13, // 23: services.centrum.UnitsService.AssignUnit:output_type -> services.centrum.AssignUnitResponse
+	15, // 24: services.centrum.UnitsService.UpdateUnitStatus:output_type -> services.centrum.UpdateUnitStatusResponse
+	17, // [17:25] is the sub-list for method output_type
+	9,  // [9:17] is the sub-list for method input_type
 	9,  // [9:9] is the sub-list for extension type_name
 	9,  // [9:9] is the sub-list for extension extendee
 	0,  // [0:9] is the sub-list for field type_name
@@ -1113,14 +1221,14 @@ func file_services_centrum_units_proto_init() {
 		return
 	}
 	file_services_centrum_units_proto_msgTypes[0].OneofWrappers = []any{}
-	file_services_centrum_units_proto_msgTypes[8].OneofWrappers = []any{}
+	file_services_centrum_units_proto_msgTypes[14].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_services_centrum_units_proto_rawDesc), len(file_services_centrum_units_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   14,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/gen/grpc-api.md
+++ b/gen/grpc-api.md
@@ -2095,6 +2095,7 @@ Dummy - DO NOT USE!
 | `updated_at` | [resources.timestamp.Timestamp](#resourcestimestampTimestamp) | optional |  |
 | `job` | [string](#string) |  |  |
 | `job_label` | [string](#string) | optional |  |
+| `sort_order` | [int32](#int32) |  |  |
 | `name` | [string](#string) |  |  |
 | `initials` | [string](#string) |  |  |
 | `color` | [string](#string) |  |  |
@@ -8651,6 +8652,23 @@ Auth Service handles user authentication, character selection and oauth2 connect
 
 
 
+### services.centrum.ReorderUnitsRequest
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `unit_ids` | [int64](#int64) | repeated |  |
+
+
+
+
+
+### services.centrum.ReorderUnitsResponse
+
+
+
+
+
 ### services.centrum.UpdateUnitStatusRequest
 
 
@@ -8686,6 +8704,7 @@ Auth Service handles user authentication, character selection and oauth2 connect
 | `ListUnitActivity` | [ListUnitActivityRequest](#servicescentrumListUnitActivityRequest) | [ListUnitActivityResponse](#servicescentrumListUnitActivityResponse) | |
 | `CreateOrUpdateUnit` | [CreateOrUpdateUnitRequest](#servicescentrumCreateOrUpdateUnitRequest) | [CreateOrUpdateUnitResponse](#servicescentrumCreateOrUpdateUnitResponse) | |
 | `DeleteUnit` | [DeleteUnitRequest](#servicescentrumDeleteUnitRequest) | [DeleteUnitResponse](#servicescentrumDeleteUnitResponse) | |
+| `ReorderUnits` | [ReorderUnitsRequest](#servicescentrumReorderUnitsRequest) | [ReorderUnitsResponse](#servicescentrumReorderUnitsResponse) | |
 | `AssignUnit` | [AssignUnitRequest](#servicescentrumAssignUnitRequest) | [AssignUnitResponse](#servicescentrumAssignUnitResponse) | |
 | `UpdateUnitStatus` | [UpdateUnitStatusRequest](#servicescentrumUpdateUnitStatusRequest) | [UpdateUnitStatusResponse](#servicescentrumUpdateUnitStatusResponse) | |
 

--- a/gen/ts/resources/centrum/units/units.ts
+++ b/gen/ts/resources/centrum/units/units.ts
@@ -39,6 +39,10 @@ export interface Unit {
      */
     jobLabel?: string;
     /**
+     * @generated from protobuf field: int32 sort_order = 17
+     */
+    sortOrder: number;
+    /**
      * @generated from protobuf field: string name = 5
      */
     name: string;
@@ -250,6 +254,7 @@ class Unit$Type extends MessageType<Unit> {
             { no: 3, name: "updated_at", kind: "message", T: () => Timestamp },
             { no: 4, name: "job", kind: "scalar", T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { maxLen: "20" } } } },
             { no: 15, name: "job_label", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { maxLen: "50" } } } },
+            { no: 17, name: "sort_order", kind: "scalar", T: 5 /*ScalarType.INT32*/, options: { "buf.validate.field": { int32: { gte: 0 } }, "tagger.tags": "alias:\"sort_order\"" } },
             { no: 5, name: "name", kind: "scalar", T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { minLen: "3", maxLen: "24" } }, "codegen.sanitizer.sanitizer": { enabled: true } } },
             { no: 6, name: "initials", kind: "scalar", T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { minLen: "2", maxLen: "4" } }, "codegen.sanitizer.sanitizer": { enabled: true } } },
             { no: 7, name: "color", kind: "scalar", T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { len: "7", pattern: "^#[A-Fa-f0-9]{6}$" } }, "codegen.sanitizer.sanitizer": { enabled: true, stripHtmlTags: true } } },
@@ -266,6 +271,7 @@ class Unit$Type extends MessageType<Unit> {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.id = 0;
         message.job = "";
+        message.sortOrder = 0;
         message.name = "";
         message.initials = "";
         message.color = "";
@@ -293,6 +299,9 @@ class Unit$Type extends MessageType<Unit> {
                     break;
                 case /* optional string job_label */ 15:
                     message.jobLabel = reader.string();
+                    break;
+                case /* int32 sort_order */ 17:
+                    message.sortOrder = reader.int32();
                     break;
                 case /* string name */ 5:
                     message.name = reader.string();
@@ -381,6 +390,9 @@ class Unit$Type extends MessageType<Unit> {
         /* optional string icon = 16; */
         if (message.icon !== undefined)
             writer.tag(16, WireType.LengthDelimited).string(message.icon);
+        /* int32 sort_order = 17; */
+        if (message.sortOrder !== 0)
+            writer.tag(17, WireType.Varint).int32(message.sortOrder);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/ts/services/centrum/units.client.ts
+++ b/gen/ts/services/centrum/units.client.ts
@@ -9,6 +9,8 @@ import type { UpdateUnitStatusResponse } from "./units";
 import type { UpdateUnitStatusRequest } from "./units";
 import type { AssignUnitResponse } from "./units";
 import type { AssignUnitRequest } from "./units";
+import type { ReorderUnitsResponse } from "./units";
+import type { ReorderUnitsRequest } from "./units";
 import type { DeleteUnitResponse } from "./units";
 import type { DeleteUnitRequest } from "./units";
 import type { CreateOrUpdateUnitResponse } from "./units";
@@ -46,6 +48,10 @@ export interface IUnitsServiceClient {
      * @generated from protobuf rpc: DeleteUnit
      */
     deleteUnit(input: DeleteUnitRequest, options?: RpcOptions): UnaryCall<DeleteUnitRequest, DeleteUnitResponse>;
+    /**
+     * @generated from protobuf rpc: ReorderUnits
+     */
+    reorderUnits(input: ReorderUnitsRequest, options?: RpcOptions): UnaryCall<ReorderUnitsRequest, ReorderUnitsResponse>;
     /**
      * @generated from protobuf rpc: AssignUnit
      */
@@ -100,17 +106,24 @@ export class UnitsServiceClient implements IUnitsServiceClient, ServiceInfo {
         return stackIntercept<DeleteUnitRequest, DeleteUnitResponse>("unary", this._transport, method, opt, input);
     }
     /**
+     * @generated from protobuf rpc: ReorderUnits
+     */
+    reorderUnits(input: ReorderUnitsRequest, options?: RpcOptions): UnaryCall<ReorderUnitsRequest, ReorderUnitsResponse> {
+        const method = this.methods[5], opt = this._transport.mergeOptions(options);
+        return stackIntercept<ReorderUnitsRequest, ReorderUnitsResponse>("unary", this._transport, method, opt, input);
+    }
+    /**
      * @generated from protobuf rpc: AssignUnit
      */
     assignUnit(input: AssignUnitRequest, options?: RpcOptions): UnaryCall<AssignUnitRequest, AssignUnitResponse> {
-        const method = this.methods[5], opt = this._transport.mergeOptions(options);
+        const method = this.methods[6], opt = this._transport.mergeOptions(options);
         return stackIntercept<AssignUnitRequest, AssignUnitResponse>("unary", this._transport, method, opt, input);
     }
     /**
      * @generated from protobuf rpc: UpdateUnitStatus
      */
     updateUnitStatus(input: UpdateUnitStatusRequest, options?: RpcOptions): UnaryCall<UpdateUnitStatusRequest, UpdateUnitStatusResponse> {
-        const method = this.methods[6], opt = this._transport.mergeOptions(options);
+        const method = this.methods[7], opt = this._transport.mergeOptions(options);
         return stackIntercept<UpdateUnitStatusRequest, UpdateUnitStatusResponse>("unary", this._transport, method, opt, input);
     }
 }

--- a/gen/ts/services/centrum/units.ts
+++ b/gen/ts/services/centrum/units.ts
@@ -54,6 +54,32 @@ export interface ListUnitsResponse {
     units: Unit[];
 }
 /**
+ * @generated from protobuf message services.centrum.ListUnitActivityRequest
+ */
+export interface ListUnitActivityRequest {
+    /**
+     * @generated from protobuf field: resources.common.database.PaginationRequest pagination = 1
+     */
+    pagination?: PaginationRequest;
+    /**
+     * @generated from protobuf field: int64 id = 2
+     */
+    id: number;
+}
+/**
+ * @generated from protobuf message services.centrum.ListUnitActivityResponse
+ */
+export interface ListUnitActivityResponse {
+    /**
+     * @generated from protobuf field: resources.common.database.PaginationResponse pagination = 1
+     */
+    pagination?: PaginationResponse;
+    /**
+     * @generated from protobuf field: repeated resources.centrum.units.UnitStatus activity = 2
+     */
+    activity: UnitStatus[];
+}
+/**
  * @generated from protobuf message services.centrum.CreateOrUpdateUnitRequest
  */
 export interface CreateOrUpdateUnitRequest {
@@ -86,30 +112,18 @@ export interface DeleteUnitRequest {
 export interface DeleteUnitResponse {
 }
 /**
- * @generated from protobuf message services.centrum.UpdateUnitStatusRequest
+ * @generated from protobuf message services.centrum.ReorderUnitsRequest
  */
-export interface UpdateUnitStatusRequest {
+export interface ReorderUnitsRequest {
     /**
-     * @generated from protobuf field: int64 unit_id = 1
+     * @generated from protobuf field: repeated int64 unit_ids = 1
      */
-    unitId: number;
-    /**
-     * @generated from protobuf field: resources.centrum.units.StatusUnit status = 2
-     */
-    status: StatusUnit;
-    /**
-     * @generated from protobuf field: optional string reason = 3
-     */
-    reason?: string;
-    /**
-     * @generated from protobuf field: optional string code = 4
-     */
-    code?: string;
+    unitIds: number[];
 }
 /**
- * @generated from protobuf message services.centrum.UpdateUnitStatusResponse
+ * @generated from protobuf message services.centrum.ReorderUnitsResponse
  */
-export interface UpdateUnitStatusResponse {
+export interface ReorderUnitsResponse {
 }
 /**
  * @generated from protobuf message services.centrum.AssignUnitRequest
@@ -134,30 +148,30 @@ export interface AssignUnitRequest {
 export interface AssignUnitResponse {
 }
 /**
- * @generated from protobuf message services.centrum.ListUnitActivityRequest
+ * @generated from protobuf message services.centrum.UpdateUnitStatusRequest
  */
-export interface ListUnitActivityRequest {
+export interface UpdateUnitStatusRequest {
     /**
-     * @generated from protobuf field: resources.common.database.PaginationRequest pagination = 1
+     * @generated from protobuf field: int64 unit_id = 1
      */
-    pagination?: PaginationRequest;
+    unitId: number;
     /**
-     * @generated from protobuf field: int64 id = 2
+     * @generated from protobuf field: resources.centrum.units.StatusUnit status = 2
      */
-    id: number;
+    status: StatusUnit;
+    /**
+     * @generated from protobuf field: optional string reason = 3
+     */
+    reason?: string;
+    /**
+     * @generated from protobuf field: optional string code = 4
+     */
+    code?: string;
 }
 /**
- * @generated from protobuf message services.centrum.ListUnitActivityResponse
+ * @generated from protobuf message services.centrum.UpdateUnitStatusResponse
  */
-export interface ListUnitActivityResponse {
-    /**
-     * @generated from protobuf field: resources.common.database.PaginationResponse pagination = 1
-     */
-    pagination?: PaginationResponse;
-    /**
-     * @generated from protobuf field: repeated resources.centrum.units.UnitStatus activity = 2
-     */
-    activity: UnitStatus[];
+export interface UpdateUnitStatusResponse {
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class JoinUnitRequest$Type extends MessageType<JoinUnitRequest> {
@@ -354,6 +368,114 @@ class ListUnitsResponse$Type extends MessageType<ListUnitsResponse> {
  */
 export const ListUnitsResponse = new ListUnitsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
+class ListUnitActivityRequest$Type extends MessageType<ListUnitActivityRequest> {
+    constructor() {
+        super("services.centrum.ListUnitActivityRequest", [
+            { no: 1, name: "pagination", kind: "message", T: () => PaginationRequest, options: { "buf.validate.field": { required: true } } },
+            { no: 2, name: "id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ }
+        ]);
+    }
+    create(value?: PartialMessage<ListUnitActivityRequest>): ListUnitActivityRequest {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.id = 0;
+        if (value !== undefined)
+            reflectionMergePartial<ListUnitActivityRequest>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ListUnitActivityRequest): ListUnitActivityRequest {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* resources.common.database.PaginationRequest pagination */ 1:
+                    message.pagination = PaginationRequest.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
+                    break;
+                case /* int64 id */ 2:
+                    message.id = reader.int64().toNumber();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ListUnitActivityRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* resources.common.database.PaginationRequest pagination = 1; */
+        if (message.pagination)
+            PaginationRequest.internalBinaryWrite(message.pagination, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* int64 id = 2; */
+        if (message.id !== 0)
+            writer.tag(2, WireType.Varint).int64(message.id);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message services.centrum.ListUnitActivityRequest
+ */
+export const ListUnitActivityRequest = new ListUnitActivityRequest$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class ListUnitActivityResponse$Type extends MessageType<ListUnitActivityResponse> {
+    constructor() {
+        super("services.centrum.ListUnitActivityResponse", [
+            { no: 1, name: "pagination", kind: "message", T: () => PaginationResponse, options: { "buf.validate.field": { required: true } } },
+            { no: 2, name: "activity", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UnitStatus, options: { "codegen.itemslen.enabled": true } }
+        ]);
+    }
+    create(value?: PartialMessage<ListUnitActivityResponse>): ListUnitActivityResponse {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.activity = [];
+        if (value !== undefined)
+            reflectionMergePartial<ListUnitActivityResponse>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ListUnitActivityResponse): ListUnitActivityResponse {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* resources.common.database.PaginationResponse pagination */ 1:
+                    message.pagination = PaginationResponse.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
+                    break;
+                case /* repeated resources.centrum.units.UnitStatus activity */ 2:
+                    message.activity.push(UnitStatus.internalBinaryRead(reader, reader.uint32(), options));
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: ListUnitActivityResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* resources.common.database.PaginationResponse pagination = 1; */
+        if (message.pagination)
+            PaginationResponse.internalBinaryWrite(message.pagination, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
+        /* repeated resources.centrum.units.UnitStatus activity = 2; */
+        for (let i = 0; i < message.activity.length; i++)
+            UnitStatus.internalBinaryWrite(message.activity[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message services.centrum.ListUnitActivityResponse
+ */
+export const ListUnitActivityResponse = new ListUnitActivityResponse$Type();
+// @generated message type with reflection information, may provide speed optimized methods
 class CreateOrUpdateUnitRequest$Type extends MessageType<CreateOrUpdateUnitRequest> {
     constructor() {
         super("services.centrum.CreateOrUpdateUnitRequest", [
@@ -531,39 +653,30 @@ class DeleteUnitResponse$Type extends MessageType<DeleteUnitResponse> {
  */
 export const DeleteUnitResponse = new DeleteUnitResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class UpdateUnitStatusRequest$Type extends MessageType<UpdateUnitStatusRequest> {
+class ReorderUnitsRequest$Type extends MessageType<ReorderUnitsRequest> {
     constructor() {
-        super("services.centrum.UpdateUnitStatusRequest", [
-            { no: 1, name: "unit_id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
-            { no: 2, name: "status", kind: "enum", T: () => ["resources.centrum.units.StatusUnit", StatusUnit, "STATUS_UNIT_"], options: { "buf.validate.field": { enum: { definedOnly: true } } } },
-            { no: 3, name: "reason", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { maxLen: "255" } }, "codegen.sanitizer.sanitizer": { enabled: true } } },
-            { no: 4, name: "code", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { maxLen: "20" } }, "codegen.sanitizer.sanitizer": { enabled: true } } }
+        super("services.centrum.ReorderUnitsRequest", [
+            { no: 1, name: "unit_ids", kind: "scalar", repeat: 1 /*RepeatType.PACKED*/, T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/, options: { "buf.validate.field": { repeated: { minItems: "1", maxItems: "250", items: { int64: { gt: "0" } } } } } }
         ]);
     }
-    create(value?: PartialMessage<UpdateUnitStatusRequest>): UpdateUnitStatusRequest {
+    create(value?: PartialMessage<ReorderUnitsRequest>): ReorderUnitsRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.unitId = 0;
-        message.status = 0;
+        message.unitIds = [];
         if (value !== undefined)
-            reflectionMergePartial<UpdateUnitStatusRequest>(this, message, value);
+            reflectionMergePartial<ReorderUnitsRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateUnitStatusRequest): UpdateUnitStatusRequest {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ReorderUnitsRequest): ReorderUnitsRequest {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* int64 unit_id */ 1:
-                    message.unitId = reader.int64().toNumber();
-                    break;
-                case /* resources.centrum.units.StatusUnit status */ 2:
-                    message.status = reader.int32();
-                    break;
-                case /* optional string reason */ 3:
-                    message.reason = reader.string();
-                    break;
-                case /* optional string code */ 4:
-                    message.code = reader.string();
+                case /* repeated int64 unit_ids */ 1:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.unitIds.push(reader.int64().toNumber());
+                    else
+                        message.unitIds.push(reader.int64().toNumber());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -576,19 +689,14 @@ class UpdateUnitStatusRequest$Type extends MessageType<UpdateUnitStatusRequest> 
         }
         return message;
     }
-    internalBinaryWrite(message: UpdateUnitStatusRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* int64 unit_id = 1; */
-        if (message.unitId !== 0)
-            writer.tag(1, WireType.Varint).int64(message.unitId);
-        /* resources.centrum.units.StatusUnit status = 2; */
-        if (message.status !== 0)
-            writer.tag(2, WireType.Varint).int32(message.status);
-        /* optional string reason = 3; */
-        if (message.reason !== undefined)
-            writer.tag(3, WireType.LengthDelimited).string(message.reason);
-        /* optional string code = 4; */
-        if (message.code !== undefined)
-            writer.tag(4, WireType.LengthDelimited).string(message.code);
+    internalBinaryWrite(message: ReorderUnitsRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated int64 unit_ids = 1; */
+        if (message.unitIds.length) {
+            writer.tag(1, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.unitIds.length; i++)
+                writer.int64(message.unitIds[i]);
+            writer.join();
+        }
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -596,21 +704,21 @@ class UpdateUnitStatusRequest$Type extends MessageType<UpdateUnitStatusRequest> 
     }
 }
 /**
- * @generated MessageType for protobuf message services.centrum.UpdateUnitStatusRequest
+ * @generated MessageType for protobuf message services.centrum.ReorderUnitsRequest
  */
-export const UpdateUnitStatusRequest = new UpdateUnitStatusRequest$Type();
+export const ReorderUnitsRequest = new ReorderUnitsRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class UpdateUnitStatusResponse$Type extends MessageType<UpdateUnitStatusResponse> {
+class ReorderUnitsResponse$Type extends MessageType<ReorderUnitsResponse> {
     constructor() {
-        super("services.centrum.UpdateUnitStatusResponse", []);
+        super("services.centrum.ReorderUnitsResponse", []);
     }
-    create(value?: PartialMessage<UpdateUnitStatusResponse>): UpdateUnitStatusResponse {
+    create(value?: PartialMessage<ReorderUnitsResponse>): ReorderUnitsResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
         if (value !== undefined)
-            reflectionMergePartial<UpdateUnitStatusResponse>(this, message, value);
+            reflectionMergePartial<ReorderUnitsResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateUnitStatusResponse): UpdateUnitStatusResponse {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ReorderUnitsResponse): ReorderUnitsResponse {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
@@ -626,7 +734,7 @@ class UpdateUnitStatusResponse$Type extends MessageType<UpdateUnitStatusResponse
         }
         return message;
     }
-    internalBinaryWrite(message: UpdateUnitStatusResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+    internalBinaryWrite(message: ReorderUnitsResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -634,9 +742,9 @@ class UpdateUnitStatusResponse$Type extends MessageType<UpdateUnitStatusResponse
     }
 }
 /**
- * @generated MessageType for protobuf message services.centrum.UpdateUnitStatusResponse
+ * @generated MessageType for protobuf message services.centrum.ReorderUnitsResponse
  */
-export const UpdateUnitStatusResponse = new UpdateUnitStatusResponse$Type();
+export const ReorderUnitsResponse = new ReorderUnitsResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class AssignUnitRequest$Type extends MessageType<AssignUnitRequest> {
     constructor() {
@@ -755,30 +863,39 @@ class AssignUnitResponse$Type extends MessageType<AssignUnitResponse> {
  */
 export const AssignUnitResponse = new AssignUnitResponse$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ListUnitActivityRequest$Type extends MessageType<ListUnitActivityRequest> {
+class UpdateUnitStatusRequest$Type extends MessageType<UpdateUnitStatusRequest> {
     constructor() {
-        super("services.centrum.ListUnitActivityRequest", [
-            { no: 1, name: "pagination", kind: "message", T: () => PaginationRequest, options: { "buf.validate.field": { required: true } } },
-            { no: 2, name: "id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ }
+        super("services.centrum.UpdateUnitStatusRequest", [
+            { no: 1, name: "unit_id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "status", kind: "enum", T: () => ["resources.centrum.units.StatusUnit", StatusUnit, "STATUS_UNIT_"], options: { "buf.validate.field": { enum: { definedOnly: true } } } },
+            { no: 3, name: "reason", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { maxLen: "255" } }, "codegen.sanitizer.sanitizer": { enabled: true } } },
+            { no: 4, name: "code", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { string: { maxLen: "20" } }, "codegen.sanitizer.sanitizer": { enabled: true } } }
         ]);
     }
-    create(value?: PartialMessage<ListUnitActivityRequest>): ListUnitActivityRequest {
+    create(value?: PartialMessage<UpdateUnitStatusRequest>): UpdateUnitStatusRequest {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.id = 0;
+        message.unitId = 0;
+        message.status = 0;
         if (value !== undefined)
-            reflectionMergePartial<ListUnitActivityRequest>(this, message, value);
+            reflectionMergePartial<UpdateUnitStatusRequest>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ListUnitActivityRequest): ListUnitActivityRequest {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateUnitStatusRequest): UpdateUnitStatusRequest {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* resources.common.database.PaginationRequest pagination */ 1:
-                    message.pagination = PaginationRequest.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
+                case /* int64 unit_id */ 1:
+                    message.unitId = reader.int64().toNumber();
                     break;
-                case /* int64 id */ 2:
-                    message.id = reader.int64().toNumber();
+                case /* resources.centrum.units.StatusUnit status */ 2:
+                    message.status = reader.int32();
+                    break;
+                case /* optional string reason */ 3:
+                    message.reason = reader.string();
+                    break;
+                case /* optional string code */ 4:
+                    message.code = reader.string();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -791,13 +908,19 @@ class ListUnitActivityRequest$Type extends MessageType<ListUnitActivityRequest> 
         }
         return message;
     }
-    internalBinaryWrite(message: ListUnitActivityRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* resources.common.database.PaginationRequest pagination = 1; */
-        if (message.pagination)
-            PaginationRequest.internalBinaryWrite(message.pagination, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
-        /* int64 id = 2; */
-        if (message.id !== 0)
-            writer.tag(2, WireType.Varint).int64(message.id);
+    internalBinaryWrite(message: UpdateUnitStatusRequest, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* int64 unit_id = 1; */
+        if (message.unitId !== 0)
+            writer.tag(1, WireType.Varint).int64(message.unitId);
+        /* resources.centrum.units.StatusUnit status = 2; */
+        if (message.status !== 0)
+            writer.tag(2, WireType.Varint).int32(message.status);
+        /* optional string reason = 3; */
+        if (message.reason !== undefined)
+            writer.tag(3, WireType.LengthDelimited).string(message.reason);
+        /* optional string code = 4; */
+        if (message.code !== undefined)
+            writer.tag(4, WireType.LengthDelimited).string(message.code);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -805,35 +928,25 @@ class ListUnitActivityRequest$Type extends MessageType<ListUnitActivityRequest> 
     }
 }
 /**
- * @generated MessageType for protobuf message services.centrum.ListUnitActivityRequest
+ * @generated MessageType for protobuf message services.centrum.UpdateUnitStatusRequest
  */
-export const ListUnitActivityRequest = new ListUnitActivityRequest$Type();
+export const UpdateUnitStatusRequest = new UpdateUnitStatusRequest$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class ListUnitActivityResponse$Type extends MessageType<ListUnitActivityResponse> {
+class UpdateUnitStatusResponse$Type extends MessageType<UpdateUnitStatusResponse> {
     constructor() {
-        super("services.centrum.ListUnitActivityResponse", [
-            { no: 1, name: "pagination", kind: "message", T: () => PaginationResponse, options: { "buf.validate.field": { required: true } } },
-            { no: 2, name: "activity", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UnitStatus, options: { "codegen.itemslen.enabled": true } }
-        ]);
+        super("services.centrum.UpdateUnitStatusResponse", []);
     }
-    create(value?: PartialMessage<ListUnitActivityResponse>): ListUnitActivityResponse {
+    create(value?: PartialMessage<UpdateUnitStatusResponse>): UpdateUnitStatusResponse {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.activity = [];
         if (value !== undefined)
-            reflectionMergePartial<ListUnitActivityResponse>(this, message, value);
+            reflectionMergePartial<UpdateUnitStatusResponse>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: ListUnitActivityResponse): ListUnitActivityResponse {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UpdateUnitStatusResponse): UpdateUnitStatusResponse {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* resources.common.database.PaginationResponse pagination */ 1:
-                    message.pagination = PaginationResponse.internalBinaryRead(reader, reader.uint32(), options, message.pagination);
-                    break;
-                case /* repeated resources.centrum.units.UnitStatus activity */ 2:
-                    message.activity.push(UnitStatus.internalBinaryRead(reader, reader.uint32(), options));
-                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -845,13 +958,7 @@ class ListUnitActivityResponse$Type extends MessageType<ListUnitActivityResponse
         }
         return message;
     }
-    internalBinaryWrite(message: ListUnitActivityResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* resources.common.database.PaginationResponse pagination = 1; */
-        if (message.pagination)
-            PaginationResponse.internalBinaryWrite(message.pagination, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
-        /* repeated resources.centrum.units.UnitStatus activity = 2; */
-        for (let i = 0; i < message.activity.length; i++)
-            UnitStatus.internalBinaryWrite(message.activity[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+    internalBinaryWrite(message: UpdateUnitStatusResponse, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -859,9 +966,9 @@ class ListUnitActivityResponse$Type extends MessageType<ListUnitActivityResponse
     }
 }
 /**
- * @generated MessageType for protobuf message services.centrum.ListUnitActivityResponse
+ * @generated MessageType for protobuf message services.centrum.UpdateUnitStatusResponse
  */
-export const ListUnitActivityResponse = new ListUnitActivityResponse$Type();
+export const UpdateUnitStatusResponse = new UpdateUnitStatusResponse$Type();
 /**
  * @generated ServiceType for protobuf service services.centrum.UnitsService
  */
@@ -871,6 +978,7 @@ export const UnitsService = new ServiceType("services.centrum.UnitsService", [
     { name: "ListUnitActivity", options: { "codegen.perms.perms": { enabled: true, namespace: "centrum", service: "CentrumService", name: "Stream" } }, I: ListUnitActivityRequest, O: ListUnitActivityResponse },
     { name: "CreateOrUpdateUnit", options: { "codegen.perms.perms": { enabled: true } }, I: CreateOrUpdateUnitRequest, O: CreateOrUpdateUnitResponse },
     { name: "DeleteUnit", options: { "codegen.perms.perms": { enabled: true } }, I: DeleteUnitRequest, O: DeleteUnitResponse },
+    { name: "ReorderUnits", options: { "codegen.perms.perms": { enabled: true, name: "CreateOrUpdateUnit" } }, I: ReorderUnitsRequest, O: ReorderUnitsResponse },
     { name: "AssignUnit", options: { "codegen.perms.perms": { enabled: true, namespace: "centrum", service: "CentrumService", name: "TakeControl" } }, I: AssignUnitRequest, O: AssignUnitResponse },
     { name: "UpdateUnitStatus", options: { "codegen.perms.perms": { enabled: true, namespace: "centrum", service: "DispatchesService", name: "TakeDispatch" } }, I: UpdateUnitStatusRequest, O: UpdateUnitStatusResponse }
 ], { "codegen.perms.perms_svc": { order: 110, icon: "i-mdi-account-group" } });

--- a/gen/ts/svcs.ts
+++ b/gen/ts/svcs.ts
@@ -278,6 +278,7 @@ export const grpcMethods = [
 	'centrum.UnitsService/ListUnitActivity',
 	'centrum.UnitsService/CreateOrUpdateUnit',
 	'centrum.UnitsService/DeleteUnit',
+	'centrum.UnitsService/ReorderUnits',
 	'centrum.UnitsService/AssignUnit',
 	'centrum.UnitsService/UpdateUnitStatus',
 	'citizens.CitizensService/ListCitizens',

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1721,7 +1721,7 @@
                 },
                 "display": {
                     "title": "Anzeige",
-                    "description": "Anzeigeeinstellungen, wie Sprache und Waehrung.",
+                    "description": "Anzeigeeinstellungen, wie Sprache und Währung.",
                     "intl_locale": "Internationale Lokalisierung"
                 },
                 "game": {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -246,6 +246,7 @@ export default defineNuxtConfig({
                 '@vue-leaflet/vue-leaflet',
                 '@vue/devtools-core',
                 '@vue/devtools-kit',
+                '@vueuse/integrations/useSortable',
                 '@zxcvbn-ts/core',
                 'browser-headers', // CJS
                 'css-blank-pseudo/browser',
@@ -263,7 +264,7 @@ export default defineNuxtConfig({
                 'maska/vue',
                 'mdi-vue3',
                 'mitt',
-                'pica', // CJS
+                'pica',
                 'splitpanes',
                 'uuid',
                 'v-calendar',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 2.0.0(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.2)(srvx@0.11.15)
       '@nuxt/ui':
         specifier: 4.8.0
-        version: 4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@nuxt/content@3.14.0(better-sqlite3@12.10.0)(magicast@0.5.2))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)
+        version: 4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@nuxt/content@3.14.0(better-sqlite3@12.10.0)(magicast@0.5.2))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sortablejs@1.15.7)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)
       '@nuxtjs/robots':
         specifier: 6.0.8
         version: 6.0.8(@nuxt/schema@4.4.6)(magicast@0.5.2)(nuxt@4.4.6(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0))(@parcel/watcher@2.5.6)(@types/node@25.9.1)(@vue/compiler-sfc@3.5.34)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.4.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.32.0)(magicast@0.5.2)(meow@14.1.0)(optionator@0.9.4)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(rollup-plugin-visualizer@7.0.1(rollup@4.60.2))(rollup@4.60.2)(sass@1.100.0)(srvx@0.11.15)(stylelint@17.9.0(typescript@6.0.3))(terser@5.46.1)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.9.0))(vue-tsc@3.3.1(typescript@6.0.3))(yaml@2.9.0))(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.9.0))(vue@3.5.34(typescript@6.0.3))(zod@4.4.3)
@@ -9003,6 +9003,9 @@ packages:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
 
+  sortablejs@1.15.7:
+    resolution: {integrity: sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -12261,7 +12264,7 @@ snapshots:
       - typescript
       - vite
 
-  '@nuxt/ui@4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@nuxt/content@3.14.0(better-sqlite3@12.10.0)(magicast@0.5.2))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)':
+  '@nuxt/ui@4.8.0(@internationalized/date@3.12.1)(@internationalized/number@3.6.5)(@nuxt/content@3.14.0(better-sqlite3@12.10.0)(magicast@0.5.2))(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/y-tiptap@3.0.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(change-case@5.4.4)(db0@0.3.4(better-sqlite3@12.10.0))(embla-carousel@8.6.0)(ioredis@5.10.1)(magicast@0.5.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(sortablejs@1.15.7)(tailwindcss@4.3.0)(typescript@6.0.3)(vite@7.3.3(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass@1.100.0)(terser@5.46.1)(yaml@2.9.0))(vue-router@5.0.7(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3)))(vue@3.5.34(typescript@6.0.3))(yjs@13.6.30)(zod@4.4.3)':
     dependencies:
       '@floating-ui/dom': 1.7.6
       '@iconify/vue': 5.0.1(vue@3.5.34(typescript@6.0.3))
@@ -12294,7 +12297,7 @@ snapshots:
       '@tiptap/vue-3': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(vue@3.5.34(typescript@6.0.3))
       '@unhead/vue': 2.1.15(vue@3.5.34(typescript@6.0.3))
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
-      '@vueuse/integrations': 14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(vue@3.5.34(typescript@6.0.3))
+      '@vueuse/integrations': 14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(sortablejs@1.15.7)(vue@3.5.34(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@6.0.3))
       colortranslator: 5.0.0
       consola: 3.4.2
@@ -14699,7 +14702,7 @@ snapshots:
       '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@6.0.3))
       vue: 3.5.34(typescript@6.0.3)
 
-  '@vueuse/integrations@14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(vue@3.5.34(typescript@6.0.3))':
+  '@vueuse/integrations@14.3.0(change-case@5.4.4)(fuse.js@7.3.0)(sortablejs@1.15.7)(vue@3.5.34(typescript@6.0.3))':
     dependencies:
       '@vueuse/core': 14.3.0(vue@3.5.34(typescript@6.0.3))
       '@vueuse/shared': 14.3.0(vue@3.5.34(typescript@6.0.3))
@@ -14707,6 +14710,7 @@ snapshots:
     optionalDependencies:
       change-case: 5.4.4
       fuse.js: 7.3.0
+      sortablejs: 1.15.7
 
   '@vueuse/metadata@10.11.1': {}
 
@@ -19990,6 +19994,9 @@ snapshots:
     dependencies:
       ip-address: 10.1.0
       smart-buffer: 4.2.0
+
+  sortablejs@1.15.7:
+    optional: true
 
   source-map-js@1.2.1: {}
 

--- a/proto/resources/centrum/units/units.proto
+++ b/proto/resources/centrum/units/units.proto
@@ -18,6 +18,10 @@ message Unit {
   optional resources.timestamp.Timestamp updated_at = 3;
   string job = 4 [(buf.validate.field).string.max_len = 20];
   optional string job_label = 15 [(buf.validate.field).string.max_len = 50];
+  int32 sort_order = 17 [
+    (buf.validate.field).int32.gte = 0,
+    (tagger.tags) = "alias:\"sort_order\""
+  ];
   string name = 5 [
     (buf.validate.field).string = {
       min_len: 3

--- a/proto/services/centrum/units.proto
+++ b/proto/services/centrum/units.proto
@@ -27,6 +27,16 @@ message ListUnitsResponse {
   repeated resources.centrum.units.Unit units = 1 [(codegen.itemslen.enabled) = true];
 }
 
+message ListUnitActivityRequest {
+  resources.common.database.PaginationRequest pagination = 1 [(buf.validate.field).required = true];
+  int64 id = 2;
+}
+
+message ListUnitActivityResponse {
+  resources.common.database.PaginationResponse pagination = 1 [(buf.validate.field).required = true];
+  repeated resources.centrum.units.UnitStatus activity = 2 [(codegen.itemslen.enabled) = true];
+}
+
 message CreateOrUpdateUnitRequest {
   resources.centrum.units.Unit unit = 1 [(buf.validate.field).required = true];
 }
@@ -40,6 +50,26 @@ message DeleteUnitRequest {
 }
 
 message DeleteUnitResponse {}
+
+message ReorderUnitsRequest {
+  repeated int64 unit_ids = 1 [(buf.validate.field).repeated = {
+    items: {
+      int64: {gt: 0}
+    }
+    min_items: 1
+    max_items: 250
+  }];
+}
+
+message ReorderUnitsResponse {}
+
+message AssignUnitRequest {
+  int64 unit_id = 1;
+  repeated int32 to_add = 2;
+  repeated int32 to_remove = 3;
+}
+
+message AssignUnitResponse {}
 
 message UpdateUnitStatusRequest {
   int64 unit_id = 1;
@@ -55,24 +85,6 @@ message UpdateUnitStatusRequest {
 }
 
 message UpdateUnitStatusResponse {}
-
-message AssignUnitRequest {
-  int64 unit_id = 1;
-  repeated int32 to_add = 2;
-  repeated int32 to_remove = 3;
-}
-
-message AssignUnitResponse {}
-
-message ListUnitActivityRequest {
-  resources.common.database.PaginationRequest pagination = 1 [(buf.validate.field).required = true];
-  int64 id = 2;
-}
-
-message ListUnitActivityResponse {
-  resources.common.database.PaginationResponse pagination = 1 [(buf.validate.field).required = true];
-  repeated resources.centrum.units.UnitStatus activity = 2 [(codegen.itemslen.enabled) = true];
-}
 
 service UnitsService {
   option (codegen.perms.perms_svc) = {
@@ -111,6 +123,14 @@ service UnitsService {
   rpc DeleteUnit(DeleteUnitRequest) returns (DeleteUnitResponse) {
     option (codegen.perms.perms) = {enabled: true};
   }
+
+  rpc ReorderUnits(ReorderUnitsRequest) returns (ReorderUnitsResponse) {
+    option (codegen.perms.perms) = {
+      enabled: true
+      name: "CreateOrUpdateUnit"
+    };
+  }
+
   rpc AssignUnit(AssignUnitRequest) returns (AssignUnitResponse) {
     option (codegen.perms.perms) = {
       enabled: true

--- a/query/fivenet/model/fivenet_centrum_units.go
+++ b/query/fivenet/model/fivenet_centrum_units.go
@@ -17,6 +17,7 @@ type FivenetCentrumUnits struct {
 	UpdatedAt   *time.Time `json:"updated_at"`
 	DeletedAt   *time.Time `json:"deleted_at"`
 	Job         string     `json:"job"`
+	SortOrder   int        `json:"sort_order"`
 	Name        string     `json:"name"`
 	Initials    string     `json:"initials"`
 	Color       string     `json:"color"`

--- a/query/fivenet/table/fivenet_centrum_units.go
+++ b/query/fivenet/table/fivenet_centrum_units.go
@@ -22,6 +22,7 @@ type fivenetCentrumUnitsTable struct {
 	UpdatedAt   mysql.ColumnTimestamp
 	DeletedAt   mysql.ColumnTimestamp
 	Job         mysql.ColumnString
+    SortOrder   mysql.ColumnInteger
 	Name        mysql.ColumnString
 	Initials    mysql.ColumnString
 	Color       mysql.ColumnString
@@ -75,6 +76,7 @@ func newFivenetCentrumUnitsTableImpl(schemaName, tableName, alias string) fivene
 		UpdatedAtColumn   = mysql.TimestampColumn("updated_at")
 		DeletedAtColumn   = mysql.TimestampColumn("deleted_at")
 		JobColumn         = mysql.StringColumn("job")
+		SortOrderColumn   = mysql.IntegerColumn("sort_order")
 		NameColumn        = mysql.StringColumn("name")
 		InitialsColumn    = mysql.StringColumn("initials")
 		ColorColumn       = mysql.StringColumn("color")
@@ -82,9 +84,9 @@ func newFivenetCentrumUnitsTableImpl(schemaName, tableName, alias string) fivene
 		DescriptionColumn = mysql.StringColumn("description")
 		AttributesColumn  = mysql.StringColumn("attributes")
 		HomePostalColumn  = mysql.StringColumn("home_postal")
-		allColumns        = mysql.ColumnList{IDColumn, CreatedAtColumn, UpdatedAtColumn, DeletedAtColumn, JobColumn, NameColumn, InitialsColumn, ColorColumn, IconColumn, DescriptionColumn, AttributesColumn, HomePostalColumn}
-		mutableColumns    = mysql.ColumnList{CreatedAtColumn, UpdatedAtColumn, DeletedAtColumn, JobColumn, NameColumn, InitialsColumn, ColorColumn, IconColumn, DescriptionColumn, AttributesColumn, HomePostalColumn}
-		defaultColumns    = mysql.ColumnList{CreatedAtColumn}
+		allColumns        = mysql.ColumnList{IDColumn, CreatedAtColumn, UpdatedAtColumn, DeletedAtColumn, JobColumn, SortOrderColumn, NameColumn, InitialsColumn, ColorColumn, IconColumn, DescriptionColumn, AttributesColumn, HomePostalColumn}
+		mutableColumns    = mysql.ColumnList{CreatedAtColumn, UpdatedAtColumn, DeletedAtColumn, JobColumn, SortOrderColumn, NameColumn, InitialsColumn, ColorColumn, IconColumn, DescriptionColumn, AttributesColumn, HomePostalColumn}
+		defaultColumns    = mysql.ColumnList{CreatedAtColumn, SortOrderColumn}
 	)
 
 	return fivenetCentrumUnitsTable{
@@ -96,6 +98,7 @@ func newFivenetCentrumUnitsTableImpl(schemaName, tableName, alias string) fivene
 		UpdatedAt:   UpdatedAtColumn,
 		DeletedAt:   DeletedAtColumn,
 		Job:         JobColumn,
+        SortOrder:   SortOrderColumn,
 		Name:        NameColumn,
 		Initials:    InitialsColumn,
 		Color:       ColorColumn,

--- a/query/migrations/1779914861_centrum_units_sort_order.down.sql
+++ b/query/migrations/1779914861_centrum_units_sort_order.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE `fivenet_centrum_units`
+  DROP KEY `idx_fivenet_centrum_units_job_sort_order`;
+
+ALTER TABLE `fivenet_centrum_units`
+  DROP COLUMN `sort_order`;
+
+COMMIT;

--- a/query/migrations/1779914861_centrum_units_sort_order.up.sql
+++ b/query/migrations/1779914861_centrum_units_sort_order.up.sql
@@ -1,0 +1,18 @@
+BEGIN;
+
+ALTER TABLE `fivenet_centrum_units`
+  ADD COLUMN `sort_order` int(11) NOT NULL DEFAULT 0 AFTER `job`;
+
+ALTER TABLE `fivenet_centrum_units`
+  ADD KEY `idx_fivenet_centrum_units_job_sort_order` (`job`, `sort_order`, `id`);
+
+UPDATE `fivenet_centrum_units` u
+JOIN (
+  SELECT
+    `id`,
+    ROW_NUMBER() OVER (PARTITION BY `job` ORDER BY `name` ASC, `id` ASC) - 1 AS `new_sort_order`
+  FROM `fivenet_centrum_units`
+) x ON x.id = u.id
+SET u.sort_order = x.new_sort_order;
+
+COMMIT;

--- a/services/centrum/units.go
+++ b/services/centrum/units.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/errswrap"
 	grpc_audit "github.com/fivenet-app/fivenet/v2026/pkg/grpc/interceptors/audit"
+	"github.com/fivenet-app/fivenet/v2026/pkg/utils"
 	"github.com/fivenet-app/fivenet/v2026/query/fivenet/table"
 	errorscentrum "github.com/fivenet-app/fivenet/v2026/services/centrum/errors"
 	"github.com/go-jet/jet/v2/mysql"
@@ -104,6 +105,84 @@ func (s *Server) CreateOrUpdateUnit(
 	return &pbcentrum.CreateOrUpdateUnitResponse{
 		Unit: unit,
 	}, nil
+}
+
+func (s *Server) ReorderUnits(
+	ctx context.Context,
+	req *pbcentrum.ReorderUnitsRequest,
+) (*pbcentrum.ReorderUnitsResponse, error) {
+	userInfo := auth.MustGetUserInfoFromContext(ctx)
+
+	// Remove any duplicate unit ids from the request
+	unitIds := utils.RemoveSliceDuplicates(req.GetUnitIds())
+
+	stmt := tUnits.
+		SELECT(tUnits.ID).
+		FROM(tUnits).
+		WHERE(mysql.AND(
+			tUnits.Job.EQ(mysql.String(userInfo.GetJob())),
+			tUnits.DeletedAt.IS_NULL(),
+		)).
+		LIMIT(int64(len(unitIds)))
+
+	var dest []int64
+	if err := stmt.QueryContext(ctx, s.db, &dest); err != nil {
+		if !errors.Is(err, qrm.ErrNoRows) {
+			return nil, errswrap.NewError(err, errorscentrum.ErrFailedQuery)
+		}
+	}
+
+	existing := make(map[int64]struct{}, len(unitIds))
+	for _, unitID := range dest {
+		existing[unitID] = struct{}{}
+	}
+
+	if len(existing) != len(unitIds) {
+		return nil, errorscentrum.ErrUnitPermDenied
+	}
+
+	for _, unitID := range unitIds {
+		if _, ok := existing[unitID]; !ok {
+			return nil, errorscentrum.ErrUnitPermDenied
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, errswrap.NewError(err, errorscentrum.ErrFailedQuery)
+	}
+	defer tx.Rollback()
+
+	for idx, unitID := range unitIds {
+		if _, err := tUnits.
+			UPDATE().
+			SET(
+				tUnits.SortOrder.SET(mysql.Int(int64(idx))),
+			).
+			WHERE(mysql.AND(
+				tUnits.ID.EQ(mysql.Int64(unitID)),
+				tUnits.Job.EQ(mysql.String(userInfo.GetJob())),
+				tUnits.DeletedAt.IS_NULL(),
+			)).
+			LIMIT(1).
+			ExecContext(ctx, tx); err != nil {
+			return nil, errswrap.NewError(err, errorscentrum.ErrFailedQuery)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, errswrap.NewError(err, errorscentrum.ErrFailedQuery)
+	}
+
+	for _, unitID := range unitIds {
+		if err := s.units.LoadFromDB(ctx, unitID); err != nil {
+			return nil, errswrap.NewError(err, errorscentrum.ErrFailedQuery)
+		}
+	}
+
+	grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_UPDATED)
+
+	return &pbcentrum.ReorderUnitsResponse{}, nil
 }
 
 func (s *Server) DeleteUnit(

--- a/services/centrum/units/kv.go
+++ b/services/centrum/units/kv.go
@@ -74,7 +74,24 @@ func (s *UnitDB) List(_ context.Context, jobs []string) []*centrumunits.Unit {
 	}
 
 	slices.SortFunc(us, func(a, b *centrumunits.Unit) int {
-		return strings.Compare(a.GetName(), b.GetName())
+		if a.GetSortOrder() != b.GetSortOrder() {
+			if a.GetSortOrder() < b.GetSortOrder() {
+				return -1
+			}
+			return 1
+		}
+
+		if c := strings.Compare(a.GetName(), b.GetName()); c != 0 {
+			return c
+		}
+
+		if a.GetId() < b.GetId() {
+			return -1
+		} else if a.GetId() > b.GetId() {
+			return 1
+		}
+
+		return 0
 	})
 
 	return us
@@ -106,6 +123,27 @@ func (s *UnitDB) Filter(
 		}
 
 		return true
+	})
+
+	slices.SortFunc(us, func(a, b *centrumunits.Unit) int {
+		if a.GetSortOrder() != b.GetSortOrder() {
+			if a.GetSortOrder() < b.GetSortOrder() {
+				return -1
+			}
+			return 1
+		}
+
+		if c := strings.Compare(a.GetName(), b.GetName()); c != 0 {
+			return c
+		}
+
+		if a.GetId() < b.GetId() {
+			return -1
+		} else if a.GetId() > b.GetId() {
+			return 1
+		}
+
+		return 0
 	})
 
 	return us

--- a/services/centrum/units/units.go
+++ b/services/centrum/units/units.go
@@ -294,6 +294,7 @@ func (s *UnitDB) LoadFromDB(ctx context.Context, id int64) error {
 			tUnits.CreatedAt,
 			tUnits.UpdatedAt,
 			tUnits.Job,
+			tUnits.SortOrder,
 			tUnits.Name,
 			tUnits.Initials,
 			tUnits.Color,
@@ -313,7 +314,9 @@ func (s *UnitDB) LoadFromDB(ctx context.Context, id int64) error {
 		WHERE(condition).
 		ORDER_BY(
 			tUnits.Job.ASC(),
+			tUnits.SortOrder.ASC(),
 			tUnits.Name.ASC(),
+			tUnits.ID.ASC(),
 		)
 
 	units := []*centrumunits.Unit{}


### PR DESCRIPTION
**Description of changes:**
Add API to allow re-ordering units in units list of dispatch center.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [CONTRIBUTING.md](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Reviewed the contributor guide [here (CONTRIBUTING.md)](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated, if necessary. Please open a PR in the [website repository](https://github.com/fivenet-app/fivenet-app.github.io) and add a link to the PR here.
- [x] Tests have been added, if necessary.