### PR TITLE
feat: handle and notify on user primary job and groups changes

### DIFF
--- a/app/components/documents/List.vue
+++ b/app/components/documents/List.vue
@@ -478,11 +478,7 @@ defineShortcuts({
                 :error="error"
                 :retry="refresh"
             />
-            <DataNoDataBlock
-                v-else-if="data?.documents.length === 0"
-                :type="$t('common.document', 2)"
-                :focus="focusInput"
-            />
+            <DataNoDataBlock v-else-if="data?.documents.length === 0" :type="$t('common.document', 2)" :focus="focusInput" />
 
             <ul
                 v-else-if="data?.documents || isRequestPending(status)"

--- a/app/components/notifications/NotificationProvider.vue
+++ b/app/components/notifications/NotificationProvider.vue
@@ -89,53 +89,65 @@ async function toggleStream(): Promise<void> {
 watch([username, activeChar, webSocket.status], async () => toggleStream());
 
 const toast = useToast();
+const seenNotificationIds = new Set<number>();
 
-function createNotifications(notifications: Notification[]): void {
-    notifications.forEach((notification) => {
-        toast.add({
-            id: notification.id?.toString() ?? uuidv4(),
-            title:
-                typeof notification.title === 'string'
-                    ? notification.title
-                    : t(notification.title.key, notification.title.parameters ?? {}),
-            description:
-                typeof notification.description === 'string'
-                    ? notification.description
-                    : t(notification.description.key, notification.description.parameters ?? {}),
-            icon: notificationTypeToIcon(notification.type),
-            color: notificationTypeToColor(notification.type),
-            duration: notification.duration ?? timeouts.notification,
-            actions: notification.actions?.map((action) => ({
-                label: t(action.label.key, action.label.parameters ?? {}),
-                to: action.to,
-                external: action.external,
-                onClick: action.onClick,
-            })),
-            'onUpdate:open': () => {
-                if (notification.id) {
-                    notificationsStore.remove(notification.id);
-                }
-                if (notification.callback) {
-                    notification.callback();
-                }
-            },
-        });
+function markNotificationSeen(notification: Notification): void {
+    if (notification.id !== undefined) seenNotificationIds.add(notification.id);
+}
+
+function createNotification(notification: Notification): void {
+    if (notification.id !== undefined && seenNotificationIds.has(notification.id)) return;
+
+    markNotificationSeen(notification);
+    toast.add({
+        id: notification.id?.toString() ?? uuidv4(),
+        title:
+            typeof notification.title === 'string'
+                ? notification.title
+                : t(notification.title.key, notification.title.parameters ?? {}),
+        description:
+            typeof notification.description === 'string'
+                ? notification.description
+                : t(notification.description.key, notification.description.parameters ?? {}),
+        icon: notificationTypeToIcon(notification.type),
+        color: notificationTypeToColor(notification.type),
+        duration: notification.duration ?? timeouts.notification,
+        actions: notification.actions?.map((action) => ({
+            label: t(action.label.key, action.label.parameters ?? {}),
+            to: action.to,
+            external: action.external,
+            onClick: action.onClick,
+        })),
+        'onUpdate:open': () => {
+            if (notification.id) {
+                notificationsStore.remove(notification.id);
+                seenNotificationIds.delete(notification.id);
+            }
+            if (notification.callback) {
+                notification.callback();
+            }
+        },
     });
 }
 
-const handleNotificationAdded = (notification: Notification): void => createNotifications([notification]);
+function createNotifications(notifications: Notification[]): void {
+    notifications.forEach((notification) => createNotification(notification));
+}
+
+const handleNotificationAdded = (notification: Notification): void => createNotification(notification);
 
 onMounted(async () => await toggleStream());
 
 onUnmounted(async () => await stopStream(true));
 
 onMounted(() => {
-    createNotifications(notifications.value);
     notificationToastEvents.on('add', handleNotificationAdded);
+    createNotifications(notifications.value);
 });
 
 onUnmounted(() => {
     notificationToastEvents.off('add', handleNotificationAdded);
+    seenNotificationIds.clear();
 });
 </script>
 

--- a/app/components/notifications/NotificationProvider.vue
+++ b/app/components/notifications/NotificationProvider.vue
@@ -2,6 +2,7 @@
 import { v4 as uuidv4 } from 'uuid';
 import { notificationTypeToColor, notificationTypeToIcon } from '~/components/notifications/helpers';
 import { useGRPCWebsocketTransport } from '~/composables/grpcws';
+import { notificationToastEvents } from '~/composables/useNotificationToasts';
 import { useCalendarStore } from '~/stores/calendar';
 import { useMailerStore } from '~/stores/mailer';
 import { logger } from '~/stores/notifications';
@@ -87,24 +88,28 @@ async function toggleStream(): Promise<void> {
 
 watch([username, activeChar, webSocket.status], async () => toggleStream());
 
-onMounted(async () => await toggleStream());
-
-onUnmounted(async () => await stopStream(true));
-
 const toast = useToast();
 
 function createNotifications(notifications: Notification[]): void {
     notifications.forEach((notification) => {
         toast.add({
             id: notification.id?.toString() ?? uuidv4(),
-            title: t(notification.title.key, notification.title.parameters ?? {}),
-            description: t(notification.description.key, notification.description.parameters ?? {}),
+            title:
+                typeof notification.title === 'string'
+                    ? notification.title
+                    : t(notification.title.key, notification.title.parameters ?? {}),
+            description:
+                typeof notification.description === 'string'
+                    ? notification.description
+                    : t(notification.description.key, notification.description.parameters ?? {}),
             icon: notificationTypeToIcon(notification.type),
             color: notificationTypeToColor(notification.type),
             duration: notification.duration ?? timeouts.notification,
             actions: notification.actions?.map((action) => ({
-                ...action,
                 label: t(action.label.key, action.label.parameters ?? {}),
+                to: action.to,
+                external: action.external,
+                onClick: action.onClick,
             })),
             'onUpdate:open': () => {
                 if (notification.id) {
@@ -118,8 +123,20 @@ function createNotifications(notifications: Notification[]): void {
     });
 }
 
-watchArray(notifications, (_, _0, added) => createNotifications(added), { deep: true });
-createNotifications(notifications.value);
+const handleNotificationAdded = (notification: Notification): void => createNotifications([notification]);
+
+onMounted(async () => await toggleStream());
+
+onUnmounted(async () => await stopStream(true));
+
+onMounted(() => {
+    createNotifications(notifications.value);
+    notificationToastEvents.on('add', handleNotificationAdded);
+});
+
+onUnmounted(() => {
+    notificationToastEvents.off('add', handleNotificationAdded);
+});
 </script>
 
 <template>

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -10,7 +10,8 @@ export type canMode = 'oneof' | 'all';
 // Wrapper around auth store to make live easier
 const _useAuth = () => {
     const authStore = useAuthStore();
-    const { username, accountId, activeChar, isSuperuser, jobProps, permissions, attributes } = storeToRefs(authStore);
+    const { username, accountId, activeChar, isSuperuser, jobProps, permissions, attributes, canBeSuperuser } =
+        storeToRefs(authStore);
 
     function checkPerm(permissions: Permission[], perm: string | string[], mode: canMode = 'oneof'): boolean {
         if (mode === undefined) mode = 'oneof';
@@ -162,6 +163,7 @@ const _useAuth = () => {
         // Getters
         accountId,
         activeChar,
+        canBeSuperuser,
         isSuperuser,
         jobProps,
         username,

--- a/app/composables/useNotificationToasts.ts
+++ b/app/composables/useNotificationToasts.ts
@@ -1,0 +1,8 @@
+import mitt from 'mitt';
+import type { Notification } from '~/types/notifications';
+
+type NotificationToastEvents = {
+    add: Notification;
+};
+
+export const notificationToastEvents = mitt<NotificationToastEvents>();

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -13,7 +13,7 @@ import type { Perms } from '~~/gen/ts/perms';
 
 const { t } = useI18n();
 
-const { can, activeChar, jobProps, isSuperuser } = useAuth();
+const { can, activeChar, jobProps, isSuperuser, canBeSuperuser } = useAuth();
 const authSessionStore = useAuthSessionStore();
 const { userInfo } = storeToRefs(authSessionStore);
 
@@ -412,7 +412,7 @@ defineShortcuts(extractShortcuts(quickAccessButtons.value, '-'));
 
                 <div class="flex-1" />
 
-                <template v-if="can(['internal.Superuser/CanBeSuperuser', 'internal.Superuser/Superuser']).value">
+                <template v-if="canBeSuperuser || isSuperuser">
                     <SuperuserJobToggle :collapsed="collapsed" />
 
                     <USeparator />

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -73,6 +73,10 @@ export const useAuthStore = defineStore(
          * The list of role attributes assigned to the user.
          */
         const attributes = ref<RoleAttribute[]>([]);
+        /**
+         * Whether the current account can enter superuser mode.
+         */
+        const canBeSuperuser = ref<boolean>(false);
 
         /**
          * Set or unset the username.
@@ -143,6 +147,15 @@ export const useAuthStore = defineStore(
         const setPermissions = (perms: Permission[], attrs: RoleAttribute[]): void => {
             permissions.value = [...perms.sort()];
             attributes.value = [...attrs.sort()];
+            canBeSuperuser.value = perms.some((p) => p.guardName === 'internal-superuser-canbesuperuser');
+        };
+
+        /**
+         * Updates whether the current account can enter superuser mode.
+         * @param val - Whether superuser mode is available.
+         */
+        const setCanBeSuperuser = (val: boolean): void => {
+            canBeSuperuser.value = val;
         };
 
         /**
@@ -387,6 +400,7 @@ export const useAuthStore = defineStore(
             setUsername(null);
             setActiveChar(null);
             setPermissions([], []);
+            setCanBeSuperuser(false);
             setJobProps(undefined);
             setUserToken();
 
@@ -438,6 +452,7 @@ export const useAuthStore = defineStore(
 
             permissions,
             attributes,
+            canBeSuperuser,
 
             // Actions
             setUsername,
@@ -450,6 +465,7 @@ export const useAuthStore = defineStore(
             setUserToken,
             setActiveChar,
             setPermissions,
+            setCanBeSuperuser,
             setJobProps,
 
             chooseCharacter,

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -157,7 +157,8 @@ export const useAuthStore = defineStore(
          * Updates whether the current account can enter superuser mode.
          * @param val - Whether superuser mode is available.
          */
-        const setCanBeSuperuser = (val: boolean): void => {
+        const setCanBeSuperuser = (val: boolean): boolean => {
+            const previousValue = canBeSuperuser.value;
             canBeSuperuser.value = val;
             if (!canBeSuperuser.value) {
                 // Remove can be- and superuser permission if user can't be superuser anymore
@@ -165,6 +166,8 @@ export const useAuthStore = defineStore(
                     (p) => p.guardName !== superuserPermGuard && p.guardName !== superuserCanBePermGuard,
                 );
             }
+
+            return previousValue;
         };
 
         /**
@@ -365,7 +368,7 @@ export const useAuthStore = defineStore(
                     job: job?.name,
                 });
                 const { response } = await call;
-                setUserToken(response.token, true);
+                setUserToken(response.token);
                 setPermissions(response.permissions, response.attributes);
                 await navigateTo('/overview');
 
@@ -421,7 +424,7 @@ export const useAuthStore = defineStore(
          * Set user token in session storage.
          * @param token - The user token to set. If undefined, the token is removed.
          */
-        const setUserToken = async (token?: string, restartWS = false): Promise<void> => {
+        const setUserToken = async (token?: string): Promise<void> => {
             if (!token) {
                 authSessionStore.setUserToken(null);
                 return;
@@ -436,7 +439,7 @@ export const useAuthStore = defineStore(
             logger.debug('Setting user token in session storage');
             authSessionStore.setUserToken(token);
 
-            if (activeChar.value !== null && restartWS) {
+            if (activeChar.value !== null) {
                 logger.info('User token updated, send WebSocket re-auth message');
                 useGRPCWebsocketTransport().updateUserToken(token);
             }

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -14,6 +14,9 @@ import type { ImpersonateJobResponse } from '~~/gen/ts/services/auth/auth';
 
 const logger = useLogger('🔑 Auth');
 
+const superuserPermGuard = 'internal-superuser-superuser' as const;
+const superuserCanBePermGuard = 'internal-superuser-canbesuperuser' as const;
+
 /**
  * Pinia store for managing user sessions, permissions, and state.
  */
@@ -147,7 +150,7 @@ export const useAuthStore = defineStore(
         const setPermissions = (perms: Permission[], attrs: RoleAttribute[]): void => {
             permissions.value = [...perms.sort()];
             attributes.value = [...attrs.sort()];
-            canBeSuperuser.value = perms.some((p) => p.guardName === 'internal-superuser-canbesuperuser');
+            canBeSuperuser.value = perms.some((p) => p.guardName === superuserCanBePermGuard);
         };
 
         /**
@@ -156,6 +159,12 @@ export const useAuthStore = defineStore(
          */
         const setCanBeSuperuser = (val: boolean): void => {
             canBeSuperuser.value = val;
+            if (!canBeSuperuser.value) {
+                // Remove can be- and superuser permission if user can't be superuser anymore
+                permissions.value = permissions.value.filter(
+                    (p) => p.guardName !== superuserPermGuard && p.guardName !== superuserCanBePermGuard,
+                );
+            }
         };
 
         /**
@@ -434,9 +443,7 @@ export const useAuthStore = defineStore(
         };
 
         // Getters
-        const isSuperuser = computed<boolean>(
-            () => !!permissions.value.find((p) => p.guardName === 'internal-superuser-superuser'),
-        );
+        const isSuperuser = computed<boolean>(() => !!permissions.value.find((p) => p.guardName === superuserPermGuard));
 
         return {
             // State

--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -173,7 +173,7 @@ export const useNotificationsStore = defineStore(
             const { activeChar } = useAuth();
 
             const jobChanged = activeChar.value!.job != userInfoChanged.newJob;
-            const jobGradeChanged = activeChar.value!.jobGrade != userInfoChanged.newJobGrade;
+            const jobGradeChanged = activeChar.value!.jobGrade !== userInfoChanged.newJobGrade;
 
             if (jobChanged || jobGradeChanged) {
                 const nextJob =
@@ -201,7 +201,7 @@ export const useNotificationsStore = defineStore(
 
             if (userInfoChanged.newJob) activeChar.value!.job = userInfoChanged.newJob;
             if (userInfoChanged.newJobLabel) activeChar.value!.jobLabel = userInfoChanged.newJobLabel;
-            if (userInfoChanged.newJobGrade) activeChar.value!.jobGrade = userInfoChanged.newJobGrade;
+            if (userInfoChanged.newJobGrade !== undefined) activeChar.value!.jobGrade = userInfoChanged.newJobGrade;
             if (userInfoChanged.newJobGradeLabel) activeChar.value!.jobGradeLabel = userInfoChanged.newJobGradeLabel;
 
             await authStore.chooseCharacter(undefined);

--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -166,13 +166,36 @@ export const useNotificationsStore = defineStore(
          * Handles the user info changed event by updating the active character's job information.
          * @param userInfoChanged - The user info change data from the server.
          */
-        const handleUserInfoChangedEvent = (userInfoChanged: UserInfoChanged): void => {
+        const handleUserInfoChangedEvent = async (
+            userInfoChanged: UserInfoChanged,
+            authStore: ReturnType<typeof useAuthStore>,
+        ): Promise<void> => {
             const { activeChar } = useAuth();
 
-            if (activeChar.value!.job != userInfoChanged.newJob || activeChar.value!.jobGrade != userInfoChanged.newJobGrade) {
+            const jobChanged = activeChar.value!.job != userInfoChanged.newJob;
+            const jobGradeChanged = activeChar.value!.jobGrade != userInfoChanged.newJobGrade;
+
+            if (jobChanged || jobGradeChanged) {
+                const nextJob =
+                    userInfoChanged.newJobLabel ??
+                    userInfoChanged.newJob ??
+                    activeChar.value!.jobLabel ??
+                    activeChar.value!.job;
+                const nextJobGrade =
+                    userInfoChanged.newJobGradeLabel ??
+                    (userInfoChanged.newJobGrade !== undefined
+                        ? `${userInfoChanged.newJobGrade}`
+                        : (activeChar.value!.jobGradeLabel ?? `${activeChar.value!.jobGrade ?? ''}`));
+
                 add({
-                    title: 'Job switched',
-                    description: `Switched to ${userInfoChanged.newJob}: ${userInfoChanged.newJobGrade}`,
+                    title: { key: 'notifications.system.user_job_changed.title', parameters: {} },
+                    description: {
+                        key: 'notifications.system.user_job_changed.content',
+                        parameters: {
+                            job: nextJob ?? '',
+                            grade: nextJobGrade,
+                        },
+                    },
                 });
             }
 
@@ -180,6 +203,8 @@ export const useNotificationsStore = defineStore(
             if (userInfoChanged.newJobLabel) activeChar.value!.jobLabel = userInfoChanged.newJobLabel;
             if (userInfoChanged.newJobGrade) activeChar.value!.jobGrade = userInfoChanged.newJobGrade;
             if (userInfoChanged.newJobGradeLabel) activeChar.value!.jobGradeLabel = userInfoChanged.newJobGradeLabel;
+
+            await authStore.chooseCharacter(undefined);
         };
 
         /**
@@ -211,7 +236,7 @@ export const useNotificationsStore = defineStore(
             } else if (userEvent.data.oneofKind === 'notificationsReadCount') {
                 notificationsCount.value = userEvent.data.notificationsReadCount;
             } else if (userEvent.data.oneofKind === 'userInfoChanged') {
-                handleUserInfoChangedEvent(userEvent.data.userInfoChanged);
+                await handleUserInfoChangedEvent(userEvent.data.userInfoChanged, authStore);
             } else if (userEvent.data.oneofKind === 'userGroupsChanged') {
                 handleUserGroupsChangedEvent(userEvent.data.userGroupsChanged, authStore);
             } else {

--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -10,7 +10,7 @@ import {
     NotificationType,
     type Notification as ProtoNotification,
 } from '~~/gen/ts/resources/notifications/notifications';
-import type { UserInfoChanged } from '~~/gen/ts/resources/userinfo/userinfo';
+import type { UserGroupsChanged, UserInfoChanged } from '~~/gen/ts/resources/userinfo/userinfo';
 import type { MarkNotificationsRequest, StreamRequest, StreamResponse } from '~~/gen/ts/services/notifications/notifications';
 import { useCalendarStore } from './calendar';
 import { useMailerStore } from './mailer';
@@ -174,6 +174,17 @@ export const useNotificationsStore = defineStore(
         };
 
         /**
+         * Handles the user groups changed event by updating the current account capabilities.
+         * @param userGroupsChanged - The user groups change data from the server.
+         */
+        const handleUserGroupsChangedEvent = (
+            userGroupsChanged: UserGroupsChanged,
+            authStore: ReturnType<typeof useAuthStore>,
+        ): void => {
+            authStore.setCanBeSuperuser(userGroupsChanged.canBeSuperuser);
+        };
+
+        /**
          * Handles a user event by delegating to the appropriate handler based on the event type.
          * @param resp - The stream response containing the user event data.
          * @param authStore - The authentication store instance.
@@ -192,6 +203,8 @@ export const useNotificationsStore = defineStore(
                 notificationsCount.value = userEvent.data.notificationsReadCount;
             } else if (userEvent.data.oneofKind === 'userInfoChanged') {
                 handleUserInfoChangedEvent(userEvent.data.userInfoChanged);
+            } else if (userEvent.data.oneofKind === 'userGroupsChanged') {
+                handleUserGroupsChangedEvent(userEvent.data.userGroupsChanged, authStore);
             } else {
                 logger.warn('Unknown userEvent data received - oneofKind:', userEvent.data.oneofKind, userEvent.data);
             }

--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -216,10 +216,10 @@ export const useNotificationsStore = defineStore(
             authStore: ReturnType<typeof useAuthStore>,
         ): Promise<void> => {
             const previousIsSuperuser = authStore.isSuperuser;
-            const hadCanBeSuperuser = authStore.setCanBeSuperuser(accountGroupsChanged.canBeSuperuser);
+            authStore.setCanBeSuperuser(accountGroupsChanged.canBeSuperuser);
 
             // If user is currently a superuser and can't be superuser anymore, force a choose character to refresh their capabilities
-            if (!hadCanBeSuperuser && previousIsSuperuser) {
+            if (previousIsSuperuser && !accountGroupsChanged.canBeSuperuser) {
                 logger.info('User can no longer be superuser, forcing a choose character refresh');
                 await authStore.chooseCharacter(undefined, false);
             }

--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -2,6 +2,7 @@ import type { DuplexStreamingCall } from '@protobuf-ts/runtime-rpc';
 import { defineStore } from 'pinia';
 import { useGRPCWebsocketTransport } from '~/composables/grpcws';
 import { notificationsEvents } from '~/composables/useClientUpdate';
+import { notificationToastEvents } from '~/composables/useNotificationToasts';
 import type { Notification } from '~/types/notifications';
 import { getNotificationsNotificationsClient } from '~~/gen/ts/clients';
 import type { ObjectEvent, ObjectType } from '~~/gen/ts/resources/notifications/clientview/clientview';
@@ -90,6 +91,7 @@ export const useNotificationsStore = defineStore(
             if (notification.actions === undefined) notification.actions = [];
 
             notifications.value.push(notification);
+            notificationToastEvents.emit('add', notification);
         };
 
         /**
@@ -166,6 +168,13 @@ export const useNotificationsStore = defineStore(
          */
         const handleUserInfoChangedEvent = (userInfoChanged: UserInfoChanged): void => {
             const { activeChar } = useAuth();
+
+            if (activeChar.value!.job != userInfoChanged.newJob || activeChar.value!.jobGrade != userInfoChanged.newJobGrade) {
+                add({
+                    title: 'Job switched',
+                    description: `Switched to ${userInfoChanged.newJob}: ${userInfoChanged.newJobGrade}`,
+                });
+            }
 
             if (userInfoChanged.newJob) activeChar.value!.job = userInfoChanged.newJob;
             if (userInfoChanged.newJobLabel) activeChar.value!.jobLabel = userInfoChanged.newJobLabel;

--- a/app/stores/notifications.ts
+++ b/app/stores/notifications.ts
@@ -11,7 +11,7 @@ import {
     NotificationType,
     type Notification as ProtoNotification,
 } from '~~/gen/ts/resources/notifications/notifications';
-import type { UserGroupsChanged, UserInfoChanged } from '~~/gen/ts/resources/userinfo/userinfo';
+import type { AccountGroupsChanged, UserInfoChanged } from '~~/gen/ts/resources/userinfo/userinfo';
 import type { MarkNotificationsRequest, StreamRequest, StreamResponse } from '~~/gen/ts/services/notifications/notifications';
 import { useCalendarStore } from './calendar';
 import { useMailerStore } from './mailer';
@@ -209,13 +209,20 @@ export const useNotificationsStore = defineStore(
 
         /**
          * Handles the user groups changed event by updating the current account capabilities.
-         * @param userGroupsChanged - The user groups change data from the server.
+         * @param accountGroupsChanged - The user groups change data from the server.
          */
-        const handleUserGroupsChangedEvent = (
-            userGroupsChanged: UserGroupsChanged,
+        const handleAccountGroupsChangedEvent = async (
+            accountGroupsChanged: AccountGroupsChanged,
             authStore: ReturnType<typeof useAuthStore>,
-        ): void => {
-            authStore.setCanBeSuperuser(userGroupsChanged.canBeSuperuser);
+        ): Promise<void> => {
+            const previousIsSuperuser = authStore.isSuperuser;
+            const hadCanBeSuperuser = authStore.setCanBeSuperuser(accountGroupsChanged.canBeSuperuser);
+
+            // If user is currently a superuser and can't be superuser anymore, force a choose character to refresh their capabilities
+            if (!hadCanBeSuperuser && previousIsSuperuser) {
+                logger.info('User can no longer be superuser, forcing a choose character refresh');
+                await authStore.chooseCharacter(undefined, false);
+            }
         };
 
         /**
@@ -237,8 +244,8 @@ export const useNotificationsStore = defineStore(
                 notificationsCount.value = userEvent.data.notificationsReadCount;
             } else if (userEvent.data.oneofKind === 'userInfoChanged') {
                 await handleUserInfoChangedEvent(userEvent.data.userInfoChanged, authStore);
-            } else if (userEvent.data.oneofKind === 'userGroupsChanged') {
-                handleUserGroupsChangedEvent(userEvent.data.userGroupsChanged, authStore);
+            } else if (userEvent.data.oneofKind === 'accountGroupsChanged') {
+                await handleAccountGroupsChangedEvent(userEvent.data.accountGroupsChanged, authStore);
             } else {
                 logger.warn('Unknown userEvent data received - oneofKind:', userEvent.data.oneofKind, userEvent.data);
             }

--- a/app/types/notifications.ts
+++ b/app/types/notifications.ts
@@ -1,14 +1,16 @@
-import type { ButtonProps } from '@nuxt/ui';
 import type { Data, NotificationCategory, NotificationType } from '~~/gen/ts/resources/notifications/notifications';
 
-export interface NotificationActionI18n extends Omit<ButtonProps, 'label'> {
+export interface NotificationActionI18n {
     label: I18NItem;
+    to?: string;
+    external?: boolean;
+    onClick?: () => void | Promise<void>;
 }
 
 export interface Notification {
     id?: number;
-    title: I18NItem;
-    description: I18NItem;
+    title: I18NItem | string;
+    description: I18NItem | string;
     duration?: number;
     type?: NotificationType;
     category?: NotificationCategory;

--- a/app/types/notifications.ts
+++ b/app/types/notifications.ts
@@ -1,9 +1,12 @@
+import type { ButtonProps } from '@nuxt/ui';
 import type { Data, NotificationCategory, NotificationType } from '~~/gen/ts/resources/notifications/notifications';
 
 export interface NotificationActionI18n {
     label: I18NItem;
     to?: string;
     external?: boolean;
+    icon?: string;
+    color?: ButtonProps['color'];
     onClick?: () => void | Promise<void>;
 }
 

--- a/gen/go/proto/resources/notifications/events/events.pb.go
+++ b/gen/go/proto/resources/notifications/events/events.pb.go
@@ -35,7 +35,7 @@ type UserEvent struct {
 	//	*UserEvent_Notification
 	//	*UserEvent_NotificationsReadCount
 	//	*UserEvent_UserInfoChanged
-	//	*UserEvent_UserGroupsChanged
+	//	*UserEvent_AccountGroupsChanged
 	Data          isUserEvent_Data `protobuf_oneof:"data"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -109,10 +109,10 @@ func (x *UserEvent) GetUserInfoChanged() *userinfo.UserInfoChanged {
 	return nil
 }
 
-func (x *UserEvent) GetUserGroupsChanged() *userinfo.UserGroupsChanged {
+func (x *UserEvent) GetAccountGroupsChanged() *userinfo.AccountGroupsChanged {
 	if x != nil {
-		if x, ok := x.Data.(*UserEvent_UserGroupsChanged); ok {
-			return x.UserGroupsChanged
+		if x, ok := x.Data.(*UserEvent_AccountGroupsChanged); ok {
+			return x.AccountGroupsChanged
 		}
 	}
 	return nil
@@ -142,12 +142,12 @@ func (x *UserEvent) SetUserInfoChanged(v *userinfo.UserInfoChanged) {
 	x.Data = &UserEvent_UserInfoChanged{v}
 }
 
-func (x *UserEvent) SetUserGroupsChanged(v *userinfo.UserGroupsChanged) {
+func (x *UserEvent) SetAccountGroupsChanged(v *userinfo.AccountGroupsChanged) {
 	if v == nil {
 		x.Data = nil
 		return
 	}
-	x.Data = &UserEvent_UserGroupsChanged{v}
+	x.Data = &UserEvent_AccountGroupsChanged{v}
 }
 
 func (x *UserEvent) HasData() bool {
@@ -189,11 +189,11 @@ func (x *UserEvent) HasUserInfoChanged() bool {
 	return ok
 }
 
-func (x *UserEvent) HasUserGroupsChanged() bool {
+func (x *UserEvent) HasAccountGroupsChanged() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.Data.(*UserEvent_UserGroupsChanged)
+	_, ok := x.Data.(*UserEvent_AccountGroupsChanged)
 	return ok
 }
 
@@ -225,8 +225,8 @@ func (x *UserEvent) ClearUserInfoChanged() {
 	}
 }
 
-func (x *UserEvent) ClearUserGroupsChanged() {
-	if _, ok := x.Data.(*UserEvent_UserGroupsChanged); ok {
+func (x *UserEvent) ClearAccountGroupsChanged() {
+	if _, ok := x.Data.(*UserEvent_AccountGroupsChanged); ok {
 		x.Data = nil
 	}
 }
@@ -236,7 +236,7 @@ const UserEvent_RefreshToken_case case_UserEvent_Data = 1
 const UserEvent_Notification_case case_UserEvent_Data = 2
 const UserEvent_NotificationsReadCount_case case_UserEvent_Data = 3
 const UserEvent_UserInfoChanged_case case_UserEvent_Data = 4
-const UserEvent_UserGroupsChanged_case case_UserEvent_Data = 5
+const UserEvent_AccountGroupsChanged_case case_UserEvent_Data = 5
 
 func (x *UserEvent) WhichData() case_UserEvent_Data {
 	if x == nil {
@@ -251,8 +251,8 @@ func (x *UserEvent) WhichData() case_UserEvent_Data {
 		return UserEvent_NotificationsReadCount_case
 	case *UserEvent_UserInfoChanged:
 		return UserEvent_UserInfoChanged_case
-	case *UserEvent_UserGroupsChanged:
-		return UserEvent_UserGroupsChanged_case
+	case *UserEvent_AccountGroupsChanged:
+		return UserEvent_AccountGroupsChanged_case
 	default:
 		return UserEvent_Data_not_set_case
 	}
@@ -267,7 +267,7 @@ type UserEvent_builder struct {
 	Notification           *notifications.Notification
 	NotificationsReadCount *int64
 	UserInfoChanged        *userinfo.UserInfoChanged
-	UserGroupsChanged      *userinfo.UserGroupsChanged
+	AccountGroupsChanged   *userinfo.AccountGroupsChanged
 	// -- end of Data
 }
 
@@ -287,8 +287,8 @@ func (b0 UserEvent_builder) Build() *UserEvent {
 	if b.UserInfoChanged != nil {
 		x.Data = &UserEvent_UserInfoChanged{b.UserInfoChanged}
 	}
-	if b.UserGroupsChanged != nil {
-		x.Data = &UserEvent_UserGroupsChanged{b.UserGroupsChanged}
+	if b.AccountGroupsChanged != nil {
+		x.Data = &UserEvent_AccountGroupsChanged{b.AccountGroupsChanged}
 	}
 	return m0
 }
@@ -324,8 +324,8 @@ type UserEvent_UserInfoChanged struct {
 	UserInfoChanged *userinfo.UserInfoChanged `protobuf:"bytes,4,opt,name=user_info_changed,json=userInfoChanged,proto3,oneof"`
 }
 
-type UserEvent_UserGroupsChanged struct {
-	UserGroupsChanged *userinfo.UserGroupsChanged `protobuf:"bytes,5,opt,name=user_groups_changed,json=userGroupsChanged,proto3,oneof"`
+type UserEvent_AccountGroupsChanged struct {
+	AccountGroupsChanged *userinfo.AccountGroupsChanged `protobuf:"bytes,5,opt,name=account_groups_changed,json=accountGroupsChanged,proto3,oneof"`
 }
 
 func (*UserEvent_RefreshToken) isUserEvent_Data() {}
@@ -336,7 +336,7 @@ func (*UserEvent_NotificationsReadCount) isUserEvent_Data() {}
 
 func (*UserEvent_UserInfoChanged) isUserEvent_Data() {}
 
-func (*UserEvent_UserGroupsChanged) isUserEvent_Data() {}
+func (*UserEvent_AccountGroupsChanged) isUserEvent_Data() {}
 
 // Job related events
 type JobEvent struct {
@@ -754,13 +754,13 @@ var File_resources_notifications_events_events_proto protoreflect.FileDescriptor
 
 const file_resources_notifications_events_events_proto_rawDesc = "" +
 	"\n" +
-	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\xef\x02\n" +
+	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\xf8\x02\n" +
 	"\tUserEvent\x12%\n" +
 	"\rrefresh_token\x18\x01 \x01(\bH\x00R\frefreshToken\x12K\n" +
 	"\fnotification\x18\x02 \x01(\v2%.resources.notifications.NotificationH\x00R\fnotification\x12:\n" +
 	"\x18notifications_read_count\x18\x03 \x01(\x03H\x00R\x16notificationsReadCount\x12Q\n" +
-	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChanged\x12W\n" +
-	"\x13user_groups_changed\x18\x05 \x01(\v2%.resources.userinfo.UserGroupsChangedH\x00R\x11userGroupsChangedB\x06\n" +
+	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChanged\x12`\n" +
+	"\x16account_groups_changed\x18\x05 \x01(\v2(.resources.userinfo.AccountGroupsChangedH\x00R\x14accountGroupsChangedB\x06\n" +
 	"\x04data\"Q\n" +
 	"\bJobEvent\x12=\n" +
 	"\tjob_props\x18\x01 \x01(\v2\x1e.resources.jobs.props.JobPropsH\x00R\bjobPropsB\x06\n" +
@@ -774,20 +774,20 @@ const file_resources_notifications_events_events_proto_rawDesc = "" +
 
 var file_resources_notifications_events_events_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_resources_notifications_events_events_proto_goTypes = []any{
-	(*UserEvent)(nil),                  // 0: resources.notifications.events.UserEvent
-	(*JobEvent)(nil),                   // 1: resources.notifications.events.JobEvent
-	(*JobGradeEvent)(nil),              // 2: resources.notifications.events.JobGradeEvent
-	(*SystemEvent)(nil),                // 3: resources.notifications.events.SystemEvent
-	(*notifications.Notification)(nil), // 4: resources.notifications.Notification
-	(*userinfo.UserInfoChanged)(nil),   // 5: resources.userinfo.UserInfoChanged
-	(*userinfo.UserGroupsChanged)(nil), // 6: resources.userinfo.UserGroupsChanged
-	(*props.JobProps)(nil),             // 7: resources.jobs.props.JobProps
-	(*clientconfig.ClientConfig)(nil),  // 8: resources.clientconfig.ClientConfig
+	(*UserEvent)(nil),                     // 0: resources.notifications.events.UserEvent
+	(*JobEvent)(nil),                      // 1: resources.notifications.events.JobEvent
+	(*JobGradeEvent)(nil),                 // 2: resources.notifications.events.JobGradeEvent
+	(*SystemEvent)(nil),                   // 3: resources.notifications.events.SystemEvent
+	(*notifications.Notification)(nil),    // 4: resources.notifications.Notification
+	(*userinfo.UserInfoChanged)(nil),      // 5: resources.userinfo.UserInfoChanged
+	(*userinfo.AccountGroupsChanged)(nil), // 6: resources.userinfo.AccountGroupsChanged
+	(*props.JobProps)(nil),                // 7: resources.jobs.props.JobProps
+	(*clientconfig.ClientConfig)(nil),     // 8: resources.clientconfig.ClientConfig
 }
 var file_resources_notifications_events_events_proto_depIdxs = []int32{
 	4, // 0: resources.notifications.events.UserEvent.notification:type_name -> resources.notifications.Notification
 	5, // 1: resources.notifications.events.UserEvent.user_info_changed:type_name -> resources.userinfo.UserInfoChanged
-	6, // 2: resources.notifications.events.UserEvent.user_groups_changed:type_name -> resources.userinfo.UserGroupsChanged
+	6, // 2: resources.notifications.events.UserEvent.account_groups_changed:type_name -> resources.userinfo.AccountGroupsChanged
 	7, // 3: resources.notifications.events.JobEvent.job_props:type_name -> resources.jobs.props.JobProps
 	8, // 4: resources.notifications.events.SystemEvent.client_config:type_name -> resources.clientconfig.ClientConfig
 	5, // [5:5] is the sub-list for method output_type
@@ -807,7 +807,7 @@ func file_resources_notifications_events_events_proto_init() {
 		(*UserEvent_Notification)(nil),
 		(*UserEvent_NotificationsReadCount)(nil),
 		(*UserEvent_UserInfoChanged)(nil),
-		(*UserEvent_UserGroupsChanged)(nil),
+		(*UserEvent_AccountGroupsChanged)(nil),
 	}
 	file_resources_notifications_events_events_proto_msgTypes[1].OneofWrappers = []any{
 		(*JobEvent_JobProps)(nil),

--- a/gen/go/proto/resources/notifications/events/events.pb.go
+++ b/gen/go/proto/resources/notifications/events/events.pb.go
@@ -35,6 +35,7 @@ type UserEvent struct {
 	//	*UserEvent_Notification
 	//	*UserEvent_NotificationsReadCount
 	//	*UserEvent_UserInfoChanged
+	//	*UserEvent_UserGroupsChanged
 	Data          isUserEvent_Data `protobuf_oneof:"data"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -108,6 +109,15 @@ func (x *UserEvent) GetUserInfoChanged() *userinfo.UserInfoChanged {
 	return nil
 }
 
+func (x *UserEvent) GetUserGroupsChanged() *userinfo.UserGroupsChanged {
+	if x != nil {
+		if x, ok := x.Data.(*UserEvent_UserGroupsChanged); ok {
+			return x.UserGroupsChanged
+		}
+	}
+	return nil
+}
+
 func (x *UserEvent) SetRefreshToken(v bool) {
 	x.Data = &UserEvent_RefreshToken{v}
 }
@@ -130,6 +140,14 @@ func (x *UserEvent) SetUserInfoChanged(v *userinfo.UserInfoChanged) {
 		return
 	}
 	x.Data = &UserEvent_UserInfoChanged{v}
+}
+
+func (x *UserEvent) SetUserGroupsChanged(v *userinfo.UserGroupsChanged) {
+	if v == nil {
+		x.Data = nil
+		return
+	}
+	x.Data = &UserEvent_UserGroupsChanged{v}
 }
 
 func (x *UserEvent) HasData() bool {
@@ -171,6 +189,14 @@ func (x *UserEvent) HasUserInfoChanged() bool {
 	return ok
 }
 
+func (x *UserEvent) HasUserGroupsChanged() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.Data.(*UserEvent_UserGroupsChanged)
+	return ok
+}
+
 func (x *UserEvent) ClearData() {
 	x.Data = nil
 }
@@ -199,11 +225,18 @@ func (x *UserEvent) ClearUserInfoChanged() {
 	}
 }
 
+func (x *UserEvent) ClearUserGroupsChanged() {
+	if _, ok := x.Data.(*UserEvent_UserGroupsChanged); ok {
+		x.Data = nil
+	}
+}
+
 const UserEvent_Data_not_set_case case_UserEvent_Data = 0
 const UserEvent_RefreshToken_case case_UserEvent_Data = 1
 const UserEvent_Notification_case case_UserEvent_Data = 2
 const UserEvent_NotificationsReadCount_case case_UserEvent_Data = 3
 const UserEvent_UserInfoChanged_case case_UserEvent_Data = 4
+const UserEvent_UserGroupsChanged_case case_UserEvent_Data = 5
 
 func (x *UserEvent) WhichData() case_UserEvent_Data {
 	if x == nil {
@@ -218,6 +251,8 @@ func (x *UserEvent) WhichData() case_UserEvent_Data {
 		return UserEvent_NotificationsReadCount_case
 	case *UserEvent_UserInfoChanged:
 		return UserEvent_UserInfoChanged_case
+	case *UserEvent_UserGroupsChanged:
+		return UserEvent_UserGroupsChanged_case
 	default:
 		return UserEvent_Data_not_set_case
 	}
@@ -232,6 +267,7 @@ type UserEvent_builder struct {
 	Notification           *notifications.Notification
 	NotificationsReadCount *int64
 	UserInfoChanged        *userinfo.UserInfoChanged
+	UserGroupsChanged      *userinfo.UserGroupsChanged
 	// -- end of Data
 }
 
@@ -250,6 +286,9 @@ func (b0 UserEvent_builder) Build() *UserEvent {
 	}
 	if b.UserInfoChanged != nil {
 		x.Data = &UserEvent_UserInfoChanged{b.UserInfoChanged}
+	}
+	if b.UserGroupsChanged != nil {
+		x.Data = &UserEvent_UserGroupsChanged{b.UserGroupsChanged}
 	}
 	return m0
 }
@@ -285,6 +324,10 @@ type UserEvent_UserInfoChanged struct {
 	UserInfoChanged *userinfo.UserInfoChanged `protobuf:"bytes,4,opt,name=user_info_changed,json=userInfoChanged,proto3,oneof"`
 }
 
+type UserEvent_UserGroupsChanged struct {
+	UserGroupsChanged *userinfo.UserGroupsChanged `protobuf:"bytes,5,opt,name=user_groups_changed,json=userGroupsChanged,proto3,oneof"`
+}
+
 func (*UserEvent_RefreshToken) isUserEvent_Data() {}
 
 func (*UserEvent_Notification) isUserEvent_Data() {}
@@ -292,6 +335,8 @@ func (*UserEvent_Notification) isUserEvent_Data() {}
 func (*UserEvent_NotificationsReadCount) isUserEvent_Data() {}
 
 func (*UserEvent_UserInfoChanged) isUserEvent_Data() {}
+
+func (*UserEvent_UserGroupsChanged) isUserEvent_Data() {}
 
 // Job related events
 type JobEvent struct {
@@ -709,12 +754,13 @@ var File_resources_notifications_events_events_proto protoreflect.FileDescriptor
 
 const file_resources_notifications_events_events_proto_rawDesc = "" +
 	"\n" +
-	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\x96\x02\n" +
+	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\xef\x02\n" +
 	"\tUserEvent\x12%\n" +
 	"\rrefresh_token\x18\x01 \x01(\bH\x00R\frefreshToken\x12K\n" +
 	"\fnotification\x18\x02 \x01(\v2%.resources.notifications.NotificationH\x00R\fnotification\x12:\n" +
 	"\x18notifications_read_count\x18\x03 \x01(\x03H\x00R\x16notificationsReadCount\x12Q\n" +
-	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChangedB\x06\n" +
+	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChanged\x12W\n" +
+	"\x13user_groups_changed\x18\x05 \x01(\v2%.resources.userinfo.UserGroupsChangedH\x00R\x11userGroupsChangedB\x06\n" +
 	"\x04data\"Q\n" +
 	"\bJobEvent\x12=\n" +
 	"\tjob_props\x18\x01 \x01(\v2\x1e.resources.jobs.props.JobPropsH\x00R\bjobPropsB\x06\n" +
@@ -734,19 +780,21 @@ var file_resources_notifications_events_events_proto_goTypes = []any{
 	(*SystemEvent)(nil),                // 3: resources.notifications.events.SystemEvent
 	(*notifications.Notification)(nil), // 4: resources.notifications.Notification
 	(*userinfo.UserInfoChanged)(nil),   // 5: resources.userinfo.UserInfoChanged
-	(*props.JobProps)(nil),             // 6: resources.jobs.props.JobProps
-	(*clientconfig.ClientConfig)(nil),  // 7: resources.clientconfig.ClientConfig
+	(*userinfo.UserGroupsChanged)(nil), // 6: resources.userinfo.UserGroupsChanged
+	(*props.JobProps)(nil),             // 7: resources.jobs.props.JobProps
+	(*clientconfig.ClientConfig)(nil),  // 8: resources.clientconfig.ClientConfig
 }
 var file_resources_notifications_events_events_proto_depIdxs = []int32{
 	4, // 0: resources.notifications.events.UserEvent.notification:type_name -> resources.notifications.Notification
 	5, // 1: resources.notifications.events.UserEvent.user_info_changed:type_name -> resources.userinfo.UserInfoChanged
-	6, // 2: resources.notifications.events.JobEvent.job_props:type_name -> resources.jobs.props.JobProps
-	7, // 3: resources.notifications.events.SystemEvent.client_config:type_name -> resources.clientconfig.ClientConfig
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	6, // 2: resources.notifications.events.UserEvent.user_groups_changed:type_name -> resources.userinfo.UserGroupsChanged
+	7, // 3: resources.notifications.events.JobEvent.job_props:type_name -> resources.jobs.props.JobProps
+	8, // 4: resources.notifications.events.SystemEvent.client_config:type_name -> resources.clientconfig.ClientConfig
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_resources_notifications_events_events_proto_init() }
@@ -759,6 +807,7 @@ func file_resources_notifications_events_events_proto_init() {
 		(*UserEvent_Notification)(nil),
 		(*UserEvent_NotificationsReadCount)(nil),
 		(*UserEvent_UserInfoChanged)(nil),
+		(*UserEvent_UserGroupsChanged)(nil),
 	}
 	file_resources_notifications_events_events_proto_msgTypes[1].OneofWrappers = []any{
 		(*JobEvent_JobProps)(nil),

--- a/gen/go/proto/resources/notifications/events/events.pb.sanitizer.go
+++ b/gen/go/proto/resources/notifications/events/events.pb.sanitizer.go
@@ -54,18 +54,18 @@ func (m *UserEvent) Sanitize() error {
 		return nil
 	}
 
-	// Field: Notification
+	// Field: AccountGroupsChanged
 	switch v := m.Data.(type) {
 
-	case *UserEvent_Notification:
+	case *UserEvent_AccountGroupsChanged:
 		if v, ok := any(v).(interface{ Sanitize() error }); ok {
 			if err := v.Sanitize(); err != nil {
 				return err
 			}
 		}
 
-		// Field: UserGroupsChanged
-	case *UserEvent_UserGroupsChanged:
+		// Field: Notification
+	case *UserEvent_Notification:
 		if v, ok := any(v).(interface{ Sanitize() error }); ok {
 			if err := v.Sanitize(); err != nil {
 				return err

--- a/gen/go/proto/resources/notifications/events/events.pb.sanitizer.go
+++ b/gen/go/proto/resources/notifications/events/events.pb.sanitizer.go
@@ -64,6 +64,14 @@ func (m *UserEvent) Sanitize() error {
 			}
 		}
 
+		// Field: UserGroupsChanged
+	case *UserEvent_UserGroupsChanged:
+		if v, ok := any(v).(interface{ Sanitize() error }); ok {
+			if err := v.Sanitize(); err != nil {
+				return err
+			}
+		}
+
 		// Field: UserInfoChanged
 	case *UserEvent_UserInfoChanged:
 		if v, ok := any(v).(interface{ Sanitize() error }); ok {

--- a/gen/go/proto/resources/notifications/events/events_protoopaque.pb.go
+++ b/gen/go/proto/resources/notifications/events/events_protoopaque.pb.go
@@ -95,6 +95,15 @@ func (x *UserEvent) GetUserInfoChanged() *userinfo.UserInfoChanged {
 	return nil
 }
 
+func (x *UserEvent) GetUserGroupsChanged() *userinfo.UserGroupsChanged {
+	if x != nil {
+		if x, ok := x.xxx_hidden_Data.(*userEvent_UserGroupsChanged); ok {
+			return x.UserGroupsChanged
+		}
+	}
+	return nil
+}
+
 func (x *UserEvent) SetRefreshToken(v bool) {
 	x.xxx_hidden_Data = &userEvent_RefreshToken{v}
 }
@@ -117,6 +126,14 @@ func (x *UserEvent) SetUserInfoChanged(v *userinfo.UserInfoChanged) {
 		return
 	}
 	x.xxx_hidden_Data = &userEvent_UserInfoChanged{v}
+}
+
+func (x *UserEvent) SetUserGroupsChanged(v *userinfo.UserGroupsChanged) {
+	if v == nil {
+		x.xxx_hidden_Data = nil
+		return
+	}
+	x.xxx_hidden_Data = &userEvent_UserGroupsChanged{v}
 }
 
 func (x *UserEvent) HasData() bool {
@@ -158,6 +175,14 @@ func (x *UserEvent) HasUserInfoChanged() bool {
 	return ok
 }
 
+func (x *UserEvent) HasUserGroupsChanged() bool {
+	if x == nil {
+		return false
+	}
+	_, ok := x.xxx_hidden_Data.(*userEvent_UserGroupsChanged)
+	return ok
+}
+
 func (x *UserEvent) ClearData() {
 	x.xxx_hidden_Data = nil
 }
@@ -186,11 +211,18 @@ func (x *UserEvent) ClearUserInfoChanged() {
 	}
 }
 
+func (x *UserEvent) ClearUserGroupsChanged() {
+	if _, ok := x.xxx_hidden_Data.(*userEvent_UserGroupsChanged); ok {
+		x.xxx_hidden_Data = nil
+	}
+}
+
 const UserEvent_Data_not_set_case case_UserEvent_Data = 0
 const UserEvent_RefreshToken_case case_UserEvent_Data = 1
 const UserEvent_Notification_case case_UserEvent_Data = 2
 const UserEvent_NotificationsReadCount_case case_UserEvent_Data = 3
 const UserEvent_UserInfoChanged_case case_UserEvent_Data = 4
+const UserEvent_UserGroupsChanged_case case_UserEvent_Data = 5
 
 func (x *UserEvent) WhichData() case_UserEvent_Data {
 	if x == nil {
@@ -205,6 +237,8 @@ func (x *UserEvent) WhichData() case_UserEvent_Data {
 		return UserEvent_NotificationsReadCount_case
 	case *userEvent_UserInfoChanged:
 		return UserEvent_UserInfoChanged_case
+	case *userEvent_UserGroupsChanged:
+		return UserEvent_UserGroupsChanged_case
 	default:
 		return UserEvent_Data_not_set_case
 	}
@@ -219,6 +253,7 @@ type UserEvent_builder struct {
 	Notification           *notifications.Notification
 	NotificationsReadCount *int64
 	UserInfoChanged        *userinfo.UserInfoChanged
+	UserGroupsChanged      *userinfo.UserGroupsChanged
 	// -- end of xxx_hidden_Data
 }
 
@@ -237,6 +272,9 @@ func (b0 UserEvent_builder) Build() *UserEvent {
 	}
 	if b.UserInfoChanged != nil {
 		x.xxx_hidden_Data = &userEvent_UserInfoChanged{b.UserInfoChanged}
+	}
+	if b.UserGroupsChanged != nil {
+		x.xxx_hidden_Data = &userEvent_UserGroupsChanged{b.UserGroupsChanged}
 	}
 	return m0
 }
@@ -272,6 +310,10 @@ type userEvent_UserInfoChanged struct {
 	UserInfoChanged *userinfo.UserInfoChanged `protobuf:"bytes,4,opt,name=user_info_changed,json=userInfoChanged,proto3,oneof"`
 }
 
+type userEvent_UserGroupsChanged struct {
+	UserGroupsChanged *userinfo.UserGroupsChanged `protobuf:"bytes,5,opt,name=user_groups_changed,json=userGroupsChanged,proto3,oneof"`
+}
+
 func (*userEvent_RefreshToken) isUserEvent_Data() {}
 
 func (*userEvent_Notification) isUserEvent_Data() {}
@@ -279,6 +321,8 @@ func (*userEvent_Notification) isUserEvent_Data() {}
 func (*userEvent_NotificationsReadCount) isUserEvent_Data() {}
 
 func (*userEvent_UserInfoChanged) isUserEvent_Data() {}
+
+func (*userEvent_UserGroupsChanged) isUserEvent_Data() {}
 
 // Job related events
 type JobEvent struct {
@@ -666,12 +710,13 @@ var File_resources_notifications_events_events_proto protoreflect.FileDescriptor
 
 const file_resources_notifications_events_events_proto_rawDesc = "" +
 	"\n" +
-	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\x96\x02\n" +
+	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\xef\x02\n" +
 	"\tUserEvent\x12%\n" +
 	"\rrefresh_token\x18\x01 \x01(\bH\x00R\frefreshToken\x12K\n" +
 	"\fnotification\x18\x02 \x01(\v2%.resources.notifications.NotificationH\x00R\fnotification\x12:\n" +
 	"\x18notifications_read_count\x18\x03 \x01(\x03H\x00R\x16notificationsReadCount\x12Q\n" +
-	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChangedB\x06\n" +
+	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChanged\x12W\n" +
+	"\x13user_groups_changed\x18\x05 \x01(\v2%.resources.userinfo.UserGroupsChangedH\x00R\x11userGroupsChangedB\x06\n" +
 	"\x04data\"Q\n" +
 	"\bJobEvent\x12=\n" +
 	"\tjob_props\x18\x01 \x01(\v2\x1e.resources.jobs.props.JobPropsH\x00R\bjobPropsB\x06\n" +
@@ -691,19 +736,21 @@ var file_resources_notifications_events_events_proto_goTypes = []any{
 	(*SystemEvent)(nil),                // 3: resources.notifications.events.SystemEvent
 	(*notifications.Notification)(nil), // 4: resources.notifications.Notification
 	(*userinfo.UserInfoChanged)(nil),   // 5: resources.userinfo.UserInfoChanged
-	(*props.JobProps)(nil),             // 6: resources.jobs.props.JobProps
-	(*clientconfig.ClientConfig)(nil),  // 7: resources.clientconfig.ClientConfig
+	(*userinfo.UserGroupsChanged)(nil), // 6: resources.userinfo.UserGroupsChanged
+	(*props.JobProps)(nil),             // 7: resources.jobs.props.JobProps
+	(*clientconfig.ClientConfig)(nil),  // 8: resources.clientconfig.ClientConfig
 }
 var file_resources_notifications_events_events_proto_depIdxs = []int32{
 	4, // 0: resources.notifications.events.UserEvent.notification:type_name -> resources.notifications.Notification
 	5, // 1: resources.notifications.events.UserEvent.user_info_changed:type_name -> resources.userinfo.UserInfoChanged
-	6, // 2: resources.notifications.events.JobEvent.job_props:type_name -> resources.jobs.props.JobProps
-	7, // 3: resources.notifications.events.SystemEvent.client_config:type_name -> resources.clientconfig.ClientConfig
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	6, // 2: resources.notifications.events.UserEvent.user_groups_changed:type_name -> resources.userinfo.UserGroupsChanged
+	7, // 3: resources.notifications.events.JobEvent.job_props:type_name -> resources.jobs.props.JobProps
+	8, // 4: resources.notifications.events.SystemEvent.client_config:type_name -> resources.clientconfig.ClientConfig
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_resources_notifications_events_events_proto_init() }
@@ -716,6 +763,7 @@ func file_resources_notifications_events_events_proto_init() {
 		(*userEvent_Notification)(nil),
 		(*userEvent_NotificationsReadCount)(nil),
 		(*userEvent_UserInfoChanged)(nil),
+		(*userEvent_UserGroupsChanged)(nil),
 	}
 	file_resources_notifications_events_events_proto_msgTypes[1].OneofWrappers = []any{
 		(*jobEvent_JobProps)(nil),

--- a/gen/go/proto/resources/notifications/events/events_protoopaque.pb.go
+++ b/gen/go/proto/resources/notifications/events/events_protoopaque.pb.go
@@ -95,10 +95,10 @@ func (x *UserEvent) GetUserInfoChanged() *userinfo.UserInfoChanged {
 	return nil
 }
 
-func (x *UserEvent) GetUserGroupsChanged() *userinfo.UserGroupsChanged {
+func (x *UserEvent) GetAccountGroupsChanged() *userinfo.AccountGroupsChanged {
 	if x != nil {
-		if x, ok := x.xxx_hidden_Data.(*userEvent_UserGroupsChanged); ok {
-			return x.UserGroupsChanged
+		if x, ok := x.xxx_hidden_Data.(*userEvent_AccountGroupsChanged); ok {
+			return x.AccountGroupsChanged
 		}
 	}
 	return nil
@@ -128,12 +128,12 @@ func (x *UserEvent) SetUserInfoChanged(v *userinfo.UserInfoChanged) {
 	x.xxx_hidden_Data = &userEvent_UserInfoChanged{v}
 }
 
-func (x *UserEvent) SetUserGroupsChanged(v *userinfo.UserGroupsChanged) {
+func (x *UserEvent) SetAccountGroupsChanged(v *userinfo.AccountGroupsChanged) {
 	if v == nil {
 		x.xxx_hidden_Data = nil
 		return
 	}
-	x.xxx_hidden_Data = &userEvent_UserGroupsChanged{v}
+	x.xxx_hidden_Data = &userEvent_AccountGroupsChanged{v}
 }
 
 func (x *UserEvent) HasData() bool {
@@ -175,11 +175,11 @@ func (x *UserEvent) HasUserInfoChanged() bool {
 	return ok
 }
 
-func (x *UserEvent) HasUserGroupsChanged() bool {
+func (x *UserEvent) HasAccountGroupsChanged() bool {
 	if x == nil {
 		return false
 	}
-	_, ok := x.xxx_hidden_Data.(*userEvent_UserGroupsChanged)
+	_, ok := x.xxx_hidden_Data.(*userEvent_AccountGroupsChanged)
 	return ok
 }
 
@@ -211,8 +211,8 @@ func (x *UserEvent) ClearUserInfoChanged() {
 	}
 }
 
-func (x *UserEvent) ClearUserGroupsChanged() {
-	if _, ok := x.xxx_hidden_Data.(*userEvent_UserGroupsChanged); ok {
+func (x *UserEvent) ClearAccountGroupsChanged() {
+	if _, ok := x.xxx_hidden_Data.(*userEvent_AccountGroupsChanged); ok {
 		x.xxx_hidden_Data = nil
 	}
 }
@@ -222,7 +222,7 @@ const UserEvent_RefreshToken_case case_UserEvent_Data = 1
 const UserEvent_Notification_case case_UserEvent_Data = 2
 const UserEvent_NotificationsReadCount_case case_UserEvent_Data = 3
 const UserEvent_UserInfoChanged_case case_UserEvent_Data = 4
-const UserEvent_UserGroupsChanged_case case_UserEvent_Data = 5
+const UserEvent_AccountGroupsChanged_case case_UserEvent_Data = 5
 
 func (x *UserEvent) WhichData() case_UserEvent_Data {
 	if x == nil {
@@ -237,8 +237,8 @@ func (x *UserEvent) WhichData() case_UserEvent_Data {
 		return UserEvent_NotificationsReadCount_case
 	case *userEvent_UserInfoChanged:
 		return UserEvent_UserInfoChanged_case
-	case *userEvent_UserGroupsChanged:
-		return UserEvent_UserGroupsChanged_case
+	case *userEvent_AccountGroupsChanged:
+		return UserEvent_AccountGroupsChanged_case
 	default:
 		return UserEvent_Data_not_set_case
 	}
@@ -253,7 +253,7 @@ type UserEvent_builder struct {
 	Notification           *notifications.Notification
 	NotificationsReadCount *int64
 	UserInfoChanged        *userinfo.UserInfoChanged
-	UserGroupsChanged      *userinfo.UserGroupsChanged
+	AccountGroupsChanged   *userinfo.AccountGroupsChanged
 	// -- end of xxx_hidden_Data
 }
 
@@ -273,8 +273,8 @@ func (b0 UserEvent_builder) Build() *UserEvent {
 	if b.UserInfoChanged != nil {
 		x.xxx_hidden_Data = &userEvent_UserInfoChanged{b.UserInfoChanged}
 	}
-	if b.UserGroupsChanged != nil {
-		x.xxx_hidden_Data = &userEvent_UserGroupsChanged{b.UserGroupsChanged}
+	if b.AccountGroupsChanged != nil {
+		x.xxx_hidden_Data = &userEvent_AccountGroupsChanged{b.AccountGroupsChanged}
 	}
 	return m0
 }
@@ -310,8 +310,8 @@ type userEvent_UserInfoChanged struct {
 	UserInfoChanged *userinfo.UserInfoChanged `protobuf:"bytes,4,opt,name=user_info_changed,json=userInfoChanged,proto3,oneof"`
 }
 
-type userEvent_UserGroupsChanged struct {
-	UserGroupsChanged *userinfo.UserGroupsChanged `protobuf:"bytes,5,opt,name=user_groups_changed,json=userGroupsChanged,proto3,oneof"`
+type userEvent_AccountGroupsChanged struct {
+	AccountGroupsChanged *userinfo.AccountGroupsChanged `protobuf:"bytes,5,opt,name=account_groups_changed,json=accountGroupsChanged,proto3,oneof"`
 }
 
 func (*userEvent_RefreshToken) isUserEvent_Data() {}
@@ -322,7 +322,7 @@ func (*userEvent_NotificationsReadCount) isUserEvent_Data() {}
 
 func (*userEvent_UserInfoChanged) isUserEvent_Data() {}
 
-func (*userEvent_UserGroupsChanged) isUserEvent_Data() {}
+func (*userEvent_AccountGroupsChanged) isUserEvent_Data() {}
 
 // Job related events
 type JobEvent struct {
@@ -710,13 +710,13 @@ var File_resources_notifications_events_events_proto protoreflect.FileDescriptor
 
 const file_resources_notifications_events_events_proto_rawDesc = "" +
 	"\n" +
-	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\xef\x02\n" +
+	"+resources/notifications/events/events.proto\x12\x1eresources.notifications.events\x1a)resources/clientconfig/clientconfig.proto\x1a resources/jobs/props/props.proto\x1a+resources/notifications/notifications.proto\x1a!resources/userinfo/userinfo.proto\"\xf8\x02\n" +
 	"\tUserEvent\x12%\n" +
 	"\rrefresh_token\x18\x01 \x01(\bH\x00R\frefreshToken\x12K\n" +
 	"\fnotification\x18\x02 \x01(\v2%.resources.notifications.NotificationH\x00R\fnotification\x12:\n" +
 	"\x18notifications_read_count\x18\x03 \x01(\x03H\x00R\x16notificationsReadCount\x12Q\n" +
-	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChanged\x12W\n" +
-	"\x13user_groups_changed\x18\x05 \x01(\v2%.resources.userinfo.UserGroupsChangedH\x00R\x11userGroupsChangedB\x06\n" +
+	"\x11user_info_changed\x18\x04 \x01(\v2#.resources.userinfo.UserInfoChangedH\x00R\x0fuserInfoChanged\x12`\n" +
+	"\x16account_groups_changed\x18\x05 \x01(\v2(.resources.userinfo.AccountGroupsChangedH\x00R\x14accountGroupsChangedB\x06\n" +
 	"\x04data\"Q\n" +
 	"\bJobEvent\x12=\n" +
 	"\tjob_props\x18\x01 \x01(\v2\x1e.resources.jobs.props.JobPropsH\x00R\bjobPropsB\x06\n" +
@@ -730,20 +730,20 @@ const file_resources_notifications_events_events_proto_rawDesc = "" +
 
 var file_resources_notifications_events_events_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_resources_notifications_events_events_proto_goTypes = []any{
-	(*UserEvent)(nil),                  // 0: resources.notifications.events.UserEvent
-	(*JobEvent)(nil),                   // 1: resources.notifications.events.JobEvent
-	(*JobGradeEvent)(nil),              // 2: resources.notifications.events.JobGradeEvent
-	(*SystemEvent)(nil),                // 3: resources.notifications.events.SystemEvent
-	(*notifications.Notification)(nil), // 4: resources.notifications.Notification
-	(*userinfo.UserInfoChanged)(nil),   // 5: resources.userinfo.UserInfoChanged
-	(*userinfo.UserGroupsChanged)(nil), // 6: resources.userinfo.UserGroupsChanged
-	(*props.JobProps)(nil),             // 7: resources.jobs.props.JobProps
-	(*clientconfig.ClientConfig)(nil),  // 8: resources.clientconfig.ClientConfig
+	(*UserEvent)(nil),                     // 0: resources.notifications.events.UserEvent
+	(*JobEvent)(nil),                      // 1: resources.notifications.events.JobEvent
+	(*JobGradeEvent)(nil),                 // 2: resources.notifications.events.JobGradeEvent
+	(*SystemEvent)(nil),                   // 3: resources.notifications.events.SystemEvent
+	(*notifications.Notification)(nil),    // 4: resources.notifications.Notification
+	(*userinfo.UserInfoChanged)(nil),      // 5: resources.userinfo.UserInfoChanged
+	(*userinfo.AccountGroupsChanged)(nil), // 6: resources.userinfo.AccountGroupsChanged
+	(*props.JobProps)(nil),                // 7: resources.jobs.props.JobProps
+	(*clientconfig.ClientConfig)(nil),     // 8: resources.clientconfig.ClientConfig
 }
 var file_resources_notifications_events_events_proto_depIdxs = []int32{
 	4, // 0: resources.notifications.events.UserEvent.notification:type_name -> resources.notifications.Notification
 	5, // 1: resources.notifications.events.UserEvent.user_info_changed:type_name -> resources.userinfo.UserInfoChanged
-	6, // 2: resources.notifications.events.UserEvent.user_groups_changed:type_name -> resources.userinfo.UserGroupsChanged
+	6, // 2: resources.notifications.events.UserEvent.account_groups_changed:type_name -> resources.userinfo.AccountGroupsChanged
 	7, // 3: resources.notifications.events.JobEvent.job_props:type_name -> resources.jobs.props.JobProps
 	8, // 4: resources.notifications.events.SystemEvent.client_config:type_name -> resources.clientconfig.ClientConfig
 	5, // [5:5] is the sub-list for method output_type
@@ -763,7 +763,7 @@ func file_resources_notifications_events_events_proto_init() {
 		(*userEvent_Notification)(nil),
 		(*userEvent_NotificationsReadCount)(nil),
 		(*userEvent_UserInfoChanged)(nil),
-		(*userEvent_UserGroupsChanged)(nil),
+		(*userEvent_AccountGroupsChanged)(nil),
 	}
 	file_resources_notifications_events_events_proto_msgTypes[1].OneofWrappers = []any{
 		(*jobEvent_JobProps)(nil),

--- a/gen/go/proto/resources/userinfo/userinfo.pb.go
+++ b/gen/go/proto/resources/userinfo/userinfo.pb.go
@@ -305,7 +305,7 @@ func (b0 PollReq_builder) Build() *PollReq {
 	return m0
 }
 
-// UserInfoChanged used to signal Job or JobGrade changes.
+// UserInfoChanged used to signal live primary job or job grade changes.
 type UserInfoChanged struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// The account the user belongs to
@@ -314,23 +314,15 @@ type UserInfoChanged struct {
 	UserId int32 `protobuf:"varint,2,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
 	// Timestamp of when the change was detected
 	ChangedAt *timestamp.Timestamp `protobuf:"bytes,3,opt,name=changed_at,json=changedAt,proto3" json:"changed_at,omitempty"`
-	// Previous job title
-	OldJob string `protobuf:"bytes,4,opt,name=old_job,json=oldJob,proto3" json:"old_job,omitempty"`
 	// New job title
 	NewJob      *string `protobuf:"bytes,5,opt,name=new_job,json=newJob,proto3,oneof" json:"new_job,omitempty"`
 	NewJobLabel *string `protobuf:"bytes,6,opt,name=new_job_label,json=newJobLabel,proto3,oneof" json:"new_job_label,omitempty"`
-	// Previous job grade
-	OldJobGrade int32 `protobuf:"varint,7,opt,name=old_job_grade,json=oldJobGrade,proto3" json:"old_job_grade,omitempty"`
 	// New job grade
 	NewJobGrade *int32 `protobuf:"varint,8,opt,name=new_job_grade,json=newJobGrade,proto3,oneof" json:"new_job_grade,omitempty"`
 	// New job grade label
 	NewJobGradeLabel *string `protobuf:"bytes,9,opt,name=new_job_grade_label,json=newJobGradeLabel,proto3,oneof" json:"new_job_grade_label,omitempty"`
-	// Can the user be superuser (by group or license)
-	CanBeSuperuser *bool `protobuf:"varint,10,opt,name=can_be_superuser,json=canBeSuperuser,proto3,oneof" json:"can_be_superuser,omitempty"`
-	// Superuser state
-	Superuser     *bool `protobuf:"varint,11,opt,name=superuser,proto3,oneof" json:"superuser,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *UserInfoChanged) Reset() {
@@ -379,13 +371,6 @@ func (x *UserInfoChanged) GetChangedAt() *timestamp.Timestamp {
 	return nil
 }
 
-func (x *UserInfoChanged) GetOldJob() string {
-	if x != nil {
-		return x.OldJob
-	}
-	return ""
-}
-
 func (x *UserInfoChanged) GetNewJob() string {
 	if x != nil && x.NewJob != nil {
 		return *x.NewJob
@@ -398,13 +383,6 @@ func (x *UserInfoChanged) GetNewJobLabel() string {
 		return *x.NewJobLabel
 	}
 	return ""
-}
-
-func (x *UserInfoChanged) GetOldJobGrade() int32 {
-	if x != nil {
-		return x.OldJobGrade
-	}
-	return 0
 }
 
 func (x *UserInfoChanged) GetNewJobGrade() int32 {
@@ -421,20 +399,6 @@ func (x *UserInfoChanged) GetNewJobGradeLabel() string {
 	return ""
 }
 
-func (x *UserInfoChanged) GetCanBeSuperuser() bool {
-	if x != nil && x.CanBeSuperuser != nil {
-		return *x.CanBeSuperuser
-	}
-	return false
-}
-
-func (x *UserInfoChanged) GetSuperuser() bool {
-	if x != nil && x.Superuser != nil {
-		return *x.Superuser
-	}
-	return false
-}
-
 func (x *UserInfoChanged) SetAccountId(v int64) {
 	x.AccountId = v
 }
@@ -447,10 +411,6 @@ func (x *UserInfoChanged) SetChangedAt(v *timestamp.Timestamp) {
 	x.ChangedAt = v
 }
 
-func (x *UserInfoChanged) SetOldJob(v string) {
-	x.OldJob = v
-}
-
 func (x *UserInfoChanged) SetNewJob(v string) {
 	x.NewJob = &v
 }
@@ -459,24 +419,12 @@ func (x *UserInfoChanged) SetNewJobLabel(v string) {
 	x.NewJobLabel = &v
 }
 
-func (x *UserInfoChanged) SetOldJobGrade(v int32) {
-	x.OldJobGrade = v
-}
-
 func (x *UserInfoChanged) SetNewJobGrade(v int32) {
 	x.NewJobGrade = &v
 }
 
 func (x *UserInfoChanged) SetNewJobGradeLabel(v string) {
 	x.NewJobGradeLabel = &v
-}
-
-func (x *UserInfoChanged) SetCanBeSuperuser(v bool) {
-	x.CanBeSuperuser = &v
-}
-
-func (x *UserInfoChanged) SetSuperuser(v bool) {
-	x.Superuser = &v
 }
 
 func (x *UserInfoChanged) HasChangedAt() bool {
@@ -514,20 +462,6 @@ func (x *UserInfoChanged) HasNewJobGradeLabel() bool {
 	return x.NewJobGradeLabel != nil
 }
 
-func (x *UserInfoChanged) HasCanBeSuperuser() bool {
-	if x == nil {
-		return false
-	}
-	return x.CanBeSuperuser != nil
-}
-
-func (x *UserInfoChanged) HasSuperuser() bool {
-	if x == nil {
-		return false
-	}
-	return x.Superuser != nil
-}
-
 func (x *UserInfoChanged) ClearChangedAt() {
 	x.ChangedAt = nil
 }
@@ -548,14 +482,6 @@ func (x *UserInfoChanged) ClearNewJobGradeLabel() {
 	x.NewJobGradeLabel = nil
 }
 
-func (x *UserInfoChanged) ClearCanBeSuperuser() {
-	x.CanBeSuperuser = nil
-}
-
-func (x *UserInfoChanged) ClearSuperuser() {
-	x.Superuser = nil
-}
-
 type UserInfoChanged_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
@@ -565,21 +491,13 @@ type UserInfoChanged_builder struct {
 	UserId int32
 	// Timestamp of when the change was detected
 	ChangedAt *timestamp.Timestamp
-	// Previous job title
-	OldJob string
 	// New job title
 	NewJob      *string
 	NewJobLabel *string
-	// Previous job grade
-	OldJobGrade int32
 	// New job grade
 	NewJobGrade *int32
 	// New job grade label
 	NewJobGradeLabel *string
-	// Can the user be superuser (by group or license)
-	CanBeSuperuser *bool
-	// Superuser state
-	Superuser *bool
 }
 
 func (b0 UserInfoChanged_builder) Build() *UserInfoChanged {
@@ -589,14 +507,140 @@ func (b0 UserInfoChanged_builder) Build() *UserInfoChanged {
 	x.AccountId = b.AccountId
 	x.UserId = b.UserId
 	x.ChangedAt = b.ChangedAt
-	x.OldJob = b.OldJob
 	x.NewJob = b.NewJob
 	x.NewJobLabel = b.NewJobLabel
-	x.OldJobGrade = b.OldJobGrade
 	x.NewJobGrade = b.NewJobGrade
 	x.NewJobGradeLabel = b.NewJobGradeLabel
+	return m0
+}
+
+// UserGroupsChanged used to signal live account group changes.
+type UserGroupsChanged struct {
+	state protoimpl.MessageState `protogen:"hybrid.v1"`
+	// The account the user belongs to
+	AccountId int64 `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	// Timestamp of when the change was detected
+	ChangedAt *timestamp.Timestamp `protobuf:"bytes,2,opt,name=changed_at,json=changedAt,proto3" json:"changed_at,omitempty"`
+	// New account groups
+	NewGroups *accounts.AccountGroups `protobuf:"bytes,3,opt,name=new_groups,json=newGroups,proto3" json:"new_groups,omitempty"`
+	// Whether the account can enter superuser mode after the change
+	CanBeSuperuser bool `protobuf:"varint,4,opt,name=can_be_superuser,json=canBeSuperuser,proto3" json:"can_be_superuser,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *UserGroupsChanged) Reset() {
+	*x = UserGroupsChanged{}
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserGroupsChanged) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserGroupsChanged) ProtoMessage() {}
+
+func (x *UserGroupsChanged) ProtoReflect() protoreflect.Message {
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *UserGroupsChanged) GetAccountId() int64 {
+	if x != nil {
+		return x.AccountId
+	}
+	return 0
+}
+
+func (x *UserGroupsChanged) GetChangedAt() *timestamp.Timestamp {
+	if x != nil {
+		return x.ChangedAt
+	}
+	return nil
+}
+
+func (x *UserGroupsChanged) GetNewGroups() *accounts.AccountGroups {
+	if x != nil {
+		return x.NewGroups
+	}
+	return nil
+}
+
+func (x *UserGroupsChanged) GetCanBeSuperuser() bool {
+	if x != nil {
+		return x.CanBeSuperuser
+	}
+	return false
+}
+
+func (x *UserGroupsChanged) SetAccountId(v int64) {
+	x.AccountId = v
+}
+
+func (x *UserGroupsChanged) SetChangedAt(v *timestamp.Timestamp) {
+	x.ChangedAt = v
+}
+
+func (x *UserGroupsChanged) SetNewGroups(v *accounts.AccountGroups) {
+	x.NewGroups = v
+}
+
+func (x *UserGroupsChanged) SetCanBeSuperuser(v bool) {
+	x.CanBeSuperuser = v
+}
+
+func (x *UserGroupsChanged) HasChangedAt() bool {
+	if x == nil {
+		return false
+	}
+	return x.ChangedAt != nil
+}
+
+func (x *UserGroupsChanged) HasNewGroups() bool {
+	if x == nil {
+		return false
+	}
+	return x.NewGroups != nil
+}
+
+func (x *UserGroupsChanged) ClearChangedAt() {
+	x.ChangedAt = nil
+}
+
+func (x *UserGroupsChanged) ClearNewGroups() {
+	x.NewGroups = nil
+}
+
+type UserGroupsChanged_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The account the user belongs to
+	AccountId int64
+	// Timestamp of when the change was detected
+	ChangedAt *timestamp.Timestamp
+	// New account groups
+	NewGroups *accounts.AccountGroups
+	// Whether the account can enter superuser mode after the change
+	CanBeSuperuser bool
+}
+
+func (b0 UserGroupsChanged_builder) Build() *UserGroupsChanged {
+	m0 := &UserGroupsChanged{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.AccountId = b.AccountId
+	x.ChangedAt = b.ChangedAt
+	x.NewGroups = b.NewGroups
 	x.CanBeSuperuser = b.CanBeSuperuser
-	x.Superuser = b.Superuser
 	return m0
 }
 
@@ -624,47 +668,50 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\aPollReq\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x17\n" +
-	"\auser_id\x18\x02 \x01(\x05R\x06userId\"\xa6\x04\n" +
+	"\auser_id\x18\x02 \x01(\x05R\x06userId\"\xf4\x02\n" +
 	"\x0fUserInfoChanged\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x17\n" +
 	"\auser_id\x18\x02 \x01(\x05R\x06userId\x12=\n" +
 	"\n" +
-	"changed_at\x18\x03 \x01(\v2\x1e.resources.timestamp.TimestampR\tchangedAt\x12\x17\n" +
-	"\aold_job\x18\x04 \x01(\tR\x06oldJob\x12\x1c\n" +
+	"changed_at\x18\x03 \x01(\v2\x1e.resources.timestamp.TimestampR\tchangedAt\x12\x1c\n" +
 	"\anew_job\x18\x05 \x01(\tH\x00R\x06newJob\x88\x01\x01\x12'\n" +
-	"\rnew_job_label\x18\x06 \x01(\tH\x01R\vnewJobLabel\x88\x01\x01\x12\"\n" +
-	"\rold_job_grade\x18\a \x01(\x05R\voldJobGrade\x12'\n" +
+	"\rnew_job_label\x18\x06 \x01(\tH\x01R\vnewJobLabel\x88\x01\x01\x12'\n" +
 	"\rnew_job_grade\x18\b \x01(\x05H\x02R\vnewJobGrade\x88\x01\x01\x122\n" +
-	"\x13new_job_grade_label\x18\t \x01(\tH\x03R\x10newJobGradeLabel\x88\x01\x01\x12-\n" +
-	"\x10can_be_superuser\x18\n" +
-	" \x01(\bH\x04R\x0ecanBeSuperuser\x88\x01\x01\x12!\n" +
-	"\tsuperuser\x18\v \x01(\bH\x05R\tsuperuser\x88\x01\x01B\n" +
+	"\x13new_job_grade_label\x18\t \x01(\tH\x03R\x10newJobGradeLabel\x88\x01\x01B\n" +
 	"\n" +
 	"\b_new_jobB\x10\n" +
 	"\x0e_new_job_labelB\x10\n" +
 	"\x0e_new_job_gradeB\x16\n" +
-	"\x14_new_job_grade_labelB\x13\n" +
-	"\x11_can_be_superuserB\f\n" +
+	"\x14_new_job_grade_label\"\xdd\x01\n" +
+	"\x11UserGroupsChanged\x12\x1d\n" +
 	"\n" +
-	"_superuserBOZMgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo;userinfob\x06proto3"
+	"account_id\x18\x01 \x01(\x03R\taccountId\x12=\n" +
+	"\n" +
+	"changed_at\x18\x02 \x01(\v2\x1e.resources.timestamp.TimestampR\tchangedAt\x12@\n" +
+	"\n" +
+	"new_groups\x18\x03 \x01(\v2!.resources.accounts.AccountGroupsR\tnewGroups\x12(\n" +
+	"\x10can_be_superuser\x18\x04 \x01(\bR\x0ecanBeSuperuserBOZMgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo;userinfob\x06proto3"
 
-var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_resources_userinfo_userinfo_proto_goTypes = []any{
 	(*UserInfo)(nil),               // 0: resources.userinfo.UserInfo
 	(*PollReq)(nil),                // 1: resources.userinfo.PollReq
 	(*UserInfoChanged)(nil),        // 2: resources.userinfo.UserInfoChanged
-	(*accounts.AccountGroups)(nil), // 3: resources.accounts.AccountGroups
-	(*timestamp.Timestamp)(nil),    // 4: resources.timestamp.Timestamp
+	(*UserGroupsChanged)(nil),      // 3: resources.userinfo.UserGroupsChanged
+	(*accounts.AccountGroups)(nil), // 4: resources.accounts.AccountGroups
+	(*timestamp.Timestamp)(nil),    // 5: resources.timestamp.Timestamp
 }
 var file_resources_userinfo_userinfo_proto_depIdxs = []int32{
-	3, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
-	4, // 1: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	4, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
+	5, // 1: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	5, // 2: resources.userinfo.UserGroupsChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	4, // 3: resources.userinfo.UserGroupsChanged.new_groups:type_name -> resources.accounts.AccountGroups
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_resources_userinfo_userinfo_proto_init() }
@@ -680,7 +727,7 @@ func file_resources_userinfo_userinfo_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resources_userinfo_userinfo_proto_rawDesc), len(file_resources_userinfo_userinfo_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/go/proto/resources/userinfo/userinfo.pb.go
+++ b/gen/go/proto/resources/userinfo/userinfo.pb.go
@@ -36,6 +36,7 @@ type UserInfo struct {
 	Groups         *accounts.AccountGroups `protobuf:"bytes,8,opt,name=groups,proto3,oneof" json:"groups,omitempty"`
 	CanBeSuperuser bool                    `protobuf:"varint,9,opt,name=can_be_superuser,json=canBeSuperuser,proto3" json:"can_be_superuser,omitempty"`
 	Superuser      bool                    `protobuf:"varint,10,opt,name=superuser,proto3" json:"superuser,omitempty"`
+	OriginalJob    *OriginalJob            `protobuf:"bytes,11,opt,name=original_job,json=originalJob,proto3,oneof" json:"original_job,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -135,6 +136,13 @@ func (x *UserInfo) GetSuperuser() bool {
 	return false
 }
 
+func (x *UserInfo) GetOriginalJob() *OriginalJob {
+	if x != nil {
+		return x.OriginalJob
+	}
+	return nil
+}
+
 func (x *UserInfo) SetAccountId(v int64) {
 	x.AccountId = v
 }
@@ -175,6 +183,10 @@ func (x *UserInfo) SetSuperuser(v bool) {
 	x.Superuser = v
 }
 
+func (x *UserInfo) SetOriginalJob(v *OriginalJob) {
+	x.OriginalJob = v
+}
+
 func (x *UserInfo) HasLastChar() bool {
 	if x == nil {
 		return false
@@ -189,12 +201,23 @@ func (x *UserInfo) HasGroups() bool {
 	return x.Groups != nil
 }
 
+func (x *UserInfo) HasOriginalJob() bool {
+	if x == nil {
+		return false
+	}
+	return x.OriginalJob != nil
+}
+
 func (x *UserInfo) ClearLastChar() {
 	x.LastChar = nil
 }
 
 func (x *UserInfo) ClearGroups() {
 	x.Groups = nil
+}
+
+func (x *UserInfo) ClearOriginalJob() {
+	x.OriginalJob = nil
 }
 
 type UserInfo_builder struct {
@@ -210,6 +233,7 @@ type UserInfo_builder struct {
 	Groups         *accounts.AccountGroups
 	CanBeSuperuser bool
 	Superuser      bool
+	OriginalJob    *OriginalJob
 }
 
 func (b0 UserInfo_builder) Build() *UserInfo {
@@ -226,6 +250,78 @@ func (b0 UserInfo_builder) Build() *UserInfo {
 	x.Groups = b.Groups
 	x.CanBeSuperuser = b.CanBeSuperuser
 	x.Superuser = b.Superuser
+	x.OriginalJob = b.OriginalJob
+	return m0
+}
+
+type OriginalJob struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	Job           string                 `protobuf:"bytes,1,opt,name=job,proto3" json:"job,omitempty"`
+	JobGrade      int32                  `protobuf:"varint,2,opt,name=job_grade,json=jobGrade,proto3" json:"job_grade,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *OriginalJob) Reset() {
+	*x = OriginalJob{}
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OriginalJob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OriginalJob) ProtoMessage() {}
+
+func (x *OriginalJob) ProtoReflect() protoreflect.Message {
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OriginalJob) GetJob() string {
+	if x != nil {
+		return x.Job
+	}
+	return ""
+}
+
+func (x *OriginalJob) GetJobGrade() int32 {
+	if x != nil {
+		return x.JobGrade
+	}
+	return 0
+}
+
+func (x *OriginalJob) SetJob(v string) {
+	x.Job = v
+}
+
+func (x *OriginalJob) SetJobGrade(v int32) {
+	x.JobGrade = v
+}
+
+type OriginalJob_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Job      string
+	JobGrade int32
+}
+
+func (b0 OriginalJob_builder) Build() *OriginalJob {
+	m0 := &OriginalJob{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.Job = b.Job
+	x.JobGrade = b.JobGrade
 	return m0
 }
 
@@ -242,7 +338,7 @@ type PollReq struct {
 
 func (x *PollReq) Reset() {
 	*x = PollReq{}
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -254,7 +350,7 @@ func (x *PollReq) String() string {
 func (*PollReq) ProtoMessage() {}
 
 func (x *PollReq) ProtoReflect() protoreflect.Message {
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -327,7 +423,7 @@ type UserInfoChanged struct {
 
 func (x *UserInfoChanged) Reset() {
 	*x = UserInfoChanged{}
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -339,7 +435,7 @@ func (x *UserInfoChanged) String() string {
 func (*UserInfoChanged) ProtoMessage() {}
 
 func (x *UserInfoChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -514,8 +610,8 @@ func (b0 UserInfoChanged_builder) Build() *UserInfoChanged {
 	return m0
 }
 
-// UserGroupsChanged used to signal live account group changes.
-type UserGroupsChanged struct {
+// AccountGroupsChanged used to signal live account group changes.
+type AccountGroupsChanged struct {
 	state protoimpl.MessageState `protogen:"hybrid.v1"`
 	// The account the user belongs to
 	AccountId int64 `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
@@ -529,21 +625,21 @@ type UserGroupsChanged struct {
 	sizeCache      protoimpl.SizeCache
 }
 
-func (x *UserGroupsChanged) Reset() {
-	*x = UserGroupsChanged{}
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+func (x *AccountGroupsChanged) Reset() {
+	*x = AccountGroupsChanged{}
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *UserGroupsChanged) String() string {
+func (x *AccountGroupsChanged) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*UserGroupsChanged) ProtoMessage() {}
+func (*AccountGroupsChanged) ProtoMessage() {}
 
-func (x *UserGroupsChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+func (x *AccountGroupsChanged) ProtoReflect() protoreflect.Message {
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -554,73 +650,73 @@ func (x *UserGroupsChanged) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *UserGroupsChanged) GetAccountId() int64 {
+func (x *AccountGroupsChanged) GetAccountId() int64 {
 	if x != nil {
 		return x.AccountId
 	}
 	return 0
 }
 
-func (x *UserGroupsChanged) GetChangedAt() *timestamp.Timestamp {
+func (x *AccountGroupsChanged) GetChangedAt() *timestamp.Timestamp {
 	if x != nil {
 		return x.ChangedAt
 	}
 	return nil
 }
 
-func (x *UserGroupsChanged) GetNewGroups() *accounts.AccountGroups {
+func (x *AccountGroupsChanged) GetNewGroups() *accounts.AccountGroups {
 	if x != nil {
 		return x.NewGroups
 	}
 	return nil
 }
 
-func (x *UserGroupsChanged) GetCanBeSuperuser() bool {
+func (x *AccountGroupsChanged) GetCanBeSuperuser() bool {
 	if x != nil {
 		return x.CanBeSuperuser
 	}
 	return false
 }
 
-func (x *UserGroupsChanged) SetAccountId(v int64) {
+func (x *AccountGroupsChanged) SetAccountId(v int64) {
 	x.AccountId = v
 }
 
-func (x *UserGroupsChanged) SetChangedAt(v *timestamp.Timestamp) {
+func (x *AccountGroupsChanged) SetChangedAt(v *timestamp.Timestamp) {
 	x.ChangedAt = v
 }
 
-func (x *UserGroupsChanged) SetNewGroups(v *accounts.AccountGroups) {
+func (x *AccountGroupsChanged) SetNewGroups(v *accounts.AccountGroups) {
 	x.NewGroups = v
 }
 
-func (x *UserGroupsChanged) SetCanBeSuperuser(v bool) {
+func (x *AccountGroupsChanged) SetCanBeSuperuser(v bool) {
 	x.CanBeSuperuser = v
 }
 
-func (x *UserGroupsChanged) HasChangedAt() bool {
+func (x *AccountGroupsChanged) HasChangedAt() bool {
 	if x == nil {
 		return false
 	}
 	return x.ChangedAt != nil
 }
 
-func (x *UserGroupsChanged) HasNewGroups() bool {
+func (x *AccountGroupsChanged) HasNewGroups() bool {
 	if x == nil {
 		return false
 	}
 	return x.NewGroups != nil
 }
 
-func (x *UserGroupsChanged) ClearChangedAt() {
+func (x *AccountGroupsChanged) ClearChangedAt() {
 	x.ChangedAt = nil
 }
 
-func (x *UserGroupsChanged) ClearNewGroups() {
+func (x *AccountGroupsChanged) ClearNewGroups() {
 	x.NewGroups = nil
 }
 
-type UserGroupsChanged_builder struct {
+type AccountGroupsChanged_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// The account the user belongs to
@@ -633,8 +729,8 @@ type UserGroupsChanged_builder struct {
 	CanBeSuperuser bool
 }
 
-func (b0 UserGroupsChanged_builder) Build() *UserGroupsChanged {
-	m0 := &UserGroupsChanged{}
+func (b0 AccountGroupsChanged_builder) Build() *AccountGroupsChanged {
+	m0 := &AccountGroupsChanged{}
 	b, x := &b0, m0
 	_, _ = b, x
 	x.AccountId = b.AccountId
@@ -648,7 +744,7 @@ var File_resources_userinfo_userinfo_proto protoreflect.FileDescriptor
 
 const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\n" +
-	"!resources/userinfo/userinfo.proto\x12\x12resources.userinfo\x1a!resources/accounts/accounts.proto\x1a#resources/timestamp/timestamp.proto\"\xe8\x02\n" +
+	"!resources/userinfo/userinfo.proto\x12\x12resources.userinfo\x1a!resources/accounts/accounts.proto\x1a#resources/timestamp/timestamp.proto\"\xc2\x03\n" +
 	"\bUserInfo\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x18\n" +
@@ -661,10 +757,15 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\x06groups\x18\b \x01(\v2!.resources.accounts.AccountGroupsH\x01R\x06groups\x88\x01\x01\x12(\n" +
 	"\x10can_be_superuser\x18\t \x01(\bR\x0ecanBeSuperuser\x12\x1c\n" +
 	"\tsuperuser\x18\n" +
-	" \x01(\bR\tsuperuserB\f\n" +
+	" \x01(\bR\tsuperuser\x12G\n" +
+	"\foriginal_job\x18\v \x01(\v2\x1f.resources.userinfo.OriginalJobH\x02R\voriginalJob\x88\x01\x01B\f\n" +
 	"\n" +
 	"_last_charB\t\n" +
-	"\a_groups\"A\n" +
+	"\a_groupsB\x0f\n" +
+	"\r_original_job\"<\n" +
+	"\vOriginalJob\x12\x10\n" +
+	"\x03job\x18\x01 \x01(\tR\x03job\x12\x1b\n" +
+	"\tjob_grade\x18\x02 \x01(\x05R\bjobGrade\"A\n" +
 	"\aPollReq\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x17\n" +
@@ -683,8 +784,8 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\b_new_jobB\x10\n" +
 	"\x0e_new_job_labelB\x10\n" +
 	"\x0e_new_job_gradeB\x16\n" +
-	"\x14_new_job_grade_label\"\xdd\x01\n" +
-	"\x11UserGroupsChanged\x12\x1d\n" +
+	"\x14_new_job_grade_label\"\xe0\x01\n" +
+	"\x14AccountGroupsChanged\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12=\n" +
 	"\n" +
@@ -693,25 +794,27 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"new_groups\x18\x03 \x01(\v2!.resources.accounts.AccountGroupsR\tnewGroups\x12(\n" +
 	"\x10can_be_superuser\x18\x04 \x01(\bR\x0ecanBeSuperuserBOZMgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo;userinfob\x06proto3"
 
-var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_resources_userinfo_userinfo_proto_goTypes = []any{
 	(*UserInfo)(nil),               // 0: resources.userinfo.UserInfo
-	(*PollReq)(nil),                // 1: resources.userinfo.PollReq
-	(*UserInfoChanged)(nil),        // 2: resources.userinfo.UserInfoChanged
-	(*UserGroupsChanged)(nil),      // 3: resources.userinfo.UserGroupsChanged
-	(*accounts.AccountGroups)(nil), // 4: resources.accounts.AccountGroups
-	(*timestamp.Timestamp)(nil),    // 5: resources.timestamp.Timestamp
+	(*OriginalJob)(nil),            // 1: resources.userinfo.OriginalJob
+	(*PollReq)(nil),                // 2: resources.userinfo.PollReq
+	(*UserInfoChanged)(nil),        // 3: resources.userinfo.UserInfoChanged
+	(*AccountGroupsChanged)(nil),   // 4: resources.userinfo.AccountGroupsChanged
+	(*accounts.AccountGroups)(nil), // 5: resources.accounts.AccountGroups
+	(*timestamp.Timestamp)(nil),    // 6: resources.timestamp.Timestamp
 }
 var file_resources_userinfo_userinfo_proto_depIdxs = []int32{
-	4, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
-	5, // 1: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
-	5, // 2: resources.userinfo.UserGroupsChanged.changed_at:type_name -> resources.timestamp.Timestamp
-	4, // 3: resources.userinfo.UserGroupsChanged.new_groups:type_name -> resources.accounts.AccountGroups
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
+	1, // 1: resources.userinfo.UserInfo.original_job:type_name -> resources.userinfo.OriginalJob
+	6, // 2: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	6, // 3: resources.userinfo.AccountGroupsChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	5, // 4: resources.userinfo.AccountGroupsChanged.new_groups:type_name -> resources.accounts.AccountGroups
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_resources_userinfo_userinfo_proto_init() }
@@ -720,14 +823,14 @@ func file_resources_userinfo_userinfo_proto_init() {
 		return
 	}
 	file_resources_userinfo_userinfo_proto_msgTypes[0].OneofWrappers = []any{}
-	file_resources_userinfo_userinfo_proto_msgTypes[2].OneofWrappers = []any{}
+	file_resources_userinfo_userinfo_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resources_userinfo_userinfo_proto_rawDesc), len(file_resources_userinfo_userinfo_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/go/proto/resources/userinfo/userinfo.pb.sanitizer.go
+++ b/gen/go/proto/resources/userinfo/userinfo.pb.sanitizer.go
@@ -9,6 +9,34 @@ import (
 
 // Sanitize sanitizes the message's fields, in case of complex types it calls
 // their Sanitize() method recursively.
+func (m *UserGroupsChanged) Sanitize() error {
+	if m == nil {
+		return nil
+	}
+
+	// Field: ChangedAt
+	if m.ChangedAt != nil {
+		if v, ok := any(m.GetChangedAt()).(interface{ Sanitize() error }); ok {
+			if err := v.Sanitize(); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Field: NewGroups
+	if m.NewGroups != nil {
+		if v, ok := any(m.GetNewGroups()).(interface{ Sanitize() error }); ok {
+			if err := v.Sanitize(); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Sanitize sanitizes the message's fields, in case of complex types it calls
+// their Sanitize() method recursively.
 func (m *UserInfo) Sanitize() error {
 	if m == nil {
 		return nil
@@ -62,9 +90,6 @@ func (m *UserInfoChanged) Sanitize() error {
 	if m.NewJobLabel != nil {
 		*m.NewJobLabel = htmlsanitizer.SanitizeAndUnescape(*m.NewJobLabel)
 	}
-
-	// Field: OldJob
-	m.OldJob = htmlsanitizer.SanitizeAndUnescape(m.OldJob)
 
 	return nil
 }

--- a/gen/go/proto/resources/userinfo/userinfo.pb.sanitizer.go
+++ b/gen/go/proto/resources/userinfo/userinfo.pb.sanitizer.go
@@ -9,7 +9,7 @@ import (
 
 // Sanitize sanitizes the message's fields, in case of complex types it calls
 // their Sanitize() method recursively.
-func (m *UserGroupsChanged) Sanitize() error {
+func (m *AccountGroupsChanged) Sanitize() error {
 	if m == nil {
 		return nil
 	}
@@ -37,6 +37,19 @@ func (m *UserGroupsChanged) Sanitize() error {
 
 // Sanitize sanitizes the message's fields, in case of complex types it calls
 // their Sanitize() method recursively.
+func (m *OriginalJob) Sanitize() error {
+	if m == nil {
+		return nil
+	}
+
+	// Field: Job
+	m.Job = htmlsanitizer.SanitizeAndUnescape(m.Job)
+
+	return nil
+}
+
+// Sanitize sanitizes the message's fields, in case of complex types it calls
+// their Sanitize() method recursively.
 func (m *UserInfo) Sanitize() error {
 	if m == nil {
 		return nil
@@ -56,6 +69,15 @@ func (m *UserInfo) Sanitize() error {
 
 	// Field: License
 	m.License = htmlsanitizer.SanitizeAndUnescape(m.License)
+
+	// Field: OriginalJob
+	if m.OriginalJob != nil {
+		if v, ok := any(m.GetOriginalJob()).(interface{ Sanitize() error }); ok {
+			if err := v.Sanitize(); err != nil {
+				return err
+			}
+		}
+	}
 
 	return nil
 }

--- a/gen/go/proto/resources/userinfo/userinfo_protoopaque.pb.go
+++ b/gen/go/proto/resources/userinfo/userinfo_protoopaque.pb.go
@@ -310,20 +310,16 @@ func (b0 PollReq_builder) Build() *PollReq {
 	return m0
 }
 
-// UserInfoChanged used to signal Job or JobGrade changes.
+// UserInfoChanged used to signal live primary job or job grade changes.
 type UserInfoChanged struct {
 	state                       protoimpl.MessageState `protogen:"opaque.v1"`
 	xxx_hidden_AccountId        int64                  `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3"`
 	xxx_hidden_UserId           int32                  `protobuf:"varint,2,opt,name=user_id,json=userId,proto3"`
 	xxx_hidden_ChangedAt        *timestamp.Timestamp   `protobuf:"bytes,3,opt,name=changed_at,json=changedAt,proto3"`
-	xxx_hidden_OldJob           string                 `protobuf:"bytes,4,opt,name=old_job,json=oldJob,proto3"`
 	xxx_hidden_NewJob           *string                `protobuf:"bytes,5,opt,name=new_job,json=newJob,proto3,oneof"`
 	xxx_hidden_NewJobLabel      *string                `protobuf:"bytes,6,opt,name=new_job_label,json=newJobLabel,proto3,oneof"`
-	xxx_hidden_OldJobGrade      int32                  `protobuf:"varint,7,opt,name=old_job_grade,json=oldJobGrade,proto3"`
 	xxx_hidden_NewJobGrade      int32                  `protobuf:"varint,8,opt,name=new_job_grade,json=newJobGrade,proto3,oneof"`
 	xxx_hidden_NewJobGradeLabel *string                `protobuf:"bytes,9,opt,name=new_job_grade_label,json=newJobGradeLabel,proto3,oneof"`
-	xxx_hidden_CanBeSuperuser   bool                   `protobuf:"varint,10,opt,name=can_be_superuser,json=canBeSuperuser,proto3,oneof"`
-	xxx_hidden_Superuser        bool                   `protobuf:"varint,11,opt,name=superuser,proto3,oneof"`
 	XXX_raceDetectHookData      protoimpl.RaceDetectHookData
 	XXX_presence                [1]uint32
 	unknownFields               protoimpl.UnknownFields
@@ -376,13 +372,6 @@ func (x *UserInfoChanged) GetChangedAt() *timestamp.Timestamp {
 	return nil
 }
 
-func (x *UserInfoChanged) GetOldJob() string {
-	if x != nil {
-		return x.xxx_hidden_OldJob
-	}
-	return ""
-}
-
 func (x *UserInfoChanged) GetNewJob() string {
 	if x != nil {
 		if x.xxx_hidden_NewJob != nil {
@@ -403,13 +392,6 @@ func (x *UserInfoChanged) GetNewJobLabel() string {
 	return ""
 }
 
-func (x *UserInfoChanged) GetOldJobGrade() int32 {
-	if x != nil {
-		return x.xxx_hidden_OldJobGrade
-	}
-	return 0
-}
-
 func (x *UserInfoChanged) GetNewJobGrade() int32 {
 	if x != nil {
 		return x.xxx_hidden_NewJobGrade
@@ -427,20 +409,6 @@ func (x *UserInfoChanged) GetNewJobGradeLabel() string {
 	return ""
 }
 
-func (x *UserInfoChanged) GetCanBeSuperuser() bool {
-	if x != nil {
-		return x.xxx_hidden_CanBeSuperuser
-	}
-	return false
-}
-
-func (x *UserInfoChanged) GetSuperuser() bool {
-	if x != nil {
-		return x.xxx_hidden_Superuser
-	}
-	return false
-}
-
 func (x *UserInfoChanged) SetAccountId(v int64) {
 	x.xxx_hidden_AccountId = v
 }
@@ -453,42 +421,24 @@ func (x *UserInfoChanged) SetChangedAt(v *timestamp.Timestamp) {
 	x.xxx_hidden_ChangedAt = v
 }
 
-func (x *UserInfoChanged) SetOldJob(v string) {
-	x.xxx_hidden_OldJob = v
-}
-
 func (x *UserInfoChanged) SetNewJob(v string) {
 	x.xxx_hidden_NewJob = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 11)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 7)
 }
 
 func (x *UserInfoChanged) SetNewJobLabel(v string) {
 	x.xxx_hidden_NewJobLabel = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 11)
-}
-
-func (x *UserInfoChanged) SetOldJobGrade(v int32) {
-	x.xxx_hidden_OldJobGrade = v
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 4, 7)
 }
 
 func (x *UserInfoChanged) SetNewJobGrade(v int32) {
 	x.xxx_hidden_NewJobGrade = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 7, 11)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 5, 7)
 }
 
 func (x *UserInfoChanged) SetNewJobGradeLabel(v string) {
 	x.xxx_hidden_NewJobGradeLabel = &v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 8, 11)
-}
-
-func (x *UserInfoChanged) SetCanBeSuperuser(v bool) {
-	x.xxx_hidden_CanBeSuperuser = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 9, 11)
-}
-
-func (x *UserInfoChanged) SetSuperuser(v bool) {
-	x.xxx_hidden_Superuser = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 10, 11)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 6, 7)
 }
 
 func (x *UserInfoChanged) HasChangedAt() bool {
@@ -502,42 +452,28 @@ func (x *UserInfoChanged) HasNewJob() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 4)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 3)
 }
 
 func (x *UserInfoChanged) HasNewJobLabel() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 4)
 }
 
 func (x *UserInfoChanged) HasNewJobGrade() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 7)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 5)
 }
 
 func (x *UserInfoChanged) HasNewJobGradeLabel() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 8)
-}
-
-func (x *UserInfoChanged) HasCanBeSuperuser() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 9)
-}
-
-func (x *UserInfoChanged) HasSuperuser() bool {
-	if x == nil {
-		return false
-	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 10)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 6)
 }
 
 func (x *UserInfoChanged) ClearChangedAt() {
@@ -545,33 +481,23 @@ func (x *UserInfoChanged) ClearChangedAt() {
 }
 
 func (x *UserInfoChanged) ClearNewJob() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 4)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 3)
 	x.xxx_hidden_NewJob = nil
 }
 
 func (x *UserInfoChanged) ClearNewJobLabel() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 5)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 4)
 	x.xxx_hidden_NewJobLabel = nil
 }
 
 func (x *UserInfoChanged) ClearNewJobGrade() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 7)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 5)
 	x.xxx_hidden_NewJobGrade = 0
 }
 
 func (x *UserInfoChanged) ClearNewJobGradeLabel() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 8)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 6)
 	x.xxx_hidden_NewJobGradeLabel = nil
-}
-
-func (x *UserInfoChanged) ClearCanBeSuperuser() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 9)
-	x.xxx_hidden_CanBeSuperuser = false
-}
-
-func (x *UserInfoChanged) ClearSuperuser() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 10)
-	x.xxx_hidden_Superuser = false
 }
 
 type UserInfoChanged_builder struct {
@@ -583,21 +509,13 @@ type UserInfoChanged_builder struct {
 	UserId int32
 	// Timestamp of when the change was detected
 	ChangedAt *timestamp.Timestamp
-	// Previous job title
-	OldJob string
 	// New job title
 	NewJob      *string
 	NewJobLabel *string
-	// Previous job grade
-	OldJobGrade int32
 	// New job grade
 	NewJobGrade *int32
 	// New job grade label
 	NewJobGradeLabel *string
-	// Can the user be superuser (by group or license)
-	CanBeSuperuser *bool
-	// Superuser state
-	Superuser *bool
 }
 
 func (b0 UserInfoChanged_builder) Build() *UserInfoChanged {
@@ -607,32 +525,148 @@ func (b0 UserInfoChanged_builder) Build() *UserInfoChanged {
 	x.xxx_hidden_AccountId = b.AccountId
 	x.xxx_hidden_UserId = b.UserId
 	x.xxx_hidden_ChangedAt = b.ChangedAt
-	x.xxx_hidden_OldJob = b.OldJob
 	if b.NewJob != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 11)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 7)
 		x.xxx_hidden_NewJob = b.NewJob
 	}
 	if b.NewJobLabel != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 11)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 4, 7)
 		x.xxx_hidden_NewJobLabel = b.NewJobLabel
 	}
-	x.xxx_hidden_OldJobGrade = b.OldJobGrade
 	if b.NewJobGrade != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 7, 11)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 5, 7)
 		x.xxx_hidden_NewJobGrade = *b.NewJobGrade
 	}
 	if b.NewJobGradeLabel != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 8, 11)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 6, 7)
 		x.xxx_hidden_NewJobGradeLabel = b.NewJobGradeLabel
 	}
-	if b.CanBeSuperuser != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 9, 11)
-		x.xxx_hidden_CanBeSuperuser = *b.CanBeSuperuser
+	return m0
+}
+
+// UserGroupsChanged used to signal live account group changes.
+type UserGroupsChanged struct {
+	state                     protoimpl.MessageState  `protogen:"opaque.v1"`
+	xxx_hidden_AccountId      int64                   `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3"`
+	xxx_hidden_ChangedAt      *timestamp.Timestamp    `protobuf:"bytes,2,opt,name=changed_at,json=changedAt,proto3"`
+	xxx_hidden_NewGroups      *accounts.AccountGroups `protobuf:"bytes,3,opt,name=new_groups,json=newGroups,proto3"`
+	xxx_hidden_CanBeSuperuser bool                    `protobuf:"varint,4,opt,name=can_be_superuser,json=canBeSuperuser,proto3"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *UserGroupsChanged) Reset() {
+	*x = UserGroupsChanged{}
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserGroupsChanged) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserGroupsChanged) ProtoMessage() {}
+
+func (x *UserGroupsChanged) ProtoReflect() protoreflect.Message {
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
 	}
-	if b.Superuser != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 10, 11)
-		x.xxx_hidden_Superuser = *b.Superuser
+	return mi.MessageOf(x)
+}
+
+func (x *UserGroupsChanged) GetAccountId() int64 {
+	if x != nil {
+		return x.xxx_hidden_AccountId
 	}
+	return 0
+}
+
+func (x *UserGroupsChanged) GetChangedAt() *timestamp.Timestamp {
+	if x != nil {
+		return x.xxx_hidden_ChangedAt
+	}
+	return nil
+}
+
+func (x *UserGroupsChanged) GetNewGroups() *accounts.AccountGroups {
+	if x != nil {
+		return x.xxx_hidden_NewGroups
+	}
+	return nil
+}
+
+func (x *UserGroupsChanged) GetCanBeSuperuser() bool {
+	if x != nil {
+		return x.xxx_hidden_CanBeSuperuser
+	}
+	return false
+}
+
+func (x *UserGroupsChanged) SetAccountId(v int64) {
+	x.xxx_hidden_AccountId = v
+}
+
+func (x *UserGroupsChanged) SetChangedAt(v *timestamp.Timestamp) {
+	x.xxx_hidden_ChangedAt = v
+}
+
+func (x *UserGroupsChanged) SetNewGroups(v *accounts.AccountGroups) {
+	x.xxx_hidden_NewGroups = v
+}
+
+func (x *UserGroupsChanged) SetCanBeSuperuser(v bool) {
+	x.xxx_hidden_CanBeSuperuser = v
+}
+
+func (x *UserGroupsChanged) HasChangedAt() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_ChangedAt != nil
+}
+
+func (x *UserGroupsChanged) HasNewGroups() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_NewGroups != nil
+}
+
+func (x *UserGroupsChanged) ClearChangedAt() {
+	x.xxx_hidden_ChangedAt = nil
+}
+
+func (x *UserGroupsChanged) ClearNewGroups() {
+	x.xxx_hidden_NewGroups = nil
+}
+
+type UserGroupsChanged_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	// The account the user belongs to
+	AccountId int64
+	// Timestamp of when the change was detected
+	ChangedAt *timestamp.Timestamp
+	// New account groups
+	NewGroups *accounts.AccountGroups
+	// Whether the account can enter superuser mode after the change
+	CanBeSuperuser bool
+}
+
+func (b0 UserGroupsChanged_builder) Build() *UserGroupsChanged {
+	m0 := &UserGroupsChanged{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_AccountId = b.AccountId
+	x.xxx_hidden_ChangedAt = b.ChangedAt
+	x.xxx_hidden_NewGroups = b.NewGroups
+	x.xxx_hidden_CanBeSuperuser = b.CanBeSuperuser
 	return m0
 }
 
@@ -660,47 +694,50 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\aPollReq\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x17\n" +
-	"\auser_id\x18\x02 \x01(\x05R\x06userId\"\xa6\x04\n" +
+	"\auser_id\x18\x02 \x01(\x05R\x06userId\"\xf4\x02\n" +
 	"\x0fUserInfoChanged\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x17\n" +
 	"\auser_id\x18\x02 \x01(\x05R\x06userId\x12=\n" +
 	"\n" +
-	"changed_at\x18\x03 \x01(\v2\x1e.resources.timestamp.TimestampR\tchangedAt\x12\x17\n" +
-	"\aold_job\x18\x04 \x01(\tR\x06oldJob\x12\x1c\n" +
+	"changed_at\x18\x03 \x01(\v2\x1e.resources.timestamp.TimestampR\tchangedAt\x12\x1c\n" +
 	"\anew_job\x18\x05 \x01(\tH\x00R\x06newJob\x88\x01\x01\x12'\n" +
-	"\rnew_job_label\x18\x06 \x01(\tH\x01R\vnewJobLabel\x88\x01\x01\x12\"\n" +
-	"\rold_job_grade\x18\a \x01(\x05R\voldJobGrade\x12'\n" +
+	"\rnew_job_label\x18\x06 \x01(\tH\x01R\vnewJobLabel\x88\x01\x01\x12'\n" +
 	"\rnew_job_grade\x18\b \x01(\x05H\x02R\vnewJobGrade\x88\x01\x01\x122\n" +
-	"\x13new_job_grade_label\x18\t \x01(\tH\x03R\x10newJobGradeLabel\x88\x01\x01\x12-\n" +
-	"\x10can_be_superuser\x18\n" +
-	" \x01(\bH\x04R\x0ecanBeSuperuser\x88\x01\x01\x12!\n" +
-	"\tsuperuser\x18\v \x01(\bH\x05R\tsuperuser\x88\x01\x01B\n" +
+	"\x13new_job_grade_label\x18\t \x01(\tH\x03R\x10newJobGradeLabel\x88\x01\x01B\n" +
 	"\n" +
 	"\b_new_jobB\x10\n" +
 	"\x0e_new_job_labelB\x10\n" +
 	"\x0e_new_job_gradeB\x16\n" +
-	"\x14_new_job_grade_labelB\x13\n" +
-	"\x11_can_be_superuserB\f\n" +
+	"\x14_new_job_grade_label\"\xdd\x01\n" +
+	"\x11UserGroupsChanged\x12\x1d\n" +
 	"\n" +
-	"_superuserBOZMgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo;userinfob\x06proto3"
+	"account_id\x18\x01 \x01(\x03R\taccountId\x12=\n" +
+	"\n" +
+	"changed_at\x18\x02 \x01(\v2\x1e.resources.timestamp.TimestampR\tchangedAt\x12@\n" +
+	"\n" +
+	"new_groups\x18\x03 \x01(\v2!.resources.accounts.AccountGroupsR\tnewGroups\x12(\n" +
+	"\x10can_be_superuser\x18\x04 \x01(\bR\x0ecanBeSuperuserBOZMgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo;userinfob\x06proto3"
 
-var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
 var file_resources_userinfo_userinfo_proto_goTypes = []any{
 	(*UserInfo)(nil),               // 0: resources.userinfo.UserInfo
 	(*PollReq)(nil),                // 1: resources.userinfo.PollReq
 	(*UserInfoChanged)(nil),        // 2: resources.userinfo.UserInfoChanged
-	(*accounts.AccountGroups)(nil), // 3: resources.accounts.AccountGroups
-	(*timestamp.Timestamp)(nil),    // 4: resources.timestamp.Timestamp
+	(*UserGroupsChanged)(nil),      // 3: resources.userinfo.UserGroupsChanged
+	(*accounts.AccountGroups)(nil), // 4: resources.accounts.AccountGroups
+	(*timestamp.Timestamp)(nil),    // 5: resources.timestamp.Timestamp
 }
 var file_resources_userinfo_userinfo_proto_depIdxs = []int32{
-	3, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
-	4, // 1: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	4, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
+	5, // 1: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	5, // 2: resources.userinfo.UserGroupsChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	4, // 3: resources.userinfo.UserGroupsChanged.new_groups:type_name -> resources.accounts.AccountGroups
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_resources_userinfo_userinfo_proto_init() }
@@ -716,7 +753,7 @@ func file_resources_userinfo_userinfo_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resources_userinfo_userinfo_proto_rawDesc), len(file_resources_userinfo_userinfo_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/go/proto/resources/userinfo/userinfo_protoopaque.pb.go
+++ b/gen/go/proto/resources/userinfo/userinfo_protoopaque.pb.go
@@ -36,6 +36,7 @@ type UserInfo struct {
 	xxx_hidden_Groups         *accounts.AccountGroups `protobuf:"bytes,8,opt,name=groups,proto3,oneof"`
 	xxx_hidden_CanBeSuperuser bool                    `protobuf:"varint,9,opt,name=can_be_superuser,json=canBeSuperuser,proto3"`
 	xxx_hidden_Superuser      bool                    `protobuf:"varint,10,opt,name=superuser,proto3"`
+	xxx_hidden_OriginalJob    *OriginalJob            `protobuf:"bytes,11,opt,name=original_job,json=originalJob,proto3,oneof"`
 	XXX_raceDetectHookData    protoimpl.RaceDetectHookData
 	XXX_presence              [1]uint32
 	unknownFields             protoimpl.UnknownFields
@@ -137,6 +138,13 @@ func (x *UserInfo) GetSuperuser() bool {
 	return false
 }
 
+func (x *UserInfo) GetOriginalJob() *OriginalJob {
+	if x != nil {
+		return x.xxx_hidden_OriginalJob
+	}
+	return nil
+}
+
 func (x *UserInfo) SetAccountId(v int64) {
 	x.xxx_hidden_AccountId = v
 }
@@ -151,7 +159,7 @@ func (x *UserInfo) SetLicense(v string) {
 
 func (x *UserInfo) SetLastChar(v int32) {
 	x.xxx_hidden_LastChar = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 10)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 3, 11)
 }
 
 func (x *UserInfo) SetUserId(v int32) {
@@ -178,6 +186,10 @@ func (x *UserInfo) SetSuperuser(v bool) {
 	x.xxx_hidden_Superuser = v
 }
 
+func (x *UserInfo) SetOriginalJob(v *OriginalJob) {
+	x.xxx_hidden_OriginalJob = v
+}
+
 func (x *UserInfo) HasLastChar() bool {
 	if x == nil {
 		return false
@@ -192,6 +204,13 @@ func (x *UserInfo) HasGroups() bool {
 	return x.xxx_hidden_Groups != nil
 }
 
+func (x *UserInfo) HasOriginalJob() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_OriginalJob != nil
+}
+
 func (x *UserInfo) ClearLastChar() {
 	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 3)
 	x.xxx_hidden_LastChar = 0
@@ -199,6 +218,10 @@ func (x *UserInfo) ClearLastChar() {
 
 func (x *UserInfo) ClearGroups() {
 	x.xxx_hidden_Groups = nil
+}
+
+func (x *UserInfo) ClearOriginalJob() {
+	x.xxx_hidden_OriginalJob = nil
 }
 
 type UserInfo_builder struct {
@@ -214,6 +237,7 @@ type UserInfo_builder struct {
 	Groups         *accounts.AccountGroups
 	CanBeSuperuser bool
 	Superuser      bool
+	OriginalJob    *OriginalJob
 }
 
 func (b0 UserInfo_builder) Build() *UserInfo {
@@ -224,7 +248,7 @@ func (b0 UserInfo_builder) Build() *UserInfo {
 	x.xxx_hidden_Enabled = b.Enabled
 	x.xxx_hidden_License = b.License
 	if b.LastChar != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 10)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 3, 11)
 		x.xxx_hidden_LastChar = *b.LastChar
 	}
 	x.xxx_hidden_UserId = b.UserId
@@ -233,6 +257,78 @@ func (b0 UserInfo_builder) Build() *UserInfo {
 	x.xxx_hidden_Groups = b.Groups
 	x.xxx_hidden_CanBeSuperuser = b.CanBeSuperuser
 	x.xxx_hidden_Superuser = b.Superuser
+	x.xxx_hidden_OriginalJob = b.OriginalJob
+	return m0
+}
+
+type OriginalJob struct {
+	state               protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_Job      string                 `protobuf:"bytes,1,opt,name=job,proto3"`
+	xxx_hidden_JobGrade int32                  `protobuf:"varint,2,opt,name=job_grade,json=jobGrade,proto3"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *OriginalJob) Reset() {
+	*x = OriginalJob{}
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OriginalJob) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OriginalJob) ProtoMessage() {}
+
+func (x *OriginalJob) ProtoReflect() protoreflect.Message {
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+func (x *OriginalJob) GetJob() string {
+	if x != nil {
+		return x.xxx_hidden_Job
+	}
+	return ""
+}
+
+func (x *OriginalJob) GetJobGrade() int32 {
+	if x != nil {
+		return x.xxx_hidden_JobGrade
+	}
+	return 0
+}
+
+func (x *OriginalJob) SetJob(v string) {
+	x.xxx_hidden_Job = v
+}
+
+func (x *OriginalJob) SetJobGrade(v int32) {
+	x.xxx_hidden_JobGrade = v
+}
+
+type OriginalJob_builder struct {
+	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
+
+	Job      string
+	JobGrade int32
+}
+
+func (b0 OriginalJob_builder) Build() *OriginalJob {
+	m0 := &OriginalJob{}
+	b, x := &b0, m0
+	_, _ = b, x
+	x.xxx_hidden_Job = b.Job
+	x.xxx_hidden_JobGrade = b.JobGrade
 	return m0
 }
 
@@ -247,7 +343,7 @@ type PollReq struct {
 
 func (x *PollReq) Reset() {
 	*x = PollReq{}
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -259,7 +355,7 @@ func (x *PollReq) String() string {
 func (*PollReq) ProtoMessage() {}
 
 func (x *PollReq) ProtoReflect() protoreflect.Message {
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[1]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -328,7 +424,7 @@ type UserInfoChanged struct {
 
 func (x *UserInfoChanged) Reset() {
 	*x = UserInfoChanged{}
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -340,7 +436,7 @@ func (x *UserInfoChanged) String() string {
 func (*UserInfoChanged) ProtoMessage() {}
 
 func (x *UserInfoChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[2]
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -544,8 +640,8 @@ func (b0 UserInfoChanged_builder) Build() *UserInfoChanged {
 	return m0
 }
 
-// UserGroupsChanged used to signal live account group changes.
-type UserGroupsChanged struct {
+// AccountGroupsChanged used to signal live account group changes.
+type AccountGroupsChanged struct {
 	state                     protoimpl.MessageState  `protogen:"opaque.v1"`
 	xxx_hidden_AccountId      int64                   `protobuf:"varint,1,opt,name=account_id,json=accountId,proto3"`
 	xxx_hidden_ChangedAt      *timestamp.Timestamp    `protobuf:"bytes,2,opt,name=changed_at,json=changedAt,proto3"`
@@ -555,21 +651,21 @@ type UserGroupsChanged struct {
 	sizeCache                 protoimpl.SizeCache
 }
 
-func (x *UserGroupsChanged) Reset() {
-	*x = UserGroupsChanged{}
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+func (x *AccountGroupsChanged) Reset() {
+	*x = AccountGroupsChanged{}
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *UserGroupsChanged) String() string {
+func (x *AccountGroupsChanged) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*UserGroupsChanged) ProtoMessage() {}
+func (*AccountGroupsChanged) ProtoMessage() {}
 
-func (x *UserGroupsChanged) ProtoReflect() protoreflect.Message {
-	mi := &file_resources_userinfo_userinfo_proto_msgTypes[3]
+func (x *AccountGroupsChanged) ProtoReflect() protoreflect.Message {
+	mi := &file_resources_userinfo_userinfo_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -580,73 +676,73 @@ func (x *UserGroupsChanged) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *UserGroupsChanged) GetAccountId() int64 {
+func (x *AccountGroupsChanged) GetAccountId() int64 {
 	if x != nil {
 		return x.xxx_hidden_AccountId
 	}
 	return 0
 }
 
-func (x *UserGroupsChanged) GetChangedAt() *timestamp.Timestamp {
+func (x *AccountGroupsChanged) GetChangedAt() *timestamp.Timestamp {
 	if x != nil {
 		return x.xxx_hidden_ChangedAt
 	}
 	return nil
 }
 
-func (x *UserGroupsChanged) GetNewGroups() *accounts.AccountGroups {
+func (x *AccountGroupsChanged) GetNewGroups() *accounts.AccountGroups {
 	if x != nil {
 		return x.xxx_hidden_NewGroups
 	}
 	return nil
 }
 
-func (x *UserGroupsChanged) GetCanBeSuperuser() bool {
+func (x *AccountGroupsChanged) GetCanBeSuperuser() bool {
 	if x != nil {
 		return x.xxx_hidden_CanBeSuperuser
 	}
 	return false
 }
 
-func (x *UserGroupsChanged) SetAccountId(v int64) {
+func (x *AccountGroupsChanged) SetAccountId(v int64) {
 	x.xxx_hidden_AccountId = v
 }
 
-func (x *UserGroupsChanged) SetChangedAt(v *timestamp.Timestamp) {
+func (x *AccountGroupsChanged) SetChangedAt(v *timestamp.Timestamp) {
 	x.xxx_hidden_ChangedAt = v
 }
 
-func (x *UserGroupsChanged) SetNewGroups(v *accounts.AccountGroups) {
+func (x *AccountGroupsChanged) SetNewGroups(v *accounts.AccountGroups) {
 	x.xxx_hidden_NewGroups = v
 }
 
-func (x *UserGroupsChanged) SetCanBeSuperuser(v bool) {
+func (x *AccountGroupsChanged) SetCanBeSuperuser(v bool) {
 	x.xxx_hidden_CanBeSuperuser = v
 }
 
-func (x *UserGroupsChanged) HasChangedAt() bool {
+func (x *AccountGroupsChanged) HasChangedAt() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_ChangedAt != nil
 }
 
-func (x *UserGroupsChanged) HasNewGroups() bool {
+func (x *AccountGroupsChanged) HasNewGroups() bool {
 	if x == nil {
 		return false
 	}
 	return x.xxx_hidden_NewGroups != nil
 }
 
-func (x *UserGroupsChanged) ClearChangedAt() {
+func (x *AccountGroupsChanged) ClearChangedAt() {
 	x.xxx_hidden_ChangedAt = nil
 }
 
-func (x *UserGroupsChanged) ClearNewGroups() {
+func (x *AccountGroupsChanged) ClearNewGroups() {
 	x.xxx_hidden_NewGroups = nil
 }
 
-type UserGroupsChanged_builder struct {
+type AccountGroupsChanged_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	// The account the user belongs to
@@ -659,8 +755,8 @@ type UserGroupsChanged_builder struct {
 	CanBeSuperuser bool
 }
 
-func (b0 UserGroupsChanged_builder) Build() *UserGroupsChanged {
-	m0 := &UserGroupsChanged{}
+func (b0 AccountGroupsChanged_builder) Build() *AccountGroupsChanged {
+	m0 := &AccountGroupsChanged{}
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_AccountId = b.AccountId
@@ -674,7 +770,7 @@ var File_resources_userinfo_userinfo_proto protoreflect.FileDescriptor
 
 const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\n" +
-	"!resources/userinfo/userinfo.proto\x12\x12resources.userinfo\x1a!resources/accounts/accounts.proto\x1a#resources/timestamp/timestamp.proto\"\xe8\x02\n" +
+	"!resources/userinfo/userinfo.proto\x12\x12resources.userinfo\x1a!resources/accounts/accounts.proto\x1a#resources/timestamp/timestamp.proto\"\xc2\x03\n" +
 	"\bUserInfo\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x18\n" +
@@ -687,10 +783,15 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\x06groups\x18\b \x01(\v2!.resources.accounts.AccountGroupsH\x01R\x06groups\x88\x01\x01\x12(\n" +
 	"\x10can_be_superuser\x18\t \x01(\bR\x0ecanBeSuperuser\x12\x1c\n" +
 	"\tsuperuser\x18\n" +
-	" \x01(\bR\tsuperuserB\f\n" +
+	" \x01(\bR\tsuperuser\x12G\n" +
+	"\foriginal_job\x18\v \x01(\v2\x1f.resources.userinfo.OriginalJobH\x02R\voriginalJob\x88\x01\x01B\f\n" +
 	"\n" +
 	"_last_charB\t\n" +
-	"\a_groups\"A\n" +
+	"\a_groupsB\x0f\n" +
+	"\r_original_job\"<\n" +
+	"\vOriginalJob\x12\x10\n" +
+	"\x03job\x18\x01 \x01(\tR\x03job\x12\x1b\n" +
+	"\tjob_grade\x18\x02 \x01(\x05R\bjobGrade\"A\n" +
 	"\aPollReq\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12\x17\n" +
@@ -709,8 +810,8 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"\b_new_jobB\x10\n" +
 	"\x0e_new_job_labelB\x10\n" +
 	"\x0e_new_job_gradeB\x16\n" +
-	"\x14_new_job_grade_label\"\xdd\x01\n" +
-	"\x11UserGroupsChanged\x12\x1d\n" +
+	"\x14_new_job_grade_label\"\xe0\x01\n" +
+	"\x14AccountGroupsChanged\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\x03R\taccountId\x12=\n" +
 	"\n" +
@@ -719,25 +820,27 @@ const file_resources_userinfo_userinfo_proto_rawDesc = "" +
 	"new_groups\x18\x03 \x01(\v2!.resources.accounts.AccountGroupsR\tnewGroups\x12(\n" +
 	"\x10can_be_superuser\x18\x04 \x01(\bR\x0ecanBeSuperuserBOZMgithub.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo;userinfob\x06proto3"
 
-var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_resources_userinfo_userinfo_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_resources_userinfo_userinfo_proto_goTypes = []any{
 	(*UserInfo)(nil),               // 0: resources.userinfo.UserInfo
-	(*PollReq)(nil),                // 1: resources.userinfo.PollReq
-	(*UserInfoChanged)(nil),        // 2: resources.userinfo.UserInfoChanged
-	(*UserGroupsChanged)(nil),      // 3: resources.userinfo.UserGroupsChanged
-	(*accounts.AccountGroups)(nil), // 4: resources.accounts.AccountGroups
-	(*timestamp.Timestamp)(nil),    // 5: resources.timestamp.Timestamp
+	(*OriginalJob)(nil),            // 1: resources.userinfo.OriginalJob
+	(*PollReq)(nil),                // 2: resources.userinfo.PollReq
+	(*UserInfoChanged)(nil),        // 3: resources.userinfo.UserInfoChanged
+	(*AccountGroupsChanged)(nil),   // 4: resources.userinfo.AccountGroupsChanged
+	(*accounts.AccountGroups)(nil), // 5: resources.accounts.AccountGroups
+	(*timestamp.Timestamp)(nil),    // 6: resources.timestamp.Timestamp
 }
 var file_resources_userinfo_userinfo_proto_depIdxs = []int32{
-	4, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
-	5, // 1: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
-	5, // 2: resources.userinfo.UserGroupsChanged.changed_at:type_name -> resources.timestamp.Timestamp
-	4, // 3: resources.userinfo.UserGroupsChanged.new_groups:type_name -> resources.accounts.AccountGroups
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	5, // 0: resources.userinfo.UserInfo.groups:type_name -> resources.accounts.AccountGroups
+	1, // 1: resources.userinfo.UserInfo.original_job:type_name -> resources.userinfo.OriginalJob
+	6, // 2: resources.userinfo.UserInfoChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	6, // 3: resources.userinfo.AccountGroupsChanged.changed_at:type_name -> resources.timestamp.Timestamp
+	5, // 4: resources.userinfo.AccountGroupsChanged.new_groups:type_name -> resources.accounts.AccountGroups
+	5, // [5:5] is the sub-list for method output_type
+	5, // [5:5] is the sub-list for method input_type
+	5, // [5:5] is the sub-list for extension type_name
+	5, // [5:5] is the sub-list for extension extendee
+	0, // [0:5] is the sub-list for field type_name
 }
 
 func init() { file_resources_userinfo_userinfo_proto_init() }
@@ -746,14 +849,14 @@ func file_resources_userinfo_userinfo_proto_init() {
 		return
 	}
 	file_resources_userinfo_userinfo_proto_msgTypes[0].OneofWrappers = []any{}
-	file_resources_userinfo_userinfo_proto_msgTypes[2].OneofWrappers = []any{}
+	file_resources_userinfo_userinfo_proto_msgTypes[3].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_resources_userinfo_userinfo_proto_rawDesc), len(file_resources_userinfo_userinfo_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/grpc-api.md
+++ b/gen/grpc-api.md
@@ -5532,22 +5532,8 @@ Policy snapshot applied to a specific version
 ## resources/userinfo/userinfo.proto
 
 
-### resources.userinfo.PollReq
-PollReq: published to `userinfo.poll.request` when an active user connects or requests a refresh.
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| `account_id` | [int64](#int64) |  | The account the user belongs to |
-| `user_id` | [int32](#int32) |  | The unique user identifier within the account |
-
-
-
-
-
-### resources.userinfo.UserGroupsChanged
-UserGroupsChanged used to signal live account group changes.
+### resources.userinfo.AccountGroupsChanged
+AccountGroupsChanged used to signal live account group changes.
 
 
 
@@ -5557,6 +5543,32 @@ UserGroupsChanged used to signal live account group changes.
 | `changed_at` | [resources.timestamp.Timestamp](#resourcestimestampTimestamp) |  | Timestamp of when the change was detected |
 | `new_groups` | [resources.accounts.AccountGroups](#resourcesaccountsAccountGroups) |  | New account groups |
 | `can_be_superuser` | [bool](#bool) |  | Whether the account can enter superuser mode after the change |
+
+
+
+
+
+### resources.userinfo.OriginalJob
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `job` | [string](#string) |  |  |
+| `job_grade` | [int32](#int32) |  |  |
+
+
+
+
+
+### resources.userinfo.PollReq
+PollReq: published to `userinfo.poll.request` when an active user connects or requests a refresh.
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `account_id` | [int64](#int64) |  | The account the user belongs to |
+| `user_id` | [int32](#int32) |  | The unique user identifier within the account |
 
 
 
@@ -5577,6 +5589,7 @@ UserGroupsChanged used to signal live account group changes.
 | `groups` | [resources.accounts.AccountGroups](#resourcesaccountsAccountGroups) | optional |  |
 | `can_be_superuser` | [bool](#bool) |  |  |
 | `superuser` | [bool](#bool) |  |  |
+| `original_job` | [OriginalJob](#resourcesuserinfoOriginalJob) | optional |  |
 
 
 
@@ -5663,7 +5676,7 @@ User related events
 | `notification` | [resources.notifications.Notification](#resourcesnotificationsNotification) |  | Notifications |
 | `notifications_read_count` | [int64](#int64) |  |  |
 | `user_info_changed` | [resources.userinfo.UserInfoChanged](#resourcesuserinfoUserInfoChanged) |  |  |
-| `user_groups_changed` | [resources.userinfo.UserGroupsChanged](#resourcesuserinfoUserGroupsChanged) |  |  |
+| `account_groups_changed` | [resources.userinfo.AccountGroupsChanged](#resourcesuserinfoAccountGroupsChanged) |  |  |
 
 
 

--- a/gen/grpc-api.md
+++ b/gen/grpc-api.md
@@ -5546,6 +5546,22 @@ PollReq: published to `userinfo.poll.request` when an active user connects or re
 
 
 
+### resources.userinfo.UserGroupsChanged
+UserGroupsChanged used to signal live account group changes.
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `account_id` | [int64](#int64) |  | The account the user belongs to |
+| `changed_at` | [resources.timestamp.Timestamp](#resourcestimestampTimestamp) |  | Timestamp of when the change was detected |
+| `new_groups` | [resources.accounts.AccountGroups](#resourcesaccountsAccountGroups) |  | New account groups |
+| `can_be_superuser` | [bool](#bool) |  | Whether the account can enter superuser mode after the change |
+
+
+
+
+
 ### resources.userinfo.UserInfo
 
 
@@ -5567,7 +5583,7 @@ PollReq: published to `userinfo.poll.request` when an active user connects or re
 
 
 ### resources.userinfo.UserInfoChanged
-UserInfoChanged used to signal Job or JobGrade changes.
+UserInfoChanged used to signal live primary job or job grade changes.
 
 
 
@@ -5576,14 +5592,10 @@ UserInfoChanged used to signal Job or JobGrade changes.
 | `account_id` | [int64](#int64) |  | The account the user belongs to |
 | `user_id` | [int32](#int32) |  | The unique user identifier within the account |
 | `changed_at` | [resources.timestamp.Timestamp](#resourcestimestampTimestamp) |  | Timestamp of when the change was detected |
-| `old_job` | [string](#string) |  | Previous job title |
 | `new_job` | [string](#string) | optional | New job title |
 | `new_job_label` | [string](#string) | optional |  |
-| `old_job_grade` | [int32](#int32) |  | Previous job grade |
 | `new_job_grade` | [int32](#int32) | optional | New job grade |
 | `new_job_grade_label` | [string](#string) | optional | New job grade label |
-| `can_be_superuser` | [bool](#bool) | optional | Can the user be superuser (by group or license) |
-| `superuser` | [bool](#bool) | optional | Superuser state |
 
 
 
@@ -5651,6 +5663,7 @@ User related events
 | `notification` | [resources.notifications.Notification](#resourcesnotificationsNotification) |  | Notifications |
 | `notifications_read_count` | [int64](#int64) |  |  |
 | `user_info_changed` | [resources.userinfo.UserInfoChanged](#resourcesuserinfoUserInfoChanged) |  |  |
+| `user_groups_changed` | [resources.userinfo.UserGroupsChanged](#resourcesuserinfoUserGroupsChanged) |  |  |
 
 
 

--- a/gen/ts/resources/notifications/events/events.ts
+++ b/gen/ts/resources/notifications/events/events.ts
@@ -13,6 +13,7 @@ import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
 import { ClientConfig } from "../../clientconfig/clientconfig";
 import { JobProps } from "../../jobs/props/props";
+import { UserGroupsChanged } from "../../userinfo/userinfo";
 import { UserInfoChanged } from "../../userinfo/userinfo";
 import { Notification } from "../notifications";
 /**
@@ -50,6 +51,12 @@ export interface UserEvent {
          * @generated from protobuf field: resources.userinfo.UserInfoChanged user_info_changed = 4
          */
         userInfoChanged: UserInfoChanged;
+    } | {
+        oneofKind: "userGroupsChanged";
+        /**
+         * @generated from protobuf field: resources.userinfo.UserGroupsChanged user_groups_changed = 5
+         */
+        userGroupsChanged: UserGroupsChanged;
     } | {
         oneofKind: undefined;
     };
@@ -120,7 +127,8 @@ class UserEvent$Type extends MessageType<UserEvent> {
             { no: 1, name: "refresh_token", kind: "scalar", oneof: "data", T: 8 /*ScalarType.BOOL*/ },
             { no: 2, name: "notification", kind: "message", oneof: "data", T: () => Notification },
             { no: 3, name: "notifications_read_count", kind: "scalar", oneof: "data", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
-            { no: 4, name: "user_info_changed", kind: "message", oneof: "data", T: () => UserInfoChanged }
+            { no: 4, name: "user_info_changed", kind: "message", oneof: "data", T: () => UserInfoChanged },
+            { no: 5, name: "user_groups_changed", kind: "message", oneof: "data", T: () => UserGroupsChanged }
         ]);
     }
     create(value?: PartialMessage<UserEvent>): UserEvent {
@@ -159,6 +167,12 @@ class UserEvent$Type extends MessageType<UserEvent> {
                         userInfoChanged: UserInfoChanged.internalBinaryRead(reader, reader.uint32(), options, (message.data as any).userInfoChanged)
                     };
                     break;
+                case /* resources.userinfo.UserGroupsChanged user_groups_changed */ 5:
+                    message.data = {
+                        oneofKind: "userGroupsChanged",
+                        userGroupsChanged: UserGroupsChanged.internalBinaryRead(reader, reader.uint32(), options, (message.data as any).userGroupsChanged)
+                    };
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -183,6 +197,9 @@ class UserEvent$Type extends MessageType<UserEvent> {
         /* resources.userinfo.UserInfoChanged user_info_changed = 4; */
         if (message.data.oneofKind === "userInfoChanged")
             UserInfoChanged.internalBinaryWrite(message.data.userInfoChanged, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+        /* resources.userinfo.UserGroupsChanged user_groups_changed = 5; */
+        if (message.data.oneofKind === "userGroupsChanged")
+            UserGroupsChanged.internalBinaryWrite(message.data.userGroupsChanged, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/ts/resources/notifications/events/events.ts
+++ b/gen/ts/resources/notifications/events/events.ts
@@ -13,7 +13,7 @@ import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
 import { ClientConfig } from "../../clientconfig/clientconfig";
 import { JobProps } from "../../jobs/props/props";
-import { UserGroupsChanged } from "../../userinfo/userinfo";
+import { AccountGroupsChanged } from "../../userinfo/userinfo";
 import { UserInfoChanged } from "../../userinfo/userinfo";
 import { Notification } from "../notifications";
 /**
@@ -52,11 +52,11 @@ export interface UserEvent {
          */
         userInfoChanged: UserInfoChanged;
     } | {
-        oneofKind: "userGroupsChanged";
+        oneofKind: "accountGroupsChanged";
         /**
-         * @generated from protobuf field: resources.userinfo.UserGroupsChanged user_groups_changed = 5
+         * @generated from protobuf field: resources.userinfo.AccountGroupsChanged account_groups_changed = 5
          */
-        userGroupsChanged: UserGroupsChanged;
+        accountGroupsChanged: AccountGroupsChanged;
     } | {
         oneofKind: undefined;
     };
@@ -128,7 +128,7 @@ class UserEvent$Type extends MessageType<UserEvent> {
             { no: 2, name: "notification", kind: "message", oneof: "data", T: () => Notification },
             { no: 3, name: "notifications_read_count", kind: "scalar", oneof: "data", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 4, name: "user_info_changed", kind: "message", oneof: "data", T: () => UserInfoChanged },
-            { no: 5, name: "user_groups_changed", kind: "message", oneof: "data", T: () => UserGroupsChanged }
+            { no: 5, name: "account_groups_changed", kind: "message", oneof: "data", T: () => AccountGroupsChanged }
         ]);
     }
     create(value?: PartialMessage<UserEvent>): UserEvent {
@@ -167,10 +167,10 @@ class UserEvent$Type extends MessageType<UserEvent> {
                         userInfoChanged: UserInfoChanged.internalBinaryRead(reader, reader.uint32(), options, (message.data as any).userInfoChanged)
                     };
                     break;
-                case /* resources.userinfo.UserGroupsChanged user_groups_changed */ 5:
+                case /* resources.userinfo.AccountGroupsChanged account_groups_changed */ 5:
                     message.data = {
-                        oneofKind: "userGroupsChanged",
-                        userGroupsChanged: UserGroupsChanged.internalBinaryRead(reader, reader.uint32(), options, (message.data as any).userGroupsChanged)
+                        oneofKind: "accountGroupsChanged",
+                        accountGroupsChanged: AccountGroupsChanged.internalBinaryRead(reader, reader.uint32(), options, (message.data as any).accountGroupsChanged)
                     };
                     break;
                 default:
@@ -197,9 +197,9 @@ class UserEvent$Type extends MessageType<UserEvent> {
         /* resources.userinfo.UserInfoChanged user_info_changed = 4; */
         if (message.data.oneofKind === "userInfoChanged")
             UserInfoChanged.internalBinaryWrite(message.data.userInfoChanged, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
-        /* resources.userinfo.UserGroupsChanged user_groups_changed = 5; */
-        if (message.data.oneofKind === "userGroupsChanged")
-            UserGroupsChanged.internalBinaryWrite(message.data.userGroupsChanged, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
+        /* resources.userinfo.AccountGroupsChanged account_groups_changed = 5; */
+        if (message.data.oneofKind === "accountGroupsChanged")
+            AccountGroupsChanged.internalBinaryWrite(message.data.accountGroupsChanged, writer.tag(5, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/ts/resources/userinfo/userinfo.ts
+++ b/gen/ts/resources/userinfo/userinfo.ts
@@ -78,7 +78,7 @@ export interface PollReq {
     userId: number;
 }
 /**
- * UserInfoChanged used to signal Job or JobGrade changes.
+ * UserInfoChanged used to signal live primary job or job grade changes.
  *
  * @generated from protobuf message resources.userinfo.UserInfoChanged
  */
@@ -102,12 +102,6 @@ export interface UserInfoChanged {
      */
     changedAt?: Timestamp;
     /**
-     * Previous job title
-     *
-     * @generated from protobuf field: string old_job = 4
-     */
-    oldJob: string;
-    /**
      * New job title
      *
      * @generated from protobuf field: optional string new_job = 5
@@ -117,12 +111,6 @@ export interface UserInfoChanged {
      * @generated from protobuf field: optional string new_job_label = 6
      */
     newJobLabel?: string;
-    /**
-     * Previous job grade
-     *
-     * @generated from protobuf field: int32 old_job_grade = 7
-     */
-    oldJobGrade: number;
     /**
      * New job grade
      *
@@ -135,18 +123,37 @@ export interface UserInfoChanged {
      * @generated from protobuf field: optional string new_job_grade_label = 9
      */
     newJobGradeLabel?: string;
+}
+/**
+ * UserGroupsChanged used to signal live account group changes.
+ *
+ * @generated from protobuf message resources.userinfo.UserGroupsChanged
+ */
+export interface UserGroupsChanged {
     /**
-     * Can the user be superuser (by group or license)
+     * The account the user belongs to
      *
-     * @generated from protobuf field: optional bool can_be_superuser = 10
+     * @generated from protobuf field: int64 account_id = 1
      */
-    canBeSuperuser?: boolean;
+    accountId: number;
     /**
-     * Superuser state
+     * Timestamp of when the change was detected
      *
-     * @generated from protobuf field: optional bool superuser = 11
+     * @generated from protobuf field: resources.timestamp.Timestamp changed_at = 2
      */
-    superuser?: boolean;
+    changedAt?: Timestamp;
+    /**
+     * New account groups
+     *
+     * @generated from protobuf field: resources.accounts.AccountGroups new_groups = 3
+     */
+    newGroups?: AccountGroups;
+    /**
+     * Whether the account can enter superuser mode after the change
+     *
+     * @generated from protobuf field: bool can_be_superuser = 4
+     */
+    canBeSuperuser: boolean;
 }
 // @generated message type with reflection information, may provide speed optimized methods
 class UserInfo$Type extends MessageType<UserInfo> {
@@ -327,22 +334,16 @@ class UserInfoChanged$Type extends MessageType<UserInfoChanged> {
             { no: 1, name: "account_id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 2, name: "user_id", kind: "scalar", T: 5 /*ScalarType.INT32*/ },
             { no: 3, name: "changed_at", kind: "message", T: () => Timestamp },
-            { no: 4, name: "old_job", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
             { no: 5, name: "new_job", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
             { no: 6, name: "new_job_label", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
-            { no: 7, name: "old_job_grade", kind: "scalar", T: 5 /*ScalarType.INT32*/ },
             { no: 8, name: "new_job_grade", kind: "scalar", opt: true, T: 5 /*ScalarType.INT32*/ },
-            { no: 9, name: "new_job_grade_label", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ },
-            { no: 10, name: "can_be_superuser", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
-            { no: 11, name: "superuser", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
+            { no: 9, name: "new_job_grade_label", kind: "scalar", opt: true, T: 9 /*ScalarType.STRING*/ }
         ]);
     }
     create(value?: PartialMessage<UserInfoChanged>): UserInfoChanged {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.accountId = 0;
         message.userId = 0;
-        message.oldJob = "";
-        message.oldJobGrade = 0;
         if (value !== undefined)
             reflectionMergePartial<UserInfoChanged>(this, message, value);
         return message;
@@ -361,29 +362,17 @@ class UserInfoChanged$Type extends MessageType<UserInfoChanged> {
                 case /* resources.timestamp.Timestamp changed_at */ 3:
                     message.changedAt = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.changedAt);
                     break;
-                case /* string old_job */ 4:
-                    message.oldJob = reader.string();
-                    break;
                 case /* optional string new_job */ 5:
                     message.newJob = reader.string();
                     break;
                 case /* optional string new_job_label */ 6:
                     message.newJobLabel = reader.string();
                     break;
-                case /* int32 old_job_grade */ 7:
-                    message.oldJobGrade = reader.int32();
-                    break;
                 case /* optional int32 new_job_grade */ 8:
                     message.newJobGrade = reader.int32();
                     break;
                 case /* optional string new_job_grade_label */ 9:
                     message.newJobGradeLabel = reader.string();
-                    break;
-                case /* optional bool can_be_superuser */ 10:
-                    message.canBeSuperuser = reader.bool();
-                    break;
-                case /* optional bool superuser */ 11:
-                    message.superuser = reader.bool();
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -406,30 +395,18 @@ class UserInfoChanged$Type extends MessageType<UserInfoChanged> {
         /* resources.timestamp.Timestamp changed_at = 3; */
         if (message.changedAt)
             Timestamp.internalBinaryWrite(message.changedAt, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
-        /* string old_job = 4; */
-        if (message.oldJob !== "")
-            writer.tag(4, WireType.LengthDelimited).string(message.oldJob);
         /* optional string new_job = 5; */
         if (message.newJob !== undefined)
             writer.tag(5, WireType.LengthDelimited).string(message.newJob);
         /* optional string new_job_label = 6; */
         if (message.newJobLabel !== undefined)
             writer.tag(6, WireType.LengthDelimited).string(message.newJobLabel);
-        /* int32 old_job_grade = 7; */
-        if (message.oldJobGrade !== 0)
-            writer.tag(7, WireType.Varint).int32(message.oldJobGrade);
         /* optional int32 new_job_grade = 8; */
         if (message.newJobGrade !== undefined)
             writer.tag(8, WireType.Varint).int32(message.newJobGrade);
         /* optional string new_job_grade_label = 9; */
         if (message.newJobGradeLabel !== undefined)
             writer.tag(9, WireType.LengthDelimited).string(message.newJobGradeLabel);
-        /* optional bool can_be_superuser = 10; */
-        if (message.canBeSuperuser !== undefined)
-            writer.tag(10, WireType.Varint).bool(message.canBeSuperuser);
-        /* optional bool superuser = 11; */
-        if (message.superuser !== undefined)
-            writer.tag(11, WireType.Varint).bool(message.superuser);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -440,3 +417,72 @@ class UserInfoChanged$Type extends MessageType<UserInfoChanged> {
  * @generated MessageType for protobuf message resources.userinfo.UserInfoChanged
  */
 export const UserInfoChanged = new UserInfoChanged$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class UserGroupsChanged$Type extends MessageType<UserGroupsChanged> {
+    constructor() {
+        super("resources.userinfo.UserGroupsChanged", [
+            { no: 1, name: "account_id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
+            { no: 2, name: "changed_at", kind: "message", T: () => Timestamp },
+            { no: 3, name: "new_groups", kind: "message", T: () => AccountGroups },
+            { no: 4, name: "can_be_superuser", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+        ]);
+    }
+    create(value?: PartialMessage<UserGroupsChanged>): UserGroupsChanged {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.accountId = 0;
+        message.canBeSuperuser = false;
+        if (value !== undefined)
+            reflectionMergePartial<UserGroupsChanged>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UserGroupsChanged): UserGroupsChanged {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* int64 account_id */ 1:
+                    message.accountId = reader.int64().toNumber();
+                    break;
+                case /* resources.timestamp.Timestamp changed_at */ 2:
+                    message.changedAt = Timestamp.internalBinaryRead(reader, reader.uint32(), options, message.changedAt);
+                    break;
+                case /* resources.accounts.AccountGroups new_groups */ 3:
+                    message.newGroups = AccountGroups.internalBinaryRead(reader, reader.uint32(), options, message.newGroups);
+                    break;
+                case /* bool can_be_superuser */ 4:
+                    message.canBeSuperuser = reader.bool();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: UserGroupsChanged, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* int64 account_id = 1; */
+        if (message.accountId !== 0)
+            writer.tag(1, WireType.Varint).int64(message.accountId);
+        /* resources.timestamp.Timestamp changed_at = 2; */
+        if (message.changedAt)
+            Timestamp.internalBinaryWrite(message.changedAt, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
+        /* resources.accounts.AccountGroups new_groups = 3; */
+        if (message.newGroups)
+            AccountGroups.internalBinaryWrite(message.newGroups, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* bool can_be_superuser = 4; */
+        if (message.canBeSuperuser !== false)
+            writer.tag(4, WireType.Varint).bool(message.canBeSuperuser);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message resources.userinfo.UserGroupsChanged
+ */
+export const UserGroupsChanged = new UserGroupsChanged$Type();

--- a/gen/ts/resources/userinfo/userinfo.ts
+++ b/gen/ts/resources/userinfo/userinfo.ts
@@ -57,6 +57,23 @@ export interface UserInfo {
      * @generated from protobuf field: bool superuser = 10
      */
     superuser: boolean;
+    /**
+     * @generated from protobuf field: optional resources.userinfo.OriginalJob original_job = 11
+     */
+    originalJob?: OriginalJob;
+}
+/**
+ * @generated from protobuf message resources.userinfo.OriginalJob
+ */
+export interface OriginalJob {
+    /**
+     * @generated from protobuf field: string job = 1
+     */
+    job: string;
+    /**
+     * @generated from protobuf field: int32 job_grade = 2
+     */
+    jobGrade: number;
 }
 /**
  * PollReq: published to `userinfo.poll.request` when an active user connects or requests a refresh.
@@ -125,11 +142,11 @@ export interface UserInfoChanged {
     newJobGradeLabel?: string;
 }
 /**
- * UserGroupsChanged used to signal live account group changes.
+ * AccountGroupsChanged used to signal live account group changes.
  *
- * @generated from protobuf message resources.userinfo.UserGroupsChanged
+ * @generated from protobuf message resources.userinfo.AccountGroupsChanged
  */
-export interface UserGroupsChanged {
+export interface AccountGroupsChanged {
     /**
      * The account the user belongs to
      *
@@ -168,7 +185,8 @@ class UserInfo$Type extends MessageType<UserInfo> {
             { no: 7, name: "job_grade", kind: "scalar", T: 5 /*ScalarType.INT32*/ },
             { no: 8, name: "groups", kind: "message", T: () => AccountGroups },
             { no: 9, name: "can_be_superuser", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
-            { no: 10, name: "superuser", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
+            { no: 10, name: "superuser", kind: "scalar", T: 8 /*ScalarType.BOOL*/ },
+            { no: 11, name: "original_job", kind: "message", T: () => OriginalJob }
         ]);
     }
     create(value?: PartialMessage<UserInfo>): UserInfo {
@@ -220,6 +238,9 @@ class UserInfo$Type extends MessageType<UserInfo> {
                 case /* bool superuser */ 10:
                     message.superuser = reader.bool();
                     break;
+                case /* optional resources.userinfo.OriginalJob original_job */ 11:
+                    message.originalJob = OriginalJob.internalBinaryRead(reader, reader.uint32(), options, message.originalJob);
+                    break;
                 default:
                     let u = options.readUnknownField;
                     if (u === "throw")
@@ -262,6 +283,9 @@ class UserInfo$Type extends MessageType<UserInfo> {
         /* bool superuser = 10; */
         if (message.superuser !== false)
             writer.tag(10, WireType.Varint).bool(message.superuser);
+        /* optional resources.userinfo.OriginalJob original_job = 11; */
+        if (message.originalJob)
+            OriginalJob.internalBinaryWrite(message.originalJob, writer.tag(11, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -272,6 +296,61 @@ class UserInfo$Type extends MessageType<UserInfo> {
  * @generated MessageType for protobuf message resources.userinfo.UserInfo
  */
 export const UserInfo = new UserInfo$Type();
+// @generated message type with reflection information, may provide speed optimized methods
+class OriginalJob$Type extends MessageType<OriginalJob> {
+    constructor() {
+        super("resources.userinfo.OriginalJob", [
+            { no: 1, name: "job", kind: "scalar", T: 9 /*ScalarType.STRING*/ },
+            { no: 2, name: "job_grade", kind: "scalar", T: 5 /*ScalarType.INT32*/ }
+        ]);
+    }
+    create(value?: PartialMessage<OriginalJob>): OriginalJob {
+        const message = globalThis.Object.create((this.messagePrototype!));
+        message.job = "";
+        message.jobGrade = 0;
+        if (value !== undefined)
+            reflectionMergePartial<OriginalJob>(this, message, value);
+        return message;
+    }
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: OriginalJob): OriginalJob {
+        let message = target ?? this.create(), end = reader.pos + length;
+        while (reader.pos < end) {
+            let [fieldNo, wireType] = reader.tag();
+            switch (fieldNo) {
+                case /* string job */ 1:
+                    message.job = reader.string();
+                    break;
+                case /* int32 job_grade */ 2:
+                    message.jobGrade = reader.int32();
+                    break;
+                default:
+                    let u = options.readUnknownField;
+                    if (u === "throw")
+                        throw new globalThis.Error(`Unknown field ${fieldNo} (wire type ${wireType}) for ${this.typeName}`);
+                    let d = reader.skip(wireType);
+                    if (u !== false)
+                        (u === true ? UnknownFieldHandler.onRead : u)(this.typeName, message, fieldNo, wireType, d);
+            }
+        }
+        return message;
+    }
+    internalBinaryWrite(message: OriginalJob, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* string job = 1; */
+        if (message.job !== "")
+            writer.tag(1, WireType.LengthDelimited).string(message.job);
+        /* int32 job_grade = 2; */
+        if (message.jobGrade !== 0)
+            writer.tag(2, WireType.Varint).int32(message.jobGrade);
+        let u = options.writeUnknownFields;
+        if (u !== false)
+            (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
+        return writer;
+    }
+}
+/**
+ * @generated MessageType for protobuf message resources.userinfo.OriginalJob
+ */
+export const OriginalJob = new OriginalJob$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class PollReq$Type extends MessageType<PollReq> {
     constructor() {
@@ -418,24 +497,24 @@ class UserInfoChanged$Type extends MessageType<UserInfoChanged> {
  */
 export const UserInfoChanged = new UserInfoChanged$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class UserGroupsChanged$Type extends MessageType<UserGroupsChanged> {
+class AccountGroupsChanged$Type extends MessageType<AccountGroupsChanged> {
     constructor() {
-        super("resources.userinfo.UserGroupsChanged", [
+        super("resources.userinfo.AccountGroupsChanged", [
             { no: 1, name: "account_id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
             { no: 2, name: "changed_at", kind: "message", T: () => Timestamp },
             { no: 3, name: "new_groups", kind: "message", T: () => AccountGroups },
             { no: 4, name: "can_be_superuser", kind: "scalar", T: 8 /*ScalarType.BOOL*/ }
         ]);
     }
-    create(value?: PartialMessage<UserGroupsChanged>): UserGroupsChanged {
+    create(value?: PartialMessage<AccountGroupsChanged>): AccountGroupsChanged {
         const message = globalThis.Object.create((this.messagePrototype!));
         message.accountId = 0;
         message.canBeSuperuser = false;
         if (value !== undefined)
-            reflectionMergePartial<UserGroupsChanged>(this, message, value);
+            reflectionMergePartial<AccountGroupsChanged>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: UserGroupsChanged): UserGroupsChanged {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: AccountGroupsChanged): AccountGroupsChanged {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
@@ -463,7 +542,7 @@ class UserGroupsChanged$Type extends MessageType<UserGroupsChanged> {
         }
         return message;
     }
-    internalBinaryWrite(message: UserGroupsChanged, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+    internalBinaryWrite(message: AccountGroupsChanged, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
         /* int64 account_id = 1; */
         if (message.accountId !== 0)
             writer.tag(1, WireType.Varint).int64(message.accountId);
@@ -483,6 +562,6 @@ class UserGroupsChanged$Type extends MessageType<UserGroupsChanged> {
     }
 }
 /**
- * @generated MessageType for protobuf message resources.userinfo.UserGroupsChanged
+ * @generated MessageType for protobuf message resources.userinfo.AccountGroupsChanged
  */
-export const UserGroupsChanged = new UserGroupsChanged$Type();
+export const AccountGroupsChanged = new AccountGroupsChanged$Type();

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -2264,6 +2264,10 @@
             "test_notification": {
                 "title": "Test-Benachrichtigung {index}",
                 "content": "Dies ist eine Test-Benachrichtigung der {type} Art."
+            },
+            "user_job_changed": {
+                "title": "Beruf aktualisiert",
+                "content": "Dein Beruf wurde zu {job} ({grade}) aktualisiert."
             }
         },
         "qualifications": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2264,6 +2264,10 @@
             "test_notification": {
                 "title": "Test Notification {index}",
                 "content": "This is a test notification of type {type}."
+            },
+            "user_job_changed": {
+                "title": "Job updated",
+                "content": "Your job has been updated to {job} ({grade})."
             }
         },
         "qualifications": {

--- a/pkg/grpc/auth/claims/token_claims.go
+++ b/pkg/grpc/auth/claims/token_claims.go
@@ -60,6 +60,7 @@ func (c *CombinedClaims) GetAccountInfoClaims() *AccountInfoClaims {
 
 func (c *CombinedClaims) GetUserInfoClaims() *UserInfoClaims {
 	return &UserInfoClaims{
+		AccID:            c.AccID,
 		RegisteredClaims: c.RegisteredClaims,
 		UserID:           c.UserID,
 		Job:              c.Job,

--- a/pkg/notifi/notifi.go
+++ b/pkg/notifi/notifi.go
@@ -22,6 +22,12 @@ type INotifi interface {
 	NotifyUser(ctx context.Context, not *notifications.Notification) error
 	// SendObjectEvent publishes an object event notification to the event system.
 	SendObjectEvent(ctx context.Context, event *notificationsclientview.ObjectEvent) error
+	// SendAccountEvent publishes an account event notification to the event system.
+	SendAccountEvent(
+		ctx context.Context,
+		accountId int64,
+		event *notificationsevents.UserEvent,
+	) error
 	// SendUserEvent publishes a user event notification to the event system.
 	SendUserEvent(ctx context.Context, userId int32, event *notificationsevents.UserEvent) error
 	// SendSystemEvent publishes a system-wide event notification to the event system.
@@ -167,6 +173,26 @@ func (n *Notifi) SendObjectEvent(
 			event.GetType().String(),
 			err,
 		)
+	}
+
+	return nil
+}
+
+func (n *Notifi) SendAccountEvent(
+	ctx context.Context,
+	accountId int64,
+	event *notificationsevents.UserEvent,
+) error {
+	if event == nil || event.Data == nil {
+		return errors.New("account event data is required")
+	}
+
+	if _, err := n.js.PublishAsyncProto(
+		ctx,
+		fmt.Sprintf("%s.%s.%d", BaseSubject, AccountTopic, accountId),
+		event,
+	); err != nil {
+		return fmt.Errorf("failed to publish account %d event message. %w", accountId, err)
 	}
 
 	return nil

--- a/pkg/userinfo/events.go
+++ b/pkg/userinfo/events.go
@@ -81,18 +81,18 @@ func BuildUserInfoChangedEvent(
 	return event
 }
 
-// BuildUserGroupsChangedEvent constructs the live account group change payload.
-func BuildUserGroupsChangedEvent(
+// BuildAccountGroupsChangedEvent constructs the live account group change payload.
+func BuildAccountGroupsChangedEvent(
 	accountID int64,
 	changedAt *pbtimestamp.Timestamp,
 	groups *accounts.AccountGroups,
 	canBeSuperuser bool,
-) *pbuserinfo.UserGroupsChanged {
+) *pbuserinfo.AccountGroupsChanged {
 	if changedAt == nil {
 		changedAt = pbtimestamp.Now()
 	}
 
-	event := &pbuserinfo.UserGroupsChanged{
+	event := &pbuserinfo.AccountGroupsChanged{
 		AccountId:      accountID,
 		ChangedAt:      changedAt,
 		CanBeSuperuser: canBeSuperuser,

--- a/pkg/userinfo/events.go
+++ b/pkg/userinfo/events.go
@@ -3,8 +3,13 @@ package userinfo
 import (
 	"context"
 	"fmt"
+	"slices"
 
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
+	pbtimestamp "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
+	pbuserinfo "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
 	"github.com/fivenet-app/fivenet/v2026/pkg/events"
+	"github.com/fivenet-app/fivenet/v2026/pkg/mstlystcdata"
 	"github.com/nats-io/nats.go/jetstream"
 )
 
@@ -19,6 +24,7 @@ const (
 
 	UserInfoStreamName = "USERINFO"
 	UserInfoSubject    = "userinfo.*.changes"
+	UserGroupsSubject  = "userinfo.*.groups"
 )
 
 func registerStreams(ctx context.Context, js *events.JSWrapper) error {
@@ -37,7 +43,7 @@ func registerStreams(ctx context.Context, js *events.JSWrapper) error {
 	userinfoStreamCfg := jetstream.StreamConfig{
 		Name:        UserInfoStreamName,
 		Description: "Stream for userinfo changes",
-		Subjects:    []string{UserInfoSubject},
+		Subjects:    []string{UserInfoSubject, UserGroupsSubject},
 		Retention:   jetstream.InterestPolicy,
 	}
 	if _, err := js.CreateOrUpdateStream(ctx, userinfoStreamCfg); err != nil {
@@ -45,4 +51,57 @@ func registerStreams(ctx context.Context, js *events.JSWrapper) error {
 	}
 
 	return nil
+}
+
+// BuildUserInfoChangedEvent constructs the live user info change payload and enriches labels.
+func BuildUserInfoChangedEvent(
+	accountID int64,
+	userID int32,
+	changedAt *pbtimestamp.Timestamp,
+	job string,
+	jobGrade int32,
+	enricher mstlystcdata.IEnricher,
+) *pbuserinfo.UserInfoChanged {
+	if changedAt == nil {
+		changedAt = pbtimestamp.Now()
+	}
+
+	event := &pbuserinfo.UserInfoChanged{
+		AccountId: accountID,
+		UserId:    userID,
+		ChangedAt: changedAt,
+	}
+	event.SetJob(job)
+	event.SetJobGrade(jobGrade)
+
+	if enricher != nil {
+		enricher.EnrichJobInfo(event)
+	}
+
+	return event
+}
+
+// BuildUserGroupsChangedEvent constructs the live account group change payload.
+func BuildUserGroupsChangedEvent(
+	accountID int64,
+	changedAt *pbtimestamp.Timestamp,
+	groups *accounts.AccountGroups,
+	canBeSuperuser bool,
+) *pbuserinfo.UserGroupsChanged {
+	if changedAt == nil {
+		changedAt = pbtimestamp.Now()
+	}
+
+	event := &pbuserinfo.UserGroupsChanged{
+		AccountId:      accountID,
+		ChangedAt:      changedAt,
+		CanBeSuperuser: canBeSuperuser,
+	}
+	if groups != nil {
+		event.NewGroups = &accounts.AccountGroups{
+			Groups: slices.Clone(groups.GetGroups()),
+		}
+	}
+
+	return event
 }

--- a/pkg/userinfo/events_test.go
+++ b/pkg/userinfo/events_test.go
@@ -1,0 +1,85 @@
+package userinfo
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/jobs"
+	pbtimestamp "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type labelEnricher struct{}
+
+func (labelEnricher) EnrichJobInfo(user common.IJobInfo) {
+	user.SetJobLabel(user.GetJob())
+	user.SetJobGradeLabel(fmt.Sprintf("Rank %d", user.GetJobGrade()))
+}
+
+func (labelEnricher) EnrichJobInfoNoFallback(common.IJobInfo) {}
+
+func (labelEnricher) EnrichJobName(common.IJobName) {}
+
+func (labelEnricher) GetJobByName(string) *jobs.Job { return nil }
+
+func (labelEnricher) GetJobGrade(string, int32) (*jobs.Job, *jobs.JobGrade) {
+	return nil, nil
+}
+
+func TestBuildUserInfoChangedEvent(t *testing.T) {
+	t.Parallel()
+
+	evt := BuildUserInfoChangedEvent(
+		42,
+		77,
+		nil,
+		"police",
+		3,
+		labelEnricher{},
+	)
+
+	require.NotNil(t, evt)
+	require.NotNil(t, evt.GetChangedAt())
+
+	assert.Equal(t, int64(42), evt.GetAccountId())
+	assert.Equal(t, int32(77), evt.GetUserId())
+	assert.Same(t, evt.GetChangedAt(), evt.ChangedAt)
+	assert.Equal(t, "police", evt.GetNewJob())
+	assert.Equal(t, "police", evt.GetNewJobLabel())
+	assert.Equal(t, int32(3), evt.GetNewJobGrade())
+	assert.Equal(t, "Rank 3", evt.GetNewJobGradeLabel())
+}
+
+func TestBuildUserInfoChangedEventUsesProvidedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	changedAt := pbtimestamp.New(time.Unix(123, 456))
+	evt := BuildUserInfoChangedEvent(1, 2, changedAt, "ems", 4, nil)
+
+	require.NotNil(t, evt)
+	assert.Same(t, changedAt, evt.GetChangedAt())
+	assert.Equal(t, "ems", evt.GetNewJob())
+	assert.Equal(t, int32(4), evt.GetNewJobGrade())
+}
+
+func TestBuildUserGroupsChangedEvent(t *testing.T) {
+	t.Parallel()
+
+	groups := &accounts.AccountGroups{Groups: []string{"supporter", "donator"}}
+	evt := BuildUserGroupsChangedEvent(42, nil, groups, true)
+
+	require.NotNil(t, evt)
+	require.NotNil(t, evt.GetChangedAt())
+	require.NotNil(t, evt.GetNewGroups())
+
+	assert.Equal(t, int64(42), evt.GetAccountId())
+	assert.Equal(t, []string{"supporter", "donator"}, evt.GetNewGroups().GetGroups())
+	assert.True(t, evt.GetCanBeSuperuser())
+
+	groups.Groups[0] = "modified"
+	assert.Equal(t, []string{"supporter", "donator"}, evt.GetNewGroups().GetGroups())
+}

--- a/pkg/userinfo/events_test.go
+++ b/pkg/userinfo/events_test.go
@@ -66,11 +66,11 @@ func TestBuildUserInfoChangedEventUsesProvidedTimestamp(t *testing.T) {
 	assert.Equal(t, int32(4), evt.GetNewJobGrade())
 }
 
-func TestBuildUserGroupsChangedEvent(t *testing.T) {
+func TestBuildAccountGroupsChangedEvent(t *testing.T) {
 	t.Parallel()
 
 	groups := &accounts.AccountGroups{Groups: []string{"supporter", "donator"}}
-	evt := BuildUserGroupsChangedEvent(42, nil, groups, true)
+	evt := BuildAccountGroupsChangedEvent(42, nil, groups, true)
 
 	require.NotNil(t, evt)
 	require.NotNil(t, evt.GetChangedAt())

--- a/pkg/userinfo/poller.go
+++ b/pkg/userinfo/poller.go
@@ -327,7 +327,7 @@ func (p *Poller) checkDiffAndPublish(
 			superuserGroups = p.cfg.Auth.SuperuserGroups
 			superuserUsers = p.cfg.Auth.SuperuserUsers
 		}
-		evt := BuildUserGroupsChangedEvent(
+		evt := BuildAccountGroupsChangedEvent(
 			acct,
 			updatedAt,
 			groups,

--- a/pkg/userinfo/poller.go
+++ b/pkg/userinfo/poller.go
@@ -11,9 +11,9 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pb "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
+	"github.com/fivenet-app/fivenet/v2026/pkg/config"
 	"github.com/fivenet-app/fivenet/v2026/pkg/events"
 	"github.com/fivenet-app/fivenet/v2026/pkg/mstlystcdata"
-	"github.com/fivenet-app/fivenet/v2026/pkg/notifi"
 	"github.com/fivenet-app/fivenet/v2026/pkg/utils/instance"
 	"github.com/fivenet-app/fivenet/v2026/pkg/utils/protoutils"
 	"github.com/fivenet-app/fivenet/v2026/query/fivenet/table"
@@ -47,9 +47,9 @@ type Poller struct {
 	jsCons jetstream.ConsumeContext
 
 	db       *sql.DB
+	cfg      *config.Config
 	js       *events.JSWrapper
 	enricher mstlystcdata.IEnricher
-	notifi   notifi.INotifi
 	kv       jetstream.KeyValue
 
 	pendingMu sync.Mutex
@@ -67,8 +67,8 @@ type PollerParams struct {
 
 	Logger   *zap.Logger
 	DB       *sql.DB
+	Cfg      *config.Config
 	Enricher mstlystcdata.IEnricher
-	Notifi   notifi.INotifi
 	JS       *events.JSWrapper
 }
 
@@ -80,8 +80,8 @@ func NewPoller(p PollerParams) *Poller {
 
 		ctx:      ctxCancel,
 		db:       p.DB,
+		cfg:      p.Cfg,
 		enricher: p.Enricher,
-		notifi:   p.Notifi,
 		js:       p.JS,
 
 		pending:  make(map[string]*pb.PollReq),
@@ -211,6 +211,7 @@ func (p *Poller) doBatch(ctx context.Context) error {
 	stmt := tUser.
 		SELECT(
 			tAccount.ID.AS("account_id"),
+			tAccount.License.AS("license"),
 			tUser.ID.AS("user_id"),
 			tUser.Job.AS("job"),
 			tUser.JobGrade.AS("job_grade"),
@@ -236,6 +237,7 @@ func (p *Poller) doBatch(ctx context.Context) error {
 
 	var dest []*struct {
 		AccountId int64
+		License   string
 		UserId    int32
 		Job       string
 		JobGrade  int32
@@ -252,6 +254,7 @@ func (p *Poller) doBatch(ctx context.Context) error {
 		if err := p.checkDiffAndPublish(
 			ctx,
 			row.AccountId,
+			row.License,
 			row.UserId,
 			row.Job,
 			row.JobGrade,
@@ -269,6 +272,7 @@ func (p *Poller) doBatch(ctx context.Context) error {
 func (p *Poller) checkDiffAndPublish(
 	ctx context.Context,
 	acct int64,
+	license string,
 	uid int32,
 	job string,
 	grade int32,
@@ -286,23 +290,20 @@ func (p *Poller) checkDiffAndPublish(
 	old, exists := userMap[uid]
 	if !exists {
 		// First-seen: record snapshot, no event
-		userMap[uid] = &userSnapshot{Job: job, JobGrade: grade}
+		userMap[uid] = &userSnapshot{
+			Job:      job,
+			JobGrade: grade,
+			Groups:   groupsSlice(groups),
+		}
 		return nil
 	}
 
-	if old.Job != job || old.JobGrade != grade || !slices.Equal(old.Groups, groups.GetGroups()) {
-		evt := &pb.UserInfoChanged{
-			AccountId: acct,
-			UserId:    uid,
-			ChangedAt: updatedAt,
+	newGroups := groupsSlice(groups)
+	jobChanged := old.Job != job || old.JobGrade != grade
+	groupsChanged := !slices.Equal(old.Groups, newGroups)
 
-			OldJob: old.Job,
-			NewJob: &job,
-
-			OldJobGrade: old.JobGrade,
-			NewJobGrade: &grade,
-		}
-		p.enricher.EnrichJobInfo(evt)
+	if jobChanged {
+		evt := BuildUserInfoChangedEvent(acct, uid, updatedAt, job, grade, p.enricher)
 
 		if _, err := p.js.PublishAsyncProto(
 			ctx,
@@ -314,16 +315,53 @@ func (p *Poller) checkDiffAndPublish(
 				zap.Int32("userId", uid),
 				zap.String("job", job),
 				zap.Int32("jobGrade", grade),
-				zap.Strings("groups", groups.GetGroups()),
+				zap.Strings("groups", newGroups),
 				zap.Error(err),
 			)
 		}
+	}
+
+	if groupsChanged {
+		superuserGroups, superuserUsers := []string(nil), []string(nil)
+		if p.cfg != nil {
+			superuserGroups = p.cfg.Auth.SuperuserGroups
+			superuserUsers = p.cfg.Auth.SuperuserUsers
+		}
+		evt := BuildUserGroupsChangedEvent(
+			acct,
+			updatedAt,
+			groups,
+			CanBeSuperuser(groups, license, superuserGroups, superuserUsers),
+		)
+
+		if _, err := p.js.PublishAsyncProto(
+			ctx,
+			fmt.Sprintf("userinfo.%d.groups", acct),
+			evt,
+		); err != nil {
+			p.logger.Error("failed to publish user groups change event",
+				zap.Int64("accountId", acct),
+				zap.Int32("userId", uid),
+				zap.Strings("groups", newGroups),
+				zap.Error(err),
+			)
+		}
+	}
+
+	if jobChanged || groupsChanged {
 		userMap[uid] = &userSnapshot{
 			Job:      job,
 			JobGrade: grade,
-			Groups:   groups.GetGroups(),
+			Groups:   newGroups,
 		}
 	}
 
 	return nil
+}
+
+func groupsSlice(groups *accounts.AccountGroups) []string {
+	if groups == nil {
+		return nil
+	}
+	return slices.Clone(groups.GetGroups())
 }

--- a/pkg/userinfo/retriever.go
+++ b/pkg/userinfo/retriever.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
@@ -122,7 +123,7 @@ func (r *Retriever) registerSubscriptions(
 		jetstream.ConsumerConfig{
 			Durable:           instance.ID() + "_ui_retriever",
 			AckPolicy:         jetstream.AckExplicitPolicy,
-			FilterSubjects:    []string{UserInfoSubject},
+			FilterSubjects:    []string{UserInfoSubject, UserGroupsSubject},
 			InactiveThreshold: 1 * time.Minute, // Close consumer if inactive for 1 minute
 		},
 	)
@@ -152,27 +153,73 @@ func (r *Retriever) handleMsg(m jetstream.Msg) {
 		r.logger.Error("failed to ack message", zap.Error(err), zap.String("subject", m.Subject()))
 	}
 
-	var evt pbuserinfo.UserInfoChanged
-	if err := protoutils.UnmarshalPartialJSON(m.Data(), &evt); err != nil {
-		r.logger.Error("failed to unmarshal user info changed event",
-			zap.Error(err),
+	parts := strings.Split(m.Subject(), ".")
+	if len(parts) < 3 {
+		r.logger.Error("failed to parse userinfo subject",
 			zap.String("subject", m.Subject()),
 		)
 		return
 	}
 
-	// Notify UI about the user info change
-	r.logger.Debug(
-		"User info changed, notifying user",
-		zap.Int32("userId", evt.GetUserId()),
-		zap.Int64("accountId", evt.GetAccountId()),
-	)
+	switch parts[2] {
+	case "changes":
+		var evt pbuserinfo.UserInfoChanged
+		if err := protoutils.UnmarshalPartialJSON(m.Data(), &evt); err != nil {
+			r.logger.Error("failed to unmarshal user info changed event",
+				zap.Error(err),
+				zap.String("subject", m.Subject()),
+			)
+			return
+		}
 
-	r.notifi.SendUserEvent(r.ctx, evt.GetUserId(), &notificationsevents.UserEvent{
-		Data: &notificationsevents.UserEvent_UserInfoChanged{
-			UserInfoChanged: &evt,
-		},
-	})
+		r.logger.Debug(
+			"User info changed, notifying user",
+			zap.Int32("userId", evt.GetUserId()),
+			zap.Int64("accountId", evt.GetAccountId()),
+		)
+
+		if err := r.notifi.SendUserEvent(r.ctx, evt.GetUserId(), &notificationsevents.UserEvent{
+			Data: &notificationsevents.UserEvent_UserInfoChanged{
+				UserInfoChanged: &evt,
+			},
+		}); err != nil {
+			r.logger.Error("failed to send user info change event",
+				zap.Error(err),
+				zap.Int32("userId", evt.GetUserId()),
+				zap.Int64("accountId", evt.GetAccountId()),
+			)
+		}
+
+	case "groups":
+		var evt pbuserinfo.UserGroupsChanged
+		if err := protoutils.UnmarshalPartialJSON(m.Data(), &evt); err != nil {
+			r.logger.Error("failed to unmarshal user groups changed event",
+				zap.Error(err),
+				zap.String("subject", m.Subject()),
+			)
+			return
+		}
+
+		r.logger.Debug(
+			"User groups changed, notifying account",
+			zap.Int64("accountId", evt.GetAccountId()),
+		)
+
+		if err := r.notifi.SendAccountEvent(
+			r.ctx,
+			evt.GetAccountId(),
+			&notificationsevents.UserEvent{
+				Data: &notificationsevents.UserEvent_UserGroupsChanged{
+					UserGroupsChanged: &evt,
+				},
+			},
+		); err != nil {
+			r.logger.Error("failed to send user groups change event",
+				zap.Error(err),
+				zap.Int64("accountId", evt.GetAccountId()),
+			)
+		}
+	}
 }
 
 // GetUserInfo retrieves user info for a given userId and accountId, using cache for performance.

--- a/pkg/userinfo/retriever.go
+++ b/pkg/userinfo/retriever.go
@@ -191,7 +191,7 @@ func (r *Retriever) handleMsg(m jetstream.Msg) {
 		}
 
 	case "groups":
-		var evt pbuserinfo.UserGroupsChanged
+		var evt pbuserinfo.AccountGroupsChanged
 		if err := protoutils.UnmarshalPartialJSON(m.Data(), &evt); err != nil {
 			r.logger.Error("failed to unmarshal user groups changed event",
 				zap.Error(err),
@@ -209,8 +209,8 @@ func (r *Retriever) handleMsg(m jetstream.Msg) {
 			r.ctx,
 			evt.GetAccountId(),
 			&notificationsevents.UserEvent{
-				Data: &notificationsevents.UserEvent_UserGroupsChanged{
-					UserGroupsChanged: &evt,
+				Data: &notificationsevents.UserEvent_AccountGroupsChanged{
+					AccountGroupsChanged: &evt,
 				},
 			},
 		); err != nil {
@@ -313,6 +313,11 @@ func (r *Retriever) GetUserInfoFromClaims(
 
 	// If the user has an original job in their claims, check if the userInfo matches that job + grade.
 	if userClaims.OriginalJob != nil {
+		userInfo.OriginalJob = &pbuserinfo.OriginalJob{
+			Job:      userClaims.OriginalJob.Job,
+			JobGrade: userClaims.OriginalJob.JobGrade,
+		}
+
 		// Check that the current user's info from the database matches the original job and grade in the claims.
 		// If not, it means the user's job has changed since the token was issued.
 		if !userInfo.GetSuperuser() && (userInfo.GetJob() != userClaims.OriginalJob.Job ||

--- a/pkg/userinfo/superuser.go
+++ b/pkg/userinfo/superuser.go
@@ -1,0 +1,21 @@
+package userinfo
+
+import (
+	"slices"
+
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
+)
+
+// CanBeSuperuser determines whether an account currently qualifies for superuser mode.
+func CanBeSuperuser(
+	groups *accounts.AccountGroups,
+	license string,
+	superuserGroups []string,
+	superuserUsers []string,
+) bool {
+	if groups != nil && groups.ContainsAnyGroup(superuserGroups) {
+		return true
+	}
+
+	return slices.Contains(superuserUsers, license)
+}

--- a/proto/resources/notifications/events/events.proto
+++ b/proto/resources/notifications/events/events.proto
@@ -20,7 +20,7 @@ message UserEvent {
     resources.notifications.Notification notification = 2;
     int64 notifications_read_count = 3;
     resources.userinfo.UserInfoChanged user_info_changed = 4;
-    resources.userinfo.UserGroupsChanged user_groups_changed = 5;
+    resources.userinfo.AccountGroupsChanged account_groups_changed = 5;
   }
 }
 

--- a/proto/resources/notifications/events/events.proto
+++ b/proto/resources/notifications/events/events.proto
@@ -20,6 +20,7 @@ message UserEvent {
     resources.notifications.Notification notification = 2;
     int64 notifications_read_count = 3;
     resources.userinfo.UserInfoChanged user_info_changed = 4;
+    resources.userinfo.UserGroupsChanged user_groups_changed = 5;
   }
 }
 

--- a/proto/resources/userinfo/userinfo.proto
+++ b/proto/resources/userinfo/userinfo.proto
@@ -21,6 +21,13 @@ message UserInfo {
 
   bool can_be_superuser = 9;
   bool superuser = 10;
+
+  optional OriginalJob original_job = 11;
+}
+
+message OriginalJob {
+  string job = 1;
+  int32 job_grade = 2;
 }
 
 // PollReq: published to `userinfo.poll.request` when an active user connects or requests a refresh.
@@ -52,8 +59,8 @@ message UserInfoChanged {
   optional string new_job_grade_label = 9;
 }
 
-// UserGroupsChanged used to signal live account group changes.
-message UserGroupsChanged {
+// AccountGroupsChanged used to signal live account group changes.
+message AccountGroupsChanged {
   // The account the user belongs to
   int64 account_id = 1;
 

--- a/proto/resources/userinfo/userinfo.proto
+++ b/proto/resources/userinfo/userinfo.proto
@@ -32,7 +32,7 @@ message PollReq {
   int32 user_id = 2;
 }
 
-// UserInfoChanged used to signal Job or JobGrade changes.
+// UserInfoChanged used to signal live primary job or job grade changes.
 message UserInfoChanged {
   // The account the user belongs to
   int64 account_id = 1;
@@ -42,21 +42,27 @@ message UserInfoChanged {
   // Timestamp of when the change was detected
   resources.timestamp.Timestamp changed_at = 3;
 
-  // Previous job title
-  string old_job = 4;
   // New job title
   optional string new_job = 5;
   optional string new_job_label = 6;
 
-  // Previous job grade
-  int32 old_job_grade = 7;
   // New job grade
   optional int32 new_job_grade = 8;
   // New job grade label
   optional string new_job_grade_label = 9;
+}
 
-  // Can the user be superuser (by group or license)
-  optional bool can_be_superuser = 10;
-  // Superuser state
-  optional bool superuser = 11;
+// UserGroupsChanged used to signal live account group changes.
+message UserGroupsChanged {
+  // The account the user belongs to
+  int64 account_id = 1;
+
+  // Timestamp of when the change was detected
+  resources.timestamp.Timestamp changed_at = 2;
+
+  // New account groups
+  resources.accounts.AccountGroups new_groups = 3;
+
+  // Whether the account can enter superuser mode after the change
+  bool can_be_superuser = 4;
 }

--- a/services/citizens/citizens.go
+++ b/services/citizens/citizens.go
@@ -191,14 +191,14 @@ func (s *Server) checkIfUserCanAccess(
 	targetUserGrade int32,
 ) (bool, error) {
 	// Skip if user is job unemployed
-	unemployedJob := s.appCfg.Get().JobInfo.GetUnemployedJob()
+	unemployedJob := s.appCfg.Get().GetJobInfo().GetUnemployedJob()
 	if unemployedJob.GetName() == targetUserJob {
 		return true, nil
 	}
 
 	// If the user is not part of public or hidden jobs (e.g., police, medics), allow access
-	if !slices.Contains(s.appCfg.Get().JobInfo.GetPublicJobs(), targetUserJob) &&
-		!slices.Contains(s.appCfg.Get().JobInfo.GetHiddenJobs(), targetUserJob) {
+	if !slices.Contains(s.appCfg.Get().GetJobInfo().GetPublicJobs(), targetUserJob) &&
+		!slices.Contains(s.appCfg.Get().GetJobInfo().GetHiddenJobs(), targetUserJob) {
 		return true, nil
 	}
 

--- a/services/livemap/markers.go
+++ b/services/livemap/markers.go
@@ -24,30 +24,30 @@ func (s *Server) CreateOrUpdateMarker(
 	ctx context.Context,
 	req *pblivemap.CreateOrUpdateMarkerRequest,
 ) (*pblivemap.CreateOrUpdateMarkerResponse, error) {
-	marker := req.GetMarker()
-	if marker != nil && marker.GetId() > 0 {
+	reqMarker := req.GetMarker()
+	if reqMarker != nil && reqMarker.GetId() > 0 {
 		logging.InjectFields(
 			ctx,
-			logging.Fields{"fivenet.livemap.marker_id", marker.GetId()},
+			logging.Fields{"fivenet.livemap.marker_id", reqMarker.GetId()},
 		)
 	}
 
 	userInfo := auth.MustGetUserInfoFromContext(ctx)
 
-	if req.Marker.Postal == nil || marker.GetPostal() == "" {
+	if reqMarker.Postal == nil || reqMarker.GetPostal() == "" {
 		if postal, ok := s.postals.Closest(
-			marker.GetX(),
-			marker.GetY(),
+			reqMarker.GetX(),
+			reqMarker.GetY(),
 		); postal != nil &&
 			ok {
-			req.Marker.Postal = postal.Code
+			reqMarker.Postal = postal.Code
 		}
 	}
 
-	if marker.GetId() <= 0 {
+	if reqMarker.GetId() <= 0 {
 		id, err := s.store.CreateMarker(
 			ctx,
-			marker,
+			reqMarker,
 			userInfo.GetUserId(),
 			userInfo.GetJob(),
 		)
@@ -55,7 +55,7 @@ func (s *Server) CreateOrUpdateMarker(
 			return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)
 		}
 
-		req.Marker.Id = id
+		reqMarker.SetId(id)
 		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_CREATED)
 	} else {
 		fields, err := permslivemap.LivemapService.CreateOrUpdateMarker.AccessTyped.Get(
@@ -66,7 +66,7 @@ func (s *Server) CreateOrUpdateMarker(
 			return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)
 		}
 
-		marker, err := s.store.GetMarker(ctx, marker.GetId())
+		checkMarker, err := s.store.GetMarker(ctx, reqMarker.GetId())
 		if err != nil {
 			return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)
 		}
@@ -74,36 +74,36 @@ func (s *Server) CreateOrUpdateMarker(
 		if !access.CheckIfHasOwnJobAccess(
 			fields.StringList(),
 			userInfo,
-			marker.GetCreator().GetJob(),
-			marker.GetCreator(),
+			checkMarker.GetCreator().GetJob(),
+			checkMarker.GetCreator(),
 		) {
 			return nil, errorslivemap.ErrMarkerDenied
 		}
 
-		if err := s.store.UpdateMarker(ctx, marker, marker.GetJob()); err != nil {
+		if err := s.store.UpdateMarker(ctx, reqMarker, reqMarker.GetJob()); err != nil {
 			return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)
 		}
 
 		grpc_audit.SetAction(ctx, audit.EventAction_EVENT_ACTION_UPDATED)
 	}
 
-	marker, err := s.store.GetMarker(ctx, marker.GetId())
+	reqMarker, err := s.store.GetMarker(ctx, reqMarker.GetId())
 	if err != nil {
 		return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)
 	}
-	s.enricher.EnrichJobName(marker)
+	s.enricher.EnrichJobName(reqMarker)
 
 	if err := s.sendUpdateEvent(
 		ctx,
 		MarkerTopic,
 		MarkerUpdate,
-		marker.GetJob(),
-		marker,
+		reqMarker.GetJob(),
+		reqMarker,
 	); err != nil {
 		return nil, errswrap.NewError(err, errorslivemap.ErrMarkerFailed)
 	}
 
-	return &pblivemap.CreateOrUpdateMarkerResponse{Marker: marker}, nil
+	return &pblivemap.CreateOrUpdateMarkerResponse{Marker: reqMarker}, nil
 }
 
 func (s *Server) DeleteMarker(

--- a/services/notifications/stream.go
+++ b/services/notifications/stream.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"sync"
 	"time"
 
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
 	mailerevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/mailer/events"
 	notificationsclientview "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/clientview"
 	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
@@ -156,6 +158,40 @@ func (s *Server) shouldDeliverObjectEvent(
 	}
 
 	return true
+}
+
+func applyUserInfoChanged(currentUserInfo *pbuserinfo.UserInfo, event *pbuserinfo.UserInfoChanged) {
+	if currentUserInfo == nil || event == nil {
+		return
+	}
+
+	currentUserInfo.Job = event.GetNewJob()
+	currentUserInfo.JobGrade = event.GetNewJobGrade()
+}
+
+func applyUserGroupsChanged(
+	currentUserInfo *pbuserinfo.UserInfo,
+	event *pbuserinfo.UserGroupsChanged,
+) {
+	if currentUserInfo == nil || event == nil {
+		return
+	}
+
+	currentUserInfo.CanBeSuperuser = event.GetCanBeSuperuser()
+	if event.GetNewGroups() == nil {
+		currentUserInfo.Groups = nil
+		if !currentUserInfo.GetCanBeSuperuser() {
+			currentUserInfo.Superuser = false
+		}
+		return
+	}
+
+	currentUserInfo.Groups = &accounts.AccountGroups{
+		Groups: slices.Clone(event.GetNewGroups().GetGroups()),
+	}
+	if !currentUserInfo.GetCanBeSuperuser() {
+		currentUserInfo.Superuser = false
+	}
 }
 
 func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) error {
@@ -323,27 +359,40 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 
 				topic, parts := notifi.SplitSubject(m.Subject())
 				switch topic {
-				case notifi.UserTopic:
+				case notifi.UserTopic, notifi.AccountTopic:
 					var dest notificationsevents.UserEvent
 					if err := protoutils.UnmarshalPartialJSON(m.Data(), &dest); err != nil {
 						return errswrap.NewError(err, ErrFailedStream)
 					}
 
+					needsSubjectRefresh := false
 					switch d := dest.GetData().(type) {
 					case *notificationsevents.UserEvent_Notification:
-						notificationCount++
+						if topic == notifi.UserTopic {
+							notificationCount++
+						}
 
 					case *notificationsevents.UserEvent_NotificationsReadCount:
-						if notificationCount-d.NotificationsReadCount <= 0 {
-							notificationCount = 0
-						} else {
-							notificationCount -= d.NotificationsReadCount
+						if topic == notifi.UserTopic {
+							if notificationCount-d.NotificationsReadCount <= 0 {
+								notificationCount = 0
+							} else {
+								notificationCount -= d.NotificationsReadCount
+							}
 						}
 
 					case *notificationsevents.UserEvent_UserInfoChanged:
-						currentUserInfo.Job = d.UserInfoChanged.GetNewJob()
-						currentUserInfo.JobGrade = d.UserInfoChanged.GetNewJobGrade()
+						if topic == notifi.UserTopic {
+							applyUserInfoChanged(currentUserInfo, d.UserInfoChanged)
+							needsSubjectRefresh = true
+						}
 
+					case *notificationsevents.UserEvent_UserGroupsChanged:
+						applyUserGroupsChanged(currentUserInfo, d.UserGroupsChanged)
+						needsSubjectRefresh = true
+					}
+
+					if needsSubjectRefresh {
 						baseSubjects, additionalSubjects, err = s.buildSubjects(
 							gctx,
 							currentUserInfo,

--- a/services/notifications/stream.go
+++ b/services/notifications/stream.go
@@ -139,10 +139,9 @@ func (s *Server) buildClientViewSubjects(
 
 func (s *Server) shouldDeliverObjectEvent(
 	dest *notificationsclientview.ObjectEvent,
-	currentUserInfo *pbuserinfo.UserInfo,
 	userInfo *pbuserinfo.UserInfo,
 ) bool {
-	if dest.UserId != nil && dest.GetUserId() == currentUserInfo.GetUserId() {
+	if dest.UserId != nil && dest.GetUserId() == userInfo.GetUserId() {
 		return false
 	}
 
@@ -218,6 +217,7 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 		return errswrap.NewError(err, ErrFailedStream)
 	}
 	clientViewSubjects := []string{}
+	var currentClientView *notificationsclientview.ClientView
 
 	notificationCount, err := s.store.CountUnread(ctx, userInfo.GetUserId())
 	if err != nil {
@@ -251,6 +251,36 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 	defer close(outCh)
 	g, gctx := errgroup.WithContext(ctx)
 
+	refreshConsumerSubjects := func() error {
+		info, err := consumer.Info(gctx)
+		if err != nil {
+			return errswrap.NewError(err, ErrFailedStream)
+		}
+
+		cfg := info.Config
+		subjectsMu.Lock()
+		filterSubjects := make(
+			[]string,
+			0,
+			len(baseSubjects)+len(additionalSubjects)+len(clientViewSubjects),
+		)
+		filterSubjects = append(filterSubjects, baseSubjects...)
+		filterSubjects = append(filterSubjects, additionalSubjects...)
+		filterSubjects = append(filterSubjects, clientViewSubjects...)
+		subjectsMu.Unlock()
+
+		cfg.FilterSubjects = filterSubjects
+
+		if _, err := s.js.UpdateConsumer(gctx, notifi.StreamName, cfg); err != nil {
+			return errswrap.NewError(
+				fmt.Errorf("failed to update consumer. %w", err),
+				ErrFailedStream,
+			)
+		}
+
+		return nil
+	}
+
 	g.Go(func() error {
 		// Update metrics for active user sessions in first goroutine
 		metricLastUserSession.SetToCurrentTime()
@@ -276,30 +306,22 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 					continue // Skip nil client view
 				}
 
-				info, err := consumer.Info(gctx)
-				if err != nil {
-					return errswrap.NewError(err, ErrFailedStream)
-				}
-				cfg := info.Config
-
-				clientViewSubjects, err = s.buildClientViewSubjects(gctx, userInfo, clientView)
+				newClientViewSubjects, err := s.buildClientViewSubjects(
+					gctx,
+					currentUserInfo,
+					clientView,
+				)
 				if err != nil {
 					return err
 				}
-				if len(clientViewSubjects) == 0 {
-					continue
-				}
 
 				subjectsMu.Lock()
-				cfg.FilterSubjects = []string{}
-				cfg.FilterSubjects = append(cfg.FilterSubjects, baseSubjects...)
-				cfg.FilterSubjects = append(cfg.FilterSubjects, additionalSubjects...)
-				cfg.FilterSubjects = append(cfg.FilterSubjects, clientViewSubjects...)
+				currentClientView = clientView
+				clientViewSubjects = newClientViewSubjects
 				subjectsMu.Unlock()
 
-				// Update consumer
-				if _, err := s.js.UpdateConsumer(gctx, notifi.StreamName, cfg); err != nil {
-					return fmt.Errorf("failed to update consumer. %w", err)
+				if err := refreshConsumerSubjects(); err != nil {
+					return err
 				}
 			}
 		}
@@ -393,7 +415,7 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 					}
 
 					if needsSubjectRefresh {
-						baseSubjects, additionalSubjects, err = s.buildSubjects(
+						newBaseSubjects, newAdditionalSubjects, err := s.buildSubjects(
 							gctx,
 							currentUserInfo,
 						)
@@ -401,23 +423,28 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 							return errswrap.NewError(err, ErrFailedStream)
 						}
 
-						info, err := consumer.Info(gctx)
-						if err != nil {
-							return errswrap.NewError(err, ErrFailedStream)
-						}
-
-						cfg := info.Config
 						subjectsMu.Lock()
-						cfg.FilterSubjects = []string{}
-						// Rebuild filter subjects with the new user info
-						cfg.FilterSubjects = append(cfg.FilterSubjects, baseSubjects...)
-						cfg.FilterSubjects = append(cfg.FilterSubjects, additionalSubjects...)
-						cfg.FilterSubjects = append(cfg.FilterSubjects, clientViewSubjects...)
+						baseSubjects = newBaseSubjects
+						additionalSubjects = newAdditionalSubjects
+						clientView := currentClientView
 						subjectsMu.Unlock()
 
-						// Update consumer subjects
-						if _, err := s.js.UpdateConsumer(gctx, notifi.StreamName, cfg); err != nil {
-							return fmt.Errorf("failed to update consumer. %w", err)
+						if clientView != nil {
+							newClientViewSubjects, err := s.buildClientViewSubjects(
+								gctx,
+								currentUserInfo,
+								clientView,
+							)
+							if err != nil {
+								return err
+							}
+							subjectsMu.Lock()
+							clientViewSubjects = newClientViewSubjects
+							subjectsMu.Unlock()
+						}
+
+						if err := refreshConsumerSubjects(); err != nil {
+							return err
 						}
 					}
 
@@ -484,7 +511,7 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 						return errswrap.NewError(err, ErrFailedStream)
 					}
 
-					if !s.shouldDeliverObjectEvent(&dest, currentUserInfo, userInfo) {
+					if !s.shouldDeliverObjectEvent(&dest, currentUserInfo) {
 						continue
 					}
 

--- a/services/notifications/stream.go
+++ b/services/notifications/stream.go
@@ -65,9 +65,10 @@ func (s *Server) buildSubjects(
 		fmt.Sprintf("%s.%s", notifi.BaseSubject, notifi.SystemTopic),
 	}
 
-	// Clone user info and disable superuser
-	userInfo.Superuser = false
-	emails, err := s.mailerStore.ListUserEmails(ctx, s.db, userInfo, nil, false, false)
+	// Clone user info and disable superuser (so a superuser doesn't receive notifications for "all" emails..)
+	clonedUserInfo := userInfo.Clone()
+	clonedUserInfo.Superuser = false
+	emails, err := s.mailerStore.ListUserEmails(ctx, s.db, clonedUserInfo, nil, false, false)
 	if err != nil {
 		return baseSubjects, nil, errswrap.NewError(err, ErrFailedStream)
 	}

--- a/services/notifications/stream.go
+++ b/services/notifications/stream.go
@@ -168,28 +168,32 @@ func applyUserInfoChanged(currentUserInfo *pbuserinfo.UserInfo, event *pbuserinf
 	currentUserInfo.JobGrade = event.GetNewJobGrade()
 }
 
-func applyUserGroupsChanged(
+func applyAccountGroupsChanged(
 	currentUserInfo *pbuserinfo.UserInfo,
-	event *pbuserinfo.UserGroupsChanged,
+	event *pbuserinfo.AccountGroupsChanged,
 ) {
 	if currentUserInfo == nil || event == nil {
 		return
 	}
 
+	wasSuperuser := currentUserInfo.GetSuperuser()
 	currentUserInfo.CanBeSuperuser = event.GetCanBeSuperuser()
 	if event.GetNewGroups() == nil {
 		currentUserInfo.Groups = nil
-		if !currentUserInfo.GetCanBeSuperuser() {
-			currentUserInfo.Superuser = false
+	} else {
+		currentUserInfo.Groups = &accounts.AccountGroups{
+			Groups: slices.Clone(event.GetNewGroups().GetGroups()),
 		}
-		return
 	}
 
-	currentUserInfo.Groups = &accounts.AccountGroups{
-		Groups: slices.Clone(event.GetNewGroups().GetGroups()),
-	}
 	if !currentUserInfo.GetCanBeSuperuser() {
 		currentUserInfo.Superuser = false
+	}
+
+	if wasSuperuser && !currentUserInfo.GetCanBeSuperuser() &&
+		currentUserInfo.GetOriginalJob() != nil {
+		currentUserInfo.Job = currentUserInfo.GetOriginalJob().GetJob()
+		currentUserInfo.JobGrade = currentUserInfo.GetOriginalJob().GetJobGrade()
 	}
 }
 
@@ -279,6 +283,35 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 		}
 
 		return nil
+	}
+
+	rebuildAndRefreshSubjects := func() error {
+		newBaseSubjects, newAdditionalSubjects, err := s.buildSubjects(gctx, currentUserInfo)
+		if err != nil {
+			return errswrap.NewError(err, ErrFailedStream)
+		}
+
+		subjectsMu.Lock()
+		baseSubjects = newBaseSubjects
+		additionalSubjects = newAdditionalSubjects
+		clientView := currentClientView
+		subjectsMu.Unlock()
+
+		if clientView != nil {
+			newClientViewSubjects, err := s.buildClientViewSubjects(
+				gctx,
+				currentUserInfo,
+				clientView,
+			)
+			if err != nil {
+				return err
+			}
+			subjectsMu.Lock()
+			clientViewSubjects = newClientViewSubjects
+			subjectsMu.Unlock()
+		}
+
+		return refreshConsumerSubjects()
 	}
 
 	g.Go(func() error {
@@ -409,41 +442,13 @@ func (s *Server) Stream(srv pbnotifications.NotificationsService_StreamServer) e
 							needsSubjectRefresh = true
 						}
 
-					case *notificationsevents.UserEvent_UserGroupsChanged:
-						applyUserGroupsChanged(currentUserInfo, d.UserGroupsChanged)
+					case *notificationsevents.UserEvent_AccountGroupsChanged:
+						applyAccountGroupsChanged(currentUserInfo, d.AccountGroupsChanged)
 						needsSubjectRefresh = true
 					}
 
 					if needsSubjectRefresh {
-						newBaseSubjects, newAdditionalSubjects, err := s.buildSubjects(
-							gctx,
-							currentUserInfo,
-						)
-						if err != nil {
-							return errswrap.NewError(err, ErrFailedStream)
-						}
-
-						subjectsMu.Lock()
-						baseSubjects = newBaseSubjects
-						additionalSubjects = newAdditionalSubjects
-						clientView := currentClientView
-						subjectsMu.Unlock()
-
-						if clientView != nil {
-							newClientViewSubjects, err := s.buildClientViewSubjects(
-								gctx,
-								currentUserInfo,
-								clientView,
-							)
-							if err != nil {
-								return err
-							}
-							subjectsMu.Lock()
-							clientViewSubjects = newClientViewSubjects
-							subjectsMu.Unlock()
-						}
-
-						if err := refreshConsumerSubjects(); err != nil {
+						if err := rebuildAndRefreshSubjects(); err != nil {
 							return err
 						}
 					}

--- a/services/notifications/stream_test.go
+++ b/services/notifications/stream_test.go
@@ -39,14 +39,14 @@ func TestApplyUserInfoChangedIgnoresNil(t *testing.T) {
 	assert.Equal(t, int32(1), current.GetJobGrade())
 }
 
-func TestApplyUserGroupsChanged(t *testing.T) {
+func TestApplyAccountGroupsChanged(t *testing.T) {
 	t.Parallel()
 
 	current := &pbuserinfo.UserInfo{
 		Groups: &accounts.AccountGroups{Groups: []string{"old"}},
 	}
 
-	applyUserGroupsChanged(current, &pbuserinfo.UserGroupsChanged{
+	applyAccountGroupsChanged(current, &pbuserinfo.AccountGroupsChanged{
 		NewGroups:      &accounts.AccountGroups{Groups: []string{"supporter", "donator"}},
 		CanBeSuperuser: true,
 	})
@@ -55,16 +55,39 @@ func TestApplyUserGroupsChanged(t *testing.T) {
 	assert.True(t, current.GetCanBeSuperuser())
 }
 
-func TestApplyUserGroupsChangedClearsNil(t *testing.T) {
+func TestApplyAccountGroupsChangedClearsNil(t *testing.T) {
 	t.Parallel()
 
 	current := &pbuserinfo.UserInfo{
 		Groups: &accounts.AccountGroups{Groups: []string{"old"}},
 	}
 
-	applyUserGroupsChanged(current, &pbuserinfo.UserGroupsChanged{})
+	applyAccountGroupsChanged(current, &pbuserinfo.AccountGroupsChanged{})
 
 	assert.Nil(t, current.GetGroups())
 	assert.False(t, current.GetCanBeSuperuser())
 	assert.False(t, current.GetSuperuser())
+}
+
+func TestApplyAccountGroupsChangedRestoresOriginalJobWhenRevokingSuperuser(t *testing.T) {
+	t.Parallel()
+
+	current := &pbuserinfo.UserInfo{
+		Job:       "ems-super",
+		JobGrade:  7,
+		Superuser: true,
+		OriginalJob: &pbuserinfo.OriginalJob{
+			Job:      "ems",
+			JobGrade: 2,
+		},
+	}
+
+	applyAccountGroupsChanged(current, &pbuserinfo.AccountGroupsChanged{
+		CanBeSuperuser: false,
+	})
+
+	assert.False(t, current.GetCanBeSuperuser())
+	assert.False(t, current.GetSuperuser())
+	assert.Equal(t, "ems", current.GetJob())
+	assert.Equal(t, int32(2), current.GetJobGrade())
 }

--- a/services/notifications/stream_test.go
+++ b/services/notifications/stream_test.go
@@ -1,0 +1,70 @@
+package notifications
+
+import (
+	"testing"
+
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
+	pbuserinfo "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyUserInfoChanged(t *testing.T) {
+	t.Parallel()
+
+	current := &pbuserinfo.UserInfo{
+		Job:      "police",
+		JobGrade: 1,
+	}
+
+	applyUserInfoChanged(current, &pbuserinfo.UserInfoChanged{
+		NewJob:      func() *string { v := "ems"; return &v }(),
+		NewJobGrade: func() *int32 { v := int32(3); return &v }(),
+	})
+
+	assert.Equal(t, "ems", current.GetJob())
+	assert.Equal(t, int32(3), current.GetJobGrade())
+}
+
+func TestApplyUserInfoChangedIgnoresNil(t *testing.T) {
+	t.Parallel()
+
+	current := &pbuserinfo.UserInfo{
+		Job:      "police",
+		JobGrade: 1,
+	}
+
+	applyUserInfoChanged(current, nil)
+
+	assert.Equal(t, "police", current.GetJob())
+	assert.Equal(t, int32(1), current.GetJobGrade())
+}
+
+func TestApplyUserGroupsChanged(t *testing.T) {
+	t.Parallel()
+
+	current := &pbuserinfo.UserInfo{
+		Groups: &accounts.AccountGroups{Groups: []string{"old"}},
+	}
+
+	applyUserGroupsChanged(current, &pbuserinfo.UserGroupsChanged{
+		NewGroups:      &accounts.AccountGroups{Groups: []string{"supporter", "donator"}},
+		CanBeSuperuser: true,
+	})
+
+	assert.Equal(t, []string{"supporter", "donator"}, current.GetGroups().GetGroups())
+	assert.True(t, current.GetCanBeSuperuser())
+}
+
+func TestApplyUserGroupsChangedClearsNil(t *testing.T) {
+	t.Parallel()
+
+	current := &pbuserinfo.UserInfo{
+		Groups: &accounts.AccountGroups{Groups: []string{"old"}},
+	}
+
+	applyUserGroupsChanged(current, &pbuserinfo.UserGroupsChanged{})
+
+	assert.Nil(t, current.GetGroups())
+	assert.False(t, current.GetCanBeSuperuser())
+	assert.False(t, current.GetSuperuser())
+}

--- a/services/sync/server.go
+++ b/services/sync/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
 	"github.com/fivenet-app/fivenet/v2026/pkg/config"
+	"github.com/fivenet-app/fivenet/v2026/pkg/config/appconfig"
 	"github.com/fivenet-app/fivenet/v2026/pkg/events"
 	pkggrpc "github.com/fivenet-app/fivenet/v2026/pkg/grpc"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
@@ -59,6 +60,7 @@ type Params struct {
 	JS            *events.JSWrapper
 	Auth          *auth.GRPCAuth
 	Config        *config.Config
+	AppConfig     appconfig.IConfig
 	DispatchDB    *dispatches.DispatchDB
 	CitizensStore citizensstore.IStore
 	JobsStore     jobsstore.IStore
@@ -84,6 +86,7 @@ func NewServer(p Params) Result {
 			p.DB,
 			p.Logger,
 			p.Config,
+			p.AppConfig,
 			p.DispatchDB,
 			p.CitizensStore,
 			p.JobsStore,

--- a/services/sync/server.go
+++ b/services/sync/server.go
@@ -16,6 +16,8 @@ import (
 	pkggrpc "github.com/fivenet-app/fivenet/v2026/pkg/grpc"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	errorsgrpcauth "github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth/errors"
+	"github.com/fivenet-app/fivenet/v2026/pkg/mstlystcdata"
+	"github.com/fivenet-app/fivenet/v2026/pkg/notifi"
 	"github.com/fivenet-app/fivenet/v2026/services/centrum/dispatches"
 	citizensstore "github.com/fivenet-app/fivenet/v2026/stores/citizens"
 	jobsstore "github.com/fivenet-app/fivenet/v2026/stores/jobs"
@@ -60,6 +62,8 @@ type Params struct {
 	DispatchDB    *dispatches.DispatchDB
 	CitizensStore citizensstore.IStore
 	JobsStore     jobsstore.IStore
+	Enricher      mstlystcdata.IEnricher
+	Notifi        notifi.INotifi
 }
 
 type Result struct {
@@ -76,7 +80,16 @@ func NewServer(p Params) Result {
 		js:     p.JS,
 		auth:   p.Auth,
 		cfg:    p.Config,
-		store:  syncstore.New(p.DB, p.Logger, p.Config, p.DispatchDB, p.CitizensStore, p.JobsStore),
+		store: syncstore.New(
+			p.DB,
+			p.Logger,
+			p.Config,
+			p.DispatchDB,
+			p.CitizensStore,
+			p.JobsStore,
+			p.Enricher,
+			p.Notifi,
+		),
 
 		dispatches:    p.DispatchDB,
 		citizensStore: p.CitizensStore,

--- a/stores/completor/citizens_test.go
+++ b/stores/completor/citizens_test.go
@@ -34,7 +34,7 @@ func TestStoreCompleteCitizensAppliesSearchAndCustomFilter(t *testing.T) {
 		`(?s).*` + regexp.QuoteMeta(`ORDER BY user_short.lastname ASC LIMIT ?;`)
 
 	mock.ExpectQuery(expectedQuery).
-		WithArgs(true, "", "", " ", "%John%", int64(15)).
+		WithArgs(true, "", "", " ", "%John%", int64(20)).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"user_short.id",
 			"user_short.firstname",
@@ -74,7 +74,7 @@ func TestStoreCompleteCitizensAddsCurrentJobColumnsAndOrdering(t *testing.T) {
 		`(?s).*` + regexp.QuoteMeta(`ORDER BY user_short.id IN (?, ?) DESC, user_short.lastname ASC LIMIT ?;`)
 
 	mock.ExpectQuery(expectedQuery).
-		WithArgs(true, "", "", "police", int32(7), int32(9), int32(7), int32(9), int64(15)).
+		WithArgs(true, "", "", "police", int32(7), int32(9), int32(7), int32(9), int64(20)).
 		WillReturnRows(sqlmock.NewRows([]string{
 			"user_short.id",
 			"user_short.firstname",

--- a/stores/sync/account_groups.go
+++ b/stores/sync/account_groups.go
@@ -123,15 +123,15 @@ func (s *Store) publishAccountGroupsChanged(
 		superuserUsers = s.cfg.Auth.SuperuserUsers
 	}
 
-	event := pkguserinfo.BuildUserGroupsChangedEvent(
+	event := pkguserinfo.BuildAccountGroupsChangedEvent(
 		accountID,
 		nil,
 		groups,
 		pkguserinfo.CanBeSuperuser(groups, license, superuserGroups, superuserUsers),
 	)
 	if err := s.notifi.SendAccountEvent(ctx, accountID, &notificationsevents.UserEvent{
-		Data: &notificationsevents.UserEvent_UserGroupsChanged{
-			UserGroupsChanged: event,
+		Data: &notificationsevents.UserEvent_AccountGroupsChanged{
+			AccountGroupsChanged: event,
 		},
 	}); err != nil {
 		groupNames := []string(nil)

--- a/stores/sync/account_groups.go
+++ b/stores/sync/account_groups.go
@@ -1,0 +1,148 @@
+package syncstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
+	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
+	activity "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/activity"
+	pkguserinfo "github.com/fivenet-app/fivenet/v2026/pkg/userinfo"
+	"github.com/fivenet-app/fivenet/v2026/query/fivenet/table"
+	"github.com/go-jet/jet/v2/mysql"
+	"go.uber.org/zap"
+)
+
+type accountGroupState struct {
+	ID      int64
+	License string
+	Groups  *accounts.AccountGroups
+}
+
+type accountGroupChange struct {
+	accountID int64
+	license   string
+	groups    *accounts.AccountGroups
+}
+
+func accountGroupsFromSyncUpdate(update *activity.AccountUpdate) *accounts.AccountGroups {
+	if update == nil {
+		return nil
+	}
+
+	if update.GetGroups() != nil && len(update.GetGroups().GetGroups()) > 0 {
+		return &accounts.AccountGroups{Groups: slices.Clone(update.GetGroups().GetGroups())}
+	}
+
+	if update.GetGroup() != "" {
+		return &accounts.AccountGroups{Groups: []string{update.GetGroup()}}
+	}
+
+	return nil
+}
+
+func accountGroupsEqual(a, b *accounts.AccountGroups) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+
+	return a.Equal(b)
+}
+
+func accountGroupsFromState(state *accountGroupState) *accounts.AccountGroups {
+	if state == nil || state.Groups == nil || len(state.Groups.GetGroups()) == 0 {
+		return nil
+	}
+
+	return &accounts.AccountGroups{Groups: slices.Clone(state.Groups.GetGroups())}
+}
+
+func (s *Store) loadAccountGroupState(
+	ctx context.Context,
+	tx *sql.Tx,
+	license string,
+) (*accountGroupState, error) {
+	if license == "" {
+		return nil, nil
+	}
+
+	tAccounts := table.FivenetAccounts
+	stmt := tAccounts.
+		SELECT(
+			tAccounts.ID.AS("id"),
+			tAccounts.License.AS("license"),
+			tAccounts.Groups.AS("groups"),
+		).
+		FROM(tAccounts).
+		WHERE(tAccounts.License.EQ(mysql.String(license))).
+		LIMIT(1)
+
+	dest := &accountGroupState{}
+	sqlStmt, args := stmt.Sql()
+	row := tx.QueryRowContext(ctx, sqlStmt, args...)
+	var groups sql.NullString
+	if err := row.Scan(&dest.ID, &dest.License, &groups); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to query account groups for license %s. %w", license, err)
+	}
+
+	if dest.ID == 0 {
+		return nil, nil
+	}
+	if groups.Valid {
+		dest.Groups = &accounts.AccountGroups{}
+		if err := dest.Groups.Scan(groups.String); err != nil {
+			return nil, fmt.Errorf("failed to scan account groups for license %s. %w", license, err)
+		}
+	}
+
+	return dest, nil
+}
+
+func (s *Store) publishAccountGroupsChanged(
+	ctx context.Context,
+	accountID int64,
+	license string,
+	groups *accounts.AccountGroups,
+) {
+	if s.notifi == nil {
+		return
+	}
+
+	superuserGroups, superuserUsers := []string(nil), []string(nil)
+	if s.cfg != nil {
+		superuserGroups = s.cfg.Auth.SuperuserGroups
+		superuserUsers = s.cfg.Auth.SuperuserUsers
+	}
+
+	event := pkguserinfo.BuildUserGroupsChangedEvent(
+		accountID,
+		nil,
+		groups,
+		pkguserinfo.CanBeSuperuser(groups, license, superuserGroups, superuserUsers),
+	)
+	if err := s.notifi.SendAccountEvent(ctx, accountID, &notificationsevents.UserEvent{
+		Data: &notificationsevents.UserEvent_UserGroupsChanged{
+			UserGroupsChanged: event,
+		},
+	}); err != nil {
+		groupNames := []string(nil)
+		if groups != nil {
+			groupNames = groups.GetGroups()
+		}
+		s.logger.Warn(
+			"failed to publish account group change event",
+			zap.Int64("account_id", accountID),
+			zap.Strings("groups", groupNames),
+			zap.Error(err),
+		)
+	}
+}

--- a/stores/sync/accounts.go
+++ b/stores/sync/accounts.go
@@ -166,16 +166,20 @@ func (s *Store) AddUserOAuth2Conn(
 }
 
 func (s *Store) handleAccountUpdate(ctx context.Context, data *activity.AccountUpdate) error {
-	tAccounts := table.FivenetAccounts
-
-	var groups *accounts.AccountGroups
-	if data.GetGroups() != nil {
-		if data.GetGroups() != nil && len(data.GetGroups().GetGroups()) > 0 {
-			groups = data.GetGroups()
-		} else if data.GetGroup() != "" {
-			groups = &accounts.AccountGroups{Groups: []string{data.GetGroup()}}
-		}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
 	}
+	defer tx.Rollback()
+
+	tAccounts := table.FivenetAccounts
+	groups := accountGroupsFromSyncUpdate(data)
+
+	current, err := s.loadAccountGroupState(ctx, tx, data.GetLicense())
+	if err != nil {
+		return err
+	}
+	changed := current != nil && !accountGroupsEqual(accountGroupsFromState(current), groups)
 
 	stmt := tAccounts.
 		UPDATE(tAccounts.Groups).
@@ -183,8 +187,16 @@ func (s *Store) handleAccountUpdate(ctx context.Context, data *activity.AccountU
 		WHERE(tAccounts.License.EQ(mysql.String(data.GetLicense()))).
 		LIMIT(1)
 
-	if _, err := stmt.ExecContext(ctx, s.db); err != nil {
+	if _, err := stmt.ExecContext(ctx, tx); err != nil {
 		return fmt.Errorf("failed to update account. %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+
+	if changed {
+		s.publishAccountGroupsChanged(ctx, current.ID, current.License, groups)
 	}
 
 	return nil

--- a/stores/sync/accounts_test.go
+++ b/stores/sync/accounts_test.go
@@ -39,7 +39,7 @@ func TestHandleAccountUpdatePublishesGroupChange(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Len(t, rec.events, 1)
-	evt := rec.events[0].GetUserGroupsChanged()
+	evt := rec.events[0].GetAccountGroupsChanged()
 	require.NotNil(t, evt)
 	assert.Equal(t, int64(42), evt.GetAccountId())
 	require.NotNil(t, evt.GetNewGroups())

--- a/stores/sync/accounts_test.go
+++ b/stores/sync/accounts_test.go
@@ -1,0 +1,110 @@
+package syncstore
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
+	activity "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/activity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleAccountUpdatePublishesGroupChange(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`SELECT fivenet_accounts.id AS "id", fivenet_accounts.license AS "license", fivenet_accounts.`+"`groups`"+` AS "groups" FROM fivenet_accounts WHERE fivenet_accounts.license = ? LIMIT ?;`,
+		),
+	).
+		WithArgs("license-42", int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "license", "groups"}).
+			AddRow(int64(42), "license-42", []byte(`["old"]`)))
+	mock.ExpectExec(`(?s)UPDATE .*fivenet_accounts.*SET .*groups.*WHERE .*license = \?.*LIMIT \?.*`).
+		WithArgs(sqlmock.AnyArg(), "license-42", int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := store.handleAccountUpdate(t.Context(), &activity.AccountUpdate{
+		License: "license-42",
+		Groups:  &accounts.AccountGroups{Groups: []string{"supporter", "donator"}},
+	})
+	require.NoError(t, err)
+
+	require.Len(t, rec.events, 1)
+	evt := rec.events[0].GetUserGroupsChanged()
+	require.NotNil(t, evt)
+	assert.Equal(t, int64(42), evt.GetAccountId())
+	require.NotNil(t, evt.GetNewGroups())
+	assert.Equal(t, []string{"supporter", "donator"}, evt.GetNewGroups().GetGroups())
+	assert.False(t, evt.GetCanBeSuperuser())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestLoadAccountGroupState(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`SELECT fivenet_accounts.id AS "id", fivenet_accounts.license AS "license", fivenet_accounts.`+"`groups`"+` AS "groups" FROM fivenet_accounts WHERE fivenet_accounts.license = ? LIMIT ?;`,
+		),
+	).
+		WithArgs("license-42", int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "license", "groups"}).
+			AddRow(int64(42), "license-42", []byte(`["old"]`)))
+	mock.ExpectRollback()
+
+	tx, err := store.db.Begin()
+	require.NoError(t, err)
+
+	state, err := store.loadAccountGroupState(t.Context(), tx, "license-42")
+	require.NoError(t, err)
+	require.NotNil(t, state)
+	assert.Equal(t, int64(42), state.ID)
+	assert.Equal(t, []string{"old"}, state.Groups.GetGroups())
+
+	require.NoError(t, tx.Rollback())
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleAccountUpdateNoopDoesNotPublish(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`SELECT fivenet_accounts.id AS "id", fivenet_accounts.license AS "license", fivenet_accounts.`+"`groups`"+` AS "groups" FROM fivenet_accounts WHERE fivenet_accounts.license = ? LIMIT ?;`,
+		),
+	).
+		WithArgs("license-42", int64(1)).
+		WillReturnRows(sqlmock.NewRows([]string{"id", "license", "groups"}).
+			AddRow(int64(42), "license-42", []byte(`["supporter","donator"]`)))
+	mock.ExpectExec(`(?s)UPDATE .*fivenet_accounts.*SET .*groups.*WHERE .*license = \?.*LIMIT \?.*`).
+		WithArgs(sqlmock.AnyArg(), "license-42", int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	err := store.handleAccountUpdate(t.Context(), &activity.AccountUpdate{
+		License: "license-42",
+		Groups:  &accounts.AccountGroups{Groups: []string{"supporter", "donator"}},
+	})
+	require.NoError(t, err)
+
+	assert.Empty(t, rec.events)
+	require.NoError(t, mock.ExpectationsWereMet())
+}

--- a/stores/sync/data.go
+++ b/stores/sync/data.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
 	citizenslicenses "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/citizens/licenses"
 	syncactivity "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/activity"
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
@@ -178,6 +177,7 @@ func (s *Store) handleAccountsData(
 	tAccounts := table.FivenetAccounts
 	rowsAffected := int64(0)
 	accountLicenses := make([]mysql.Expression, 0, len(data))
+	pendingGroupChanges := make([]accountGroupChange, 0, len(data))
 	for _, account := range data {
 		license := account.GetLicense()
 		if license == "" {
@@ -185,11 +185,19 @@ func (s *Store) handleAccountsData(
 		}
 		accountLicenses = append(accountLicenses, mysql.String(license))
 
-		var groups *accounts.AccountGroups
-		if account.GetGroups() != nil && len(account.GetGroups().GetGroups()) > 0 {
-			groups = account.GetGroups()
-		} else if account.GetGroup() != "" {
-			groups = &accounts.AccountGroups{Groups: []string{account.GetGroup()}}
+		groups := accountGroupsFromSyncUpdate(account)
+
+		current, err := s.loadAccountGroupState(ctx, tx, license)
+		if err != nil {
+			return 0, err
+		}
+		currentGroups := accountGroupsFromState(current)
+		if current != nil && !accountGroupsEqual(currentGroups, groups) {
+			pendingGroupChanges = append(pendingGroupChanges, accountGroupChange{
+				accountID: current.ID,
+				license:   current.License,
+				groups:    groups,
+			})
 		}
 
 		stmt := tAccounts.
@@ -215,25 +223,44 @@ func (s *Store) handleAccountsData(
 		rowsAffected += rows
 	}
 
-	if clearGroups && len(data) > 0 && len(accountLicenses) == 0 {
-		if err := tx.Commit(); err != nil {
-			return 0, err
+	if clearGroups {
+		clearCandidates := []*accountGroupState{}
+		clearQuery := tAccounts.
+			SELECT(
+				tAccounts.ID.AS("id"),
+				tAccounts.License.AS("license"),
+				tAccounts.Groups.AS("groups"),
+			).
+			FROM(tAccounts)
+		clearConditions := []mysql.BoolExpression{tAccounts.Groups.IS_NOT_NULL()}
+		if len(accountLicenses) > 0 {
+			clearConditions = append(clearConditions, tAccounts.License.NOT_IN(accountLicenses...))
+		}
+		clearQuery = clearQuery.WHERE(mysql.AND(clearConditions...))
+		if err := clearQuery.QueryContext(ctx, tx, &clearCandidates); err != nil {
+			return 0, fmt.Errorf("failed to query account groups to clear. %w", err)
+		}
+		for _, acc := range clearCandidates {
+			if len(acc.Groups.GetGroups()) == 0 {
+				continue
+			}
+			pendingGroupChanges = append(pendingGroupChanges, accountGroupChange{
+				accountID: acc.ID,
+				license:   acc.License,
+				groups:    nil,
+			})
 		}
 
-		return rowsAffected, nil
-	}
-
-	if clearGroups {
-		clearStmt := tAccounts.
+		clearUpdate := tAccounts.
 			UPDATE(tAccounts.Groups).
 			SET(mysql.StringExp(mysql.NULL))
 
 		if len(accountLicenses) > 0 {
-			clearStmt = clearStmt.
+			clearUpdate = clearUpdate.
 				WHERE(tAccounts.License.NOT_IN(accountLicenses...))
 		}
 
-		res, err := clearStmt.ExecContext(ctx, tx)
+		res, err := clearUpdate.ExecContext(ctx, tx)
 		if err != nil {
 			return 0, fmt.Errorf("failed to execute accounts clear statement. %w", err)
 		}
@@ -246,6 +273,10 @@ func (s *Store) handleAccountsData(
 
 	if err := tx.Commit(); err != nil {
 		return 0, err
+	}
+
+	for _, change := range pendingGroupChanges {
+		s.publishAccountGroupsChanged(ctx, change.accountID, change.license, change.groups)
 	}
 
 	return rowsAffected, nil

--- a/stores/sync/data.go
+++ b/stores/sync/data.go
@@ -223,21 +223,23 @@ func (s *Store) handleAccountsData(
 		rowsAffected += rows
 	}
 
-	if clearGroups {
+	// Skip clearing when the request has entries, but none of them carry a license.
+	skipClearGroups := clearGroups && len(data) > 0 && len(accountLicenses) == 0
+	if clearGroups && !skipClearGroups {
 		clearCandidates := []*accountGroupState{}
-		clearQuery := tAccounts.
+		clearQueryStmt := tAccounts.
 			SELECT(
-				tAccounts.ID.AS("id"),
-				tAccounts.License.AS("license"),
-				tAccounts.Groups.AS("groups"),
+				tAccounts.ID.AS("account_group_state.id"),
+				tAccounts.License.AS("account_group_state.license"),
+				tAccounts.Groups.AS("account_group_state.groups"),
 			).
 			FROM(tAccounts)
 		clearConditions := []mysql.BoolExpression{tAccounts.Groups.IS_NOT_NULL()}
 		if len(accountLicenses) > 0 {
 			clearConditions = append(clearConditions, tAccounts.License.NOT_IN(accountLicenses...))
 		}
-		clearQuery = clearQuery.WHERE(mysql.AND(clearConditions...))
-		if err := clearQuery.QueryContext(ctx, tx, &clearCandidates); err != nil {
+		clearQueryStmt = clearQueryStmt.WHERE(mysql.AND(clearConditions...))
+		if err := clearQueryStmt.QueryContext(ctx, tx, &clearCandidates); err != nil {
 			return 0, fmt.Errorf("failed to query account groups to clear. %w", err)
 		}
 		for _, acc := range clearCandidates {
@@ -251,16 +253,16 @@ func (s *Store) handleAccountsData(
 			})
 		}
 
-		clearUpdate := tAccounts.
+		clearUpdateStmt := tAccounts.
 			UPDATE(tAccounts.Groups).
 			SET(mysql.StringExp(mysql.NULL))
 
 		if len(accountLicenses) > 0 {
-			clearUpdate = clearUpdate.
+			clearUpdateStmt = clearUpdateStmt.
 				WHERE(tAccounts.License.NOT_IN(accountLicenses...))
 		}
 
-		res, err := clearUpdate.ExecContext(ctx, tx)
+		res, err := clearUpdateStmt.ExecContext(ctx, tx)
 		if err != nil {
 			return 0, fmt.Errorf("failed to execute accounts clear statement. %w", err)
 		}

--- a/stores/sync/store.go
+++ b/stores/sync/store.go
@@ -7,6 +7,7 @@ import (
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
 	"github.com/fivenet-app/fivenet/v2026/pkg/config"
+	"github.com/fivenet-app/fivenet/v2026/pkg/config/appconfig"
 	"github.com/fivenet-app/fivenet/v2026/pkg/mstlystcdata"
 	"github.com/fivenet-app/fivenet/v2026/pkg/notifi"
 	"github.com/fivenet-app/fivenet/v2026/services/centrum/dispatches"
@@ -108,6 +109,7 @@ type Store struct {
 
 	logger *zap.Logger
 	cfg    *config.Config
+	appCfg appconfig.IConfig
 
 	enricher mstlystcdata.IEnricher
 	notifi   notifi.INotifi
@@ -121,6 +123,7 @@ func New(
 	db *sql.DB,
 	logger *zap.Logger,
 	cfg *config.Config,
+	appCfg appconfig.IConfig,
 	dispatches *dispatches.DispatchDB,
 	citizensStore citizensstore.IStore,
 	jobsStore jobsstore.IStore,
@@ -131,6 +134,7 @@ func New(
 		db:            db,
 		logger:        logger,
 		cfg:           cfg,
+		appCfg:        appCfg,
 		enricher:      enricher,
 		notifi:        notifi,
 		dispatches:    dispatches,

--- a/stores/sync/store.go
+++ b/stores/sync/store.go
@@ -7,6 +7,8 @@ import (
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
 	"github.com/fivenet-app/fivenet/v2026/pkg/config"
+	"github.com/fivenet-app/fivenet/v2026/pkg/mstlystcdata"
+	"github.com/fivenet-app/fivenet/v2026/pkg/notifi"
 	"github.com/fivenet-app/fivenet/v2026/services/centrum/dispatches"
 	citizensstore "github.com/fivenet-app/fivenet/v2026/stores/citizens"
 	jobsstore "github.com/fivenet-app/fivenet/v2026/stores/jobs"
@@ -107,6 +109,9 @@ type Store struct {
 	logger *zap.Logger
 	cfg    *config.Config
 
+	enricher mstlystcdata.IEnricher
+	notifi   notifi.INotifi
+
 	dispatches    *dispatches.DispatchDB
 	citizensStore citizensstore.IStore
 	jobsStore     jobsstore.IStore
@@ -119,11 +124,15 @@ func New(
 	dispatches *dispatches.DispatchDB,
 	citizensStore citizensstore.IStore,
 	jobsStore jobsstore.IStore,
+	enricher mstlystcdata.IEnricher,
+	notifi notifi.INotifi,
 ) IStore {
 	return &Store{
 		db:            db,
 		logger:        logger,
 		cfg:           cfg,
+		enricher:      enricher,
+		notifi:        notifi,
 		dispatches:    dispatches,
 		citizensStore: citizensStore,
 		jobsStore:     jobsStore,

--- a/stores/sync/users.go
+++ b/stores/sync/users.go
@@ -11,11 +11,13 @@ import (
 	"time"
 
 	userslicenses "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/citizens/licenses"
+	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
 	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
+	pkguserinfo "github.com/fivenet-app/fivenet/v2026/pkg/userinfo"
 	"github.com/fivenet-app/fivenet/v2026/pkg/utils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/utils/protoutils"
 	"github.com/fivenet-app/fivenet/v2026/query/fivenet/table"
@@ -42,6 +44,11 @@ type existingUser struct {
 	UserID     int32  `alias:"user_id"`
 	Identifier string `alias:"identifier"`
 	DataHash   uint64 `alias:"data_hash"`
+}
+
+type userJobChange struct {
+	job   string
+	grade int32
 }
 
 func (s *Store) SendUsers(ctx context.Context, data []*syncdata.DataUser) (int64, error) {
@@ -233,8 +240,6 @@ func (s *Store) handleUsersData(ctx context.Context, us []*syncdata.DataUser) (i
 
 	if len(toUpdate) > 0 {
 		for _, user := range toUpdate {
-			// TODO compare user's primary job and notify user via stream userInfoChanged event
-
 			affected, err := s.updateUser(ctx, syncedAt, user)
 			if err != nil {
 				return 0, fmt.Errorf(
@@ -347,7 +352,7 @@ func (s *Store) createUser(
 	if err := s.createOrUpdateSyncUserEntry(ctx, tx, syncedAt, user); err != nil {
 		return 0, err
 	}
-	if err := s.syncUserAccount(ctx, tx, user.GetUserId(), user.GetIdentifier()); err != nil {
+	if _, err := s.syncUserAccount(ctx, tx, user.GetUserId(), user.GetIdentifier()); err != nil {
 		return 0, fmt.Errorf(
 			"failed to handle user account mapping for user %d (%s). %w",
 			user.GetUserId(),
@@ -355,7 +360,7 @@ func (s *Store) createUser(
 			err,
 		)
 	}
-	if err := s.handleUserJobs(ctx, tx, user.GetUserId(), user.GetJobs()); err != nil {
+	if _, err := s.handleUserJobs(ctx, tx, user); err != nil {
 		return 0, fmt.Errorf(
 			"failed to handle user jobs for user %d (%s). %w",
 			user.GetUserId(),
@@ -443,10 +448,10 @@ func (s *Store) syncUserAccount(
 	tx *sql.Tx,
 	userID int32,
 	identifier string,
-) error {
+) (*int64, error) {
 	accountID, err := s.resolveUserAccountID(ctx, tx, identifier)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if accountID == nil {
@@ -455,9 +460,13 @@ func (s *Store) syncUserAccount(
 			WHERE(tUserAccounts.UserID.EQ(mysql.Int32(userID))).
 			LIMIT(1)
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
-			return fmt.Errorf("failed to delete user account mapping for user %d. %w", userID, err)
+			return nil, fmt.Errorf(
+				"failed to delete user account mapping for user %d. %w",
+				userID,
+				err,
+			)
 		}
-		return nil
+		return nil, nil
 	}
 
 	stmt := tUserAccounts.
@@ -473,10 +482,10 @@ func (s *Store) syncUserAccount(
 			tUserAccounts.AccountID.SET(mysql.RawInt("VALUES(`account_id`)")),
 		)
 	if _, err := stmt.ExecContext(ctx, tx); err != nil {
-		return fmt.Errorf("failed to upsert user account mapping for user %d. %w", userID, err)
+		return nil, fmt.Errorf("failed to upsert user account mapping for user %d. %w", userID, err)
 	}
 
-	return nil
+	return accountID, nil
 }
 
 func (s *Store) createOrUpdateSyncUserEntry(
@@ -610,7 +619,8 @@ func (s *Store) updateUser(
 	if err := s.createOrUpdateSyncUserEntry(ctx, tx, syncedAt, user); err != nil {
 		return 0, err
 	}
-	if err := s.syncUserAccount(ctx, tx, user.GetUserId(), user.GetIdentifier()); err != nil {
+	accountID, err := s.syncUserAccount(ctx, tx, user.GetUserId(), user.GetIdentifier())
+	if err != nil {
 		return 0, fmt.Errorf(
 			"failed to handle user account mapping for user %d (%s). %w",
 			user.GetUserId(),
@@ -618,7 +628,8 @@ func (s *Store) updateUser(
 			err,
 		)
 	}
-	if err := s.handleUserJobs(ctx, tx, user.GetUserId(), user.GetJobs()); err != nil {
+	jobChange, err := s.handleUserJobs(ctx, tx, user)
+	if err != nil {
 		return 0, fmt.Errorf(
 			"failed to handle user jobs for user %d (%s). %w",
 			user.GetUserId(),
@@ -651,6 +662,8 @@ func (s *Store) updateUser(
 	if err := tx.Commit(); err != nil {
 		return 0, err
 	}
+
+	s.publishUserInfoChanged(ctx, accountID, user.GetUserId(), jobChange)
 
 	return rows, nil
 }
@@ -727,9 +740,9 @@ func (s *Store) handleUserLicenses(
 func (s *Store) handleUserJobs(
 	ctx context.Context,
 	tx *sql.Tx,
-	userId int32,
-	jobs []*users.UserJob,
-) error {
+	user *syncdata.DataUser,
+) (*userJobChange, error) {
+	jobs := user.GetJobs()
 	slices.SortFunc(jobs, func(a, b *users.UserJob) int {
 		if a.GetIsPrimary() && !b.GetIsPrimary() {
 			return -1
@@ -743,12 +756,12 @@ func (s *Store) handleUserJobs(
 	if len(jobs) == 0 {
 		stmt := tCitizensJobs.
 			DELETE().
-			WHERE(tCitizensJobs.UserID.EQ(mysql.Int32(userId))).
+			WHERE(tCitizensJobs.UserID.EQ(mysql.Int32(user.GetUserId()))).
 			LIMIT(25)
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
-			return fmt.Errorf("failed to execute user jobs delete statement. %w", err)
+			return nil, fmt.Errorf("failed to execute user jobs delete statement. %w", err)
 		}
-		return nil
+		return nil, nil
 	}
 
 	tJobs := tCitizensJobs.AS("user_job")
@@ -759,13 +772,28 @@ func (s *Store) handleUserJobs(
 			tJobs.IsPrimary,
 		).
 		FROM(tJobs).
-		WHERE(tJobs.UserID.EQ(mysql.Int32(userId))).
+		WHERE(tJobs.UserID.EQ(mysql.Int32(user.GetUserId()))).
 		ORDER_BY(tJobs.IsPrimary, tJobs.Job, tJobs.Grade)
 
 	currentJobs := []*users.UserJob{}
 	if err := selectStmt.QueryContext(ctx, tx, &currentJobs); err != nil {
 		if !errors.Is(err, qrm.ErrNoRows) {
-			return fmt.Errorf("failed to query current user jobs for user ID %d. %w", userId, err)
+			return nil, fmt.Errorf(
+				"failed to query current user jobs for user ID %d. %w",
+				user.GetUserId(),
+				err,
+			)
+		}
+	}
+
+	var jobChange *userJobChange
+	if currentPrimary := primaryJob(currentJobs); currentPrimary != nil {
+		if currentPrimary.GetJob() != user.GetJob() ||
+			currentPrimary.GetGrade() != user.GetJobGrade() {
+			jobChange = &userJobChange{
+				job:   user.GetJob(),
+				grade: user.GetJobGrade(),
+			}
 		}
 	}
 
@@ -779,7 +807,7 @@ func (s *Store) handleUserJobs(
 				tCitizensJobs.IsPrimary,
 			)
 		for _, t := range append(toAdd, toUpdate...) {
-			stmt = stmt.VALUES(userId, t.GetJob(), t.GetGrade(), t.GetIsPrimary())
+			stmt = stmt.VALUES(user.GetUserId(), t.GetJob(), t.GetGrade(), t.GetIsPrimary())
 		}
 		stmt = stmt.
 			ON_DUPLICATE_KEY_UPDATE(
@@ -788,10 +816,8 @@ func (s *Store) handleUserJobs(
 				tCitizensJobs.IsPrimary.SET(mysql.RawBool("VALUES(`is_primary`)")),
 			)
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
-			return fmt.Errorf("failed to execute user jobs insert statement. %w", err)
+			return nil, fmt.Errorf("failed to execute user jobs insert statement. %w", err)
 		}
-
-		// TODO send event to user stream on (primary) job change and/or trigger userinfo refresh
 	}
 
 	if len(toRemove) > 0 {
@@ -801,14 +827,60 @@ func (s *Store) handleUserJobs(
 		}
 		stmt := tCitizensJobs.
 			DELETE().
-			WHERE(mysql.AND(tCitizensJobs.UserID.EQ(mysql.Int32(userId)), tCitizensJobs.Job.IN(jobExprs...))).
+			WHERE(mysql.AND(tCitizensJobs.UserID.EQ(mysql.Int32(user.GetUserId())), tCitizensJobs.Job.IN(jobExprs...))).
 			LIMIT(int64(len(toRemove)))
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
-			return fmt.Errorf("failed to execute user jobs delete statement. %w", err)
+			return nil, fmt.Errorf("failed to execute user jobs delete statement. %w", err)
 		}
 	}
 
+	return jobChange, nil
+}
+
+func primaryJob(jobs []*users.UserJob) *users.UserJob {
+	for _, job := range jobs {
+		if job.GetIsPrimary() {
+			return job
+		}
+	}
+	if len(jobs) > 0 {
+		return jobs[0]
+	}
 	return nil
+}
+
+func (s *Store) publishUserInfoChanged(
+	ctx context.Context,
+	accountID *int64,
+	userID int32,
+	jobChange *userJobChange,
+) {
+	if jobChange == nil || accountID == nil || s.notifi == nil {
+		return
+	}
+
+	event := pkguserinfo.BuildUserInfoChangedEvent(
+		*accountID,
+		userID,
+		nil,
+		jobChange.job,
+		jobChange.grade,
+		s.enricher,
+	)
+
+	if err := s.notifi.SendUserEvent(ctx, userID, &notificationsevents.UserEvent{
+		Data: &notificationsevents.UserEvent_UserInfoChanged{
+			UserInfoChanged: event,
+		},
+	}); err != nil {
+		s.logger.Warn(
+			"failed to publish user info change event",
+			zap.Int32("user_id", userID),
+			zap.String("job", jobChange.job),
+			zap.Int32("job_grade", jobChange.grade),
+			zap.Error(err),
+		)
+	}
 }
 
 func compareJobs(

--- a/stores/sync/users.go
+++ b/stores/sync/users.go
@@ -12,10 +12,12 @@ import (
 
 	userslicenses "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/citizens/licenses"
 	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/settings"
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
+	"github.com/fivenet-app/fivenet/v2026/pkg/config/appconfig"
 	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	pkguserinfo "github.com/fivenet-app/fivenet/v2026/pkg/userinfo"
 	"github.com/fivenet-app/fivenet/v2026/pkg/utils"
@@ -743,6 +745,25 @@ func (s *Store) handleUserJobs(
 	user *syncdata.DataUser,
 ) (*userJobChange, error) {
 	jobs := user.GetJobs()
+	// Fallback to unemployed job when user has no jobs
+	if len(jobs) == 0 {
+		unemployedJob := unemployedJobFromAppConfig(s.appCfg)
+		jobs = []*users.UserJob{
+			{
+				UserId:    user.GetUserId(),
+				Job:       unemployedJob.GetName(),
+				Grade:     unemployedJob.GetGrade(),
+				IsPrimary: true,
+			},
+		}
+		user.Jobs = jobs
+		if user.GetJob() == "" {
+			user.Job = jobs[0].Job
+		}
+		if user.GetJobGrade() == 0 {
+			user.JobGrade = jobs[0].Grade
+		}
+	}
 	slices.SortFunc(jobs, func(a, b *users.UserJob) int {
 		if a.GetIsPrimary() && !b.GetIsPrimary() {
 			return -1
@@ -752,17 +773,6 @@ func (s *Store) handleUserJobs(
 		}
 		return strings.Compare(a.GetJob(), b.GetJob())
 	})
-
-	if len(jobs) == 0 {
-		stmt := tCitizensJobs.
-			DELETE().
-			WHERE(tCitizensJobs.UserID.EQ(mysql.Int32(user.GetUserId()))).
-			LIMIT(25)
-		if _, err := stmt.ExecContext(ctx, tx); err != nil {
-			return nil, fmt.Errorf("failed to execute user jobs delete statement. %w", err)
-		}
-		return nil, nil
-	}
 
 	tJobs := tCitizensJobs.AS("user_job")
 	selectStmt := tJobs.
@@ -787,13 +797,16 @@ func (s *Store) handleUserJobs(
 	}
 
 	var jobChange *userJobChange
-	if currentPrimary := primaryJob(currentJobs); currentPrimary != nil {
-		if currentPrimary.GetJob() != user.GetJob() ||
-			currentPrimary.GetGrade() != user.GetJobGrade() {
-			jobChange = &userJobChange{
-				job:   user.GetJob(),
-				grade: user.GetJobGrade(),
-			}
+	if currentPrimary := primaryJob(currentJobs); currentPrimary == nil {
+		jobChange = &userJobChange{
+			job:   user.GetJob(),
+			grade: user.GetJobGrade(),
+		}
+	} else if currentPrimary.GetJob() != user.GetJob() ||
+		currentPrimary.GetGrade() != user.GetJobGrade() {
+		jobChange = &userJobChange{
+			job:   user.GetJob(),
+			grade: user.GetJobGrade(),
 		}
 	}
 
@@ -835,6 +848,25 @@ func (s *Store) handleUserJobs(
 	}
 
 	return jobChange, nil
+}
+
+func unemployedJobFromAppConfig(appCfg appconfig.IConfig) *settings.UnemployedJob {
+	spec := &settings.UnemployedJob{
+		Name:  "unemployed",
+		Grade: 1,
+	}
+	if appCfg == nil || appCfg.Get() == nil || appCfg.Get().GetJobInfo() == nil {
+		return spec
+	}
+
+	unemployedJob := appCfg.Get().GetJobInfo().GetUnemployedJob()
+	if unemployedJob == nil {
+		return spec
+	}
+
+	spec.SetName(unemployedJob.GetName())
+	spec.SetGrade(unemployedJob.GetGrade())
+	return spec
 }
 
 func primaryJob(jobs []*users.UserJob) *users.UserJob {

--- a/stores/sync/users.go
+++ b/stores/sync/users.go
@@ -98,77 +98,9 @@ func (s *Store) handleUsersData(ctx context.Context, us []*syncdata.DataUser) (i
 	for i := range us {
 		userIds = append(userIds, mysql.Int32(us[i].GetUserId()))
 
-		if len(us[i].GetJobs()) == 0 {
-			if us[i].GetJob() == "" {
-				// Fallback to unemployed job when user has no job(s)
-				unemployedJob := unemployedJobFromAppConfig(s.appCfg)
-				jobs := []*users.UserJob{
-					{
-						UserId:    us[i].GetUserId(),
-						Job:       unemployedJob.GetName(),
-						Grade:     unemployedJob.GetGrade(),
-						IsPrimary: true,
-					},
-				}
-				us[i].SetJobs(jobs)
-				us[i].SetJob(jobs[0].Job)
-				us[i].SetJobGrade(jobs[0].Grade)
-			} else {
-				// Ensure user's job is set in the jobs list
-				us[i].SetJobs([]*users.UserJob{
-					{
-						Job:       us[i].GetJob(),
-						Grade:     us[i].GetJobGrade(),
-						IsPrimary: true,
-					},
-				})
-			}
-		} else {
-			slices.SortFunc(us[i].GetJobs(), func(a, b *users.UserJob) int {
-				if a.GetIsPrimary() && !b.GetIsPrimary() {
-					return -1
-				}
-				if !a.GetIsPrimary() && b.GetIsPrimary() {
-					return 1
-				}
-				return strings.Compare(a.GetJob(), b.GetJob())
-			})
+		s.cleanupUserJobs(us[i])
 
-			foundPrimary := false
-			primaryJob := us[i].GetJob()
-			for _, job := range us[i].GetJobs() {
-				if job.GetJob() == primaryJob {
-					foundPrimary = true
-					job.IsPrimary = true
-				} else {
-					job.IsPrimary = false
-				}
-			}
-			if !foundPrimary {
-				us[i].Jobs[0].IsPrimary = true
-			}
-		}
-
-		if len(us[i].GetPhoneNumbers()) == 0 {
-			if us[i].GetPhoneNumber() != "" {
-				us[i].PhoneNumbers = []*users.PhoneNumber{
-					{Number: us[i].GetPhoneNumber(), IsPrimary: true},
-				}
-			} else {
-				foundPrimary := false
-				for _, phoneNumber := range us[i].GetPhoneNumbers() {
-					if phoneNumber.GetNumber() == us[i].GetPhoneNumber() {
-						foundPrimary = true
-						phoneNumber.IsPrimary = true
-					} else {
-						phoneNumber.IsPrimary = false
-					}
-				}
-				if !foundPrimary && len(us[i].GetPhoneNumbers()) > 0 {
-					us[i].PhoneNumbers[0].IsPrimary = true
-				}
-			}
-		}
+		s.cleanupUserPhoneNumbers(us[i])
 	}
 
 	checkStmt := tSyncUser.
@@ -691,6 +623,125 @@ func (s *Store) updateUser(
 	return rows, nil
 }
 
+func (s *Store) cleanupUserJobs(user *syncdata.DataUser) {
+	jobs := user.GetJobs()
+	// Fallback to unemployed job when user has no jobs.
+	if len(jobs) == 0 {
+		if user.GetJob() == "" {
+			unemployedJob := unemployedJobFromAppConfig(s.appCfg)
+			jobs = []*users.UserJob{
+				{
+					UserId:    user.GetUserId(),
+					Job:       unemployedJob.GetName(),
+					Grade:     unemployedJob.GetGrade(),
+					IsPrimary: true,
+				},
+			}
+			user.SetJobs(jobs)
+			if user.GetJob() == "" {
+				user.SetJob(jobs[0].GetJob())
+			}
+			if user.GetJobGrade() == 0 {
+				user.SetJobGrade(jobs[0].GetGrade())
+			}
+		} else {
+			// Ensure user's job is set in the jobs list
+			user.SetJobs([]*users.UserJob{
+				{
+					Job:       user.GetJob(),
+					Grade:     user.GetJobGrade(),
+					IsPrimary: true,
+				},
+			})
+		}
+	} else {
+		slices.SortFunc(user.GetJobs(), func(a, b *users.UserJob) int {
+			if a.GetIsPrimary() && !b.GetIsPrimary() {
+				return -1
+			}
+			if !a.GetIsPrimary() && b.GetIsPrimary() {
+				return 1
+			}
+			return strings.Compare(a.GetJob(), b.GetJob())
+		})
+
+		foundPrimary := false
+		primaryJob := user.GetJob()
+		for _, job := range user.GetJobs() {
+			if job.GetJob() == primaryJob {
+				foundPrimary = true
+				job.IsPrimary = true
+			} else {
+				job.IsPrimary = false
+			}
+		}
+		if !foundPrimary {
+			user.Jobs[0].IsPrimary = true
+		}
+	}
+}
+
+func (s *Store) cleanupUserPhoneNumbers(user *syncdata.DataUser) {
+	phoneNumbers := user.GetPhoneNumbers()
+	if len(phoneNumbers) == 0 {
+		if user.GetPhoneNumber() == "" {
+			return
+		}
+
+		// Add the single phone number as the primary entry when the user has no phone-number list.
+		user.SetPhoneNumbers([]*users.PhoneNumber{
+			{
+				Number:    user.GetPhoneNumber(),
+				IsPrimary: true,
+			},
+		})
+		return
+	}
+
+	primaryPhoneNumber := ""
+	foundPrimary := false
+	// Prefer an explicitly marked primary number from the phone numbers list over the user object phone number (fallback).
+	for _, phoneNumber := range phoneNumbers {
+		if phoneNumber.GetIsPrimary() {
+			primaryPhoneNumber = phoneNumber.GetNumber()
+			foundPrimary = true
+			break
+		}
+	}
+	if primaryPhoneNumber == "" {
+		primaryPhoneNumber = user.GetPhoneNumber()
+	}
+	if primaryPhoneNumber == "" {
+		primaryPhoneNumber = phoneNumbers[0].GetNumber()
+	}
+	user.SetPhoneNumber(primaryPhoneNumber)
+
+	// Sort phone numbers
+	slices.SortFunc(phoneNumbers, func(a, b *users.PhoneNumber) int {
+		if a.GetIsPrimary() && !b.GetIsPrimary() {
+			return -1
+		}
+		if !a.GetIsPrimary() && b.GetIsPrimary() {
+			return 1
+		}
+		return strings.Compare(a.GetNumber(), b.GetNumber())
+	})
+
+	// Ensure exactly one phone number is primary.
+	primaryIndex := -1
+	for i, phoneNumber := range phoneNumbers {
+		phoneNumber.IsPrimary = false
+		if primaryIndex == -1 && primaryPhoneNumber == phoneNumber.GetNumber() {
+			primaryIndex = i
+			continue
+		}
+	}
+	if primaryIndex == -1 && !foundPrimary {
+		primaryIndex = 0
+	}
+	phoneNumbers[primaryIndex].IsPrimary = true
+}
+
 func (s *Store) handleUserLicenses(
 	ctx context.Context,
 	tx *sql.Tx,
@@ -766,15 +817,6 @@ func (s *Store) handleUserJobs(
 	user *syncdata.DataUser,
 ) (*userJobChange, error) {
 	jobs := user.GetJobs()
-	slices.SortFunc(jobs, func(a, b *users.UserJob) int {
-		if a.GetIsPrimary() && !b.GetIsPrimary() {
-			return -1
-		}
-		if !a.GetIsPrimary() && b.GetIsPrimary() {
-			return 1
-		}
-		return strings.Compare(a.GetJob(), b.GetJob())
-	})
 
 	tJobs := tCitizensJobs.AS("user_job")
 	selectStmt := tJobs.
@@ -958,21 +1000,11 @@ func (s *Store) handleUserPhoneNumbers(
 	userId int32,
 	phoneNumbers []*users.PhoneNumber,
 ) error {
-	slices.SortFunc(phoneNumbers, func(a, b *users.PhoneNumber) int {
-		if a.GetIsPrimary() && !b.GetIsPrimary() {
-			return -1
-		}
-		if !a.GetIsPrimary() && b.GetIsPrimary() {
-			return 1
-		}
-		return strings.Compare(a.GetNumber(), b.GetNumber())
-	})
-
 	if len(phoneNumbers) == 0 {
 		stmt := tCitizensPhoneNumbers.
 			DELETE().
 			WHERE(tCitizensPhoneNumbers.UserID.EQ(mysql.Int32(userId))).
-			LIMIT(25)
+			LIMIT(10)
 		if _, err := stmt.ExecContext(ctx, tx); err != nil {
 			return fmt.Errorf("failed to execute user phone numbers delete statement. %w", err)
 		}

--- a/stores/sync/users.go
+++ b/stores/sync/users.go
@@ -99,8 +99,29 @@ func (s *Store) handleUsersData(ctx context.Context, us []*syncdata.DataUser) (i
 		userIds = append(userIds, mysql.Int32(us[i].GetUserId()))
 
 		if len(us[i].GetJobs()) == 0 {
-			us[i].Jobs = []*users.UserJob{
-				{Job: us[i].GetJob(), Grade: us[i].GetJobGrade(), IsPrimary: true},
+			if us[i].GetJob() == "" {
+				// Fallback to unemployed job when user has no job(s)
+				unemployedJob := unemployedJobFromAppConfig(s.appCfg)
+				jobs := []*users.UserJob{
+					{
+						UserId:    us[i].GetUserId(),
+						Job:       unemployedJob.GetName(),
+						Grade:     unemployedJob.GetGrade(),
+						IsPrimary: true,
+					},
+				}
+				us[i].SetJobs(jobs)
+				us[i].SetJob(jobs[0].Job)
+				us[i].SetJobGrade(jobs[0].Grade)
+			} else {
+				// Ensure user's job is set in the jobs list
+				us[i].SetJobs([]*users.UserJob{
+					{
+						Job:       us[i].GetJob(),
+						Grade:     us[i].GetJobGrade(),
+						IsPrimary: true,
+					},
+				})
 			}
 		} else {
 			slices.SortFunc(us[i].GetJobs(), func(a, b *users.UserJob) int {
@@ -745,25 +766,6 @@ func (s *Store) handleUserJobs(
 	user *syncdata.DataUser,
 ) (*userJobChange, error) {
 	jobs := user.GetJobs()
-	// Fallback to unemployed job when user has no jobs
-	if len(jobs) == 0 {
-		unemployedJob := unemployedJobFromAppConfig(s.appCfg)
-		jobs = []*users.UserJob{
-			{
-				UserId:    user.GetUserId(),
-				Job:       unemployedJob.GetName(),
-				Grade:     unemployedJob.GetGrade(),
-				IsPrimary: true,
-			},
-		}
-		user.Jobs = jobs
-		if user.GetJob() == "" {
-			user.Job = jobs[0].Job
-		}
-		if user.GetJobGrade() == 0 {
-			user.JobGrade = jobs[0].Grade
-		}
-	}
 	slices.SortFunc(jobs, func(a, b *users.UserJob) int {
 		if a.GetIsPrimary() && !b.GetIsPrimary() {
 			return -1
@@ -855,11 +857,16 @@ func unemployedJobFromAppConfig(appCfg appconfig.IConfig) *settings.UnemployedJo
 		Name:  "unemployed",
 		Grade: 1,
 	}
-	if appCfg == nil || appCfg.Get() == nil || appCfg.Get().GetJobInfo() == nil {
+	if appCfg == nil {
 		return spec
 	}
 
-	unemployedJob := appCfg.Get().GetJobInfo().GetUnemployedJob()
+	cfg := appCfg.Get()
+	if cfg == nil || cfg.GetJobInfo() == nil {
+		return spec
+	}
+
+	unemployedJob := cfg.GetJobInfo().GetUnemployedJob()
 	if unemployedJob == nil {
 		return spec
 	}

--- a/stores/sync/users.go
+++ b/stores/sync/users.go
@@ -150,9 +150,9 @@ func (s *Store) handleUsersData(ctx context.Context, us []*syncdata.DataUser) (i
 
 	checkStmt := tSyncUser.
 		SELECT(
-			tSyncUser.UserID.AS("user_id"),
-			tSyncUser.Identifier.AS("identifier"),
-			tSyncUser.DataHash.AS("data_hash"),
+			tSyncUser.UserID.AS("existing_user.user_id"),
+			tSyncUser.Identifier.AS("existing_user.identifier"),
+			tSyncUser.DataHash.AS("existing_user.data_hash"),
 		).
 		FROM(tSyncUser).
 		WHERE(tSyncUser.UserID.IN(userIds...)).

--- a/stores/sync/users_test.go
+++ b/stores/sync/users_test.go
@@ -308,6 +308,106 @@ func TestComparePhoneNumbers(t *testing.T) {
 	})
 }
 
+func TestCleanupUserPhoneNumbersDefaultsToSinglePrimaryPhone(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newTestStore(t)
+
+	user := &syncdata.DataUser{
+		PhoneNumber: func() *string { v := "111"; return &v }(),
+	}
+
+	store.cleanupUserPhoneNumbers(user)
+
+	require.Len(t, user.GetPhoneNumbers(), 1)
+	assert.Equal(t, "111", user.GetPhoneNumbers()[0].GetNumber())
+	assert.True(t, user.GetPhoneNumbers()[0].GetIsPrimary())
+}
+
+func TestCleanupUserPhoneNumbersPrefersIncomingPrimaryFlag(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newTestStore(t)
+
+	user := &syncdata.DataUser{
+		PhoneNumber: func() *string { v := "222"; return &v }(),
+		PhoneNumbers: []*users.PhoneNumber{
+			{Number: "222", IsPrimary: false},
+			{Number: "111", IsPrimary: true},
+		},
+	}
+
+	store.cleanupUserPhoneNumbers(user)
+
+	require.Len(t, user.GetPhoneNumbers(), 2)
+	assert.Equal(t, "111", user.GetPhoneNumber())
+	assert.True(t, user.GetPhoneNumbers()[0].GetIsPrimary())
+	assert.False(t, user.GetPhoneNumbers()[1].GetIsPrimary())
+}
+
+func TestCleanupUserPhoneNumbersPrefersIncomingPrimaryOverLegacy(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newTestStore(t)
+
+	user := &syncdata.DataUser{
+		PhoneNumbers: []*users.PhoneNumber{
+			{Number: "111", IsPrimary: false},
+			{Number: "222", IsPrimary: true},
+		},
+	}
+
+	store.cleanupUserPhoneNumbers(user)
+
+	require.Len(t, user.GetPhoneNumbers(), 2)
+	assert.Equal(t, "222", user.GetPhoneNumber())
+	assert.True(t, user.GetPhoneNumbers()[0].GetIsPrimary())
+	assert.False(t, user.GetPhoneNumbers()[1].GetIsPrimary())
+}
+
+func TestCleanupUserPhoneNumbersFallsBackToLegacyWhenNoPrimary(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newTestStore(t)
+
+	user := &syncdata.DataUser{
+		PhoneNumber: func() *string { v := "222"; return &v }(),
+		PhoneNumbers: []*users.PhoneNumber{
+			{Number: "111", IsPrimary: false},
+			{Number: "222", IsPrimary: false},
+		},
+	}
+
+	store.cleanupUserPhoneNumbers(user)
+
+	require.Len(t, user.GetPhoneNumbers(), 2)
+	assert.Equal(t, "222", user.GetPhoneNumber())
+	assert.False(t, user.GetPhoneNumbers()[0].GetIsPrimary())
+	assert.True(t, user.GetPhoneNumbers()[1].GetIsPrimary())
+}
+
+func TestCleanupUserPhoneNumbersKeepsOnlyOnePrimary(t *testing.T) {
+	t.Parallel()
+
+	store, _ := newTestStore(t)
+
+	user := &syncdata.DataUser{
+		PhoneNumber: func() *string { v := "111"; return &v }(),
+		PhoneNumbers: []*users.PhoneNumber{
+			{Number: "111", IsPrimary: true},
+			{Number: "222", IsPrimary: true},
+			{Number: "333", IsPrimary: false},
+		},
+	}
+
+	store.cleanupUserPhoneNumbers(user)
+
+	require.Len(t, user.GetPhoneNumbers(), 3)
+	assert.True(t, user.GetPhoneNumbers()[0].GetIsPrimary())
+	assert.False(t, user.GetPhoneNumbers()[1].GetIsPrimary())
+	assert.False(t, user.GetPhoneNumbers()[2].GetIsPrimary())
+}
+
 func newTestStore(t *testing.T) (*Store, sqlmock.Sqlmock) {
 	t.Helper()
 
@@ -533,8 +633,16 @@ func TestHandleUserJobsDefaultsToUnemployedWhenNoJobs(t *testing.T) {
 	mock.ExpectCommit()
 
 	user := &syncdata.DataUser{
-		UserId: 11,
-		Jobs:   []*users.UserJob{},
+		UserId:   11,
+		Job:      "civilian",
+		JobGrade: 7,
+		Jobs: []*users.UserJob{
+			{
+				Job:       "civilian",
+				Grade:     7,
+				IsPrimary: true,
+			},
+		},
 	}
 
 	tx, err := store.db.Begin()

--- a/stores/sync/users_test.go
+++ b/stores/sync/users_test.go
@@ -1,16 +1,78 @@
 package syncstore
 
 import (
+	"context"
+	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/jobs"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications"
+	notificationsclientview "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/clientview"
+	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
+	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
 	"github.com/fivenet-app/fivenet/v2026/pkg/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
+
+type labelEnricher struct{}
+
+func (labelEnricher) EnrichJobInfo(user common.IJobInfo) {
+	user.SetJobLabel(user.GetJob())
+	user.SetJobGradeLabel(fmt.Sprintf("Rank %d", user.GetJobGrade()))
+}
+
+func (labelEnricher) EnrichJobInfoNoFallback(common.IJobInfo) {}
+
+func (labelEnricher) EnrichJobName(common.IJobName) {}
+
+func (labelEnricher) GetJobByName(string) *jobs.Job { return nil }
+
+func (labelEnricher) GetJobGrade(string, int32) (*jobs.Job, *jobs.JobGrade) {
+	return nil, nil
+}
+
+type recordingNotifi struct {
+	events []*notificationsevents.UserEvent
+}
+
+func (n *recordingNotifi) NotifyUser(context.Context, *notifications.Notification) error {
+	return nil
+}
+
+func (n *recordingNotifi) SendObjectEvent(
+	context.Context,
+	*notificationsclientview.ObjectEvent,
+) error {
+	return nil
+}
+
+func (n *recordingNotifi) SendAccountEvent(
+	_ context.Context,
+	_ int64,
+	event *notificationsevents.UserEvent,
+) error {
+	n.events = append(n.events, event)
+	return nil
+}
+
+func (n *recordingNotifi) SendUserEvent(
+	_ context.Context,
+	_ int32,
+	event *notificationsevents.UserEvent,
+) error {
+	n.events = append(n.events, event)
+	return nil
+}
+
+func (n *recordingNotifi) SendSystemEvent(context.Context, *notificationsevents.SystemEvent) error {
+	return nil
+}
 
 func TestCompareJobs(t *testing.T) {
 	t.Parallel()
@@ -250,12 +312,196 @@ func newTestStore(t *testing.T) (*Store, sqlmock.Sqlmock) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 
-	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil).(*Store)
+	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil, nil, nil).(*Store)
 	t.Cleanup(func() {
 		_ = db.Close()
 	})
 
 	return store, mock
+}
+
+func TestHandleUserJobsPublishesPrimaryJobChange(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+	store.enricher = labelEnricher{}
+	accountID := int64(42)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT .*fivenet_user_jobs.*WHERE .*user_id = \?.*ORDER BY .*`).
+		WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_job.job", "user_job.grade", "user_job.is_primary"}).
+			AddRow("police", int32(1), true).
+			AddRow("ems", int32(1), false))
+	mock.ExpectExec(`(?s)INSERT INTO .*fivenet_user_jobs.*ON DUPLICATE KEY UPDATE.*`).
+		WithArgs(int64(11), "sheriff", int32(1), true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`(?s)DELETE FROM .*fivenet_user_jobs.*job IN \(\?\).*LIMIT \?.*`).
+		WithArgs(int64(11), "police", int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	user := &syncdata.DataUser{
+		UserId:   11,
+		Job:      "sheriff",
+		JobGrade: 1,
+		Jobs: []*users.UserJob{
+			{Job: "sheriff", Grade: 1, IsPrimary: true},
+			{Job: "ems", Grade: 1, IsPrimary: false},
+		},
+		Firstname: "Test",
+	}
+
+	tx, err := store.db.Begin()
+	require.NoError(t, err)
+
+	jobChange, err := store.handleUserJobs(t.Context(), tx, user)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	store.publishUserInfoChanged(t.Context(), &accountID, user.GetUserId(), jobChange)
+
+	require.Len(t, rec.events, 1)
+	evt := rec.events[0].GetUserInfoChanged()
+	require.NotNil(t, evt)
+	assert.Equal(t, int64(42), evt.GetAccountId())
+	assert.Equal(t, int32(11), evt.GetUserId())
+	assert.Equal(t, "sheriff", evt.GetNewJob())
+	assert.Equal(t, "sheriff", evt.GetNewJobLabel())
+	assert.Equal(t, int32(1), evt.GetNewJobGrade())
+	assert.Equal(t, "Rank 1", evt.GetNewJobGradeLabel())
+	require.NotNil(t, evt.GetChangedAt())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleUserJobsPublishesPrimaryGradeChange(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+	store.enricher = labelEnricher{}
+	accountID := int64(42)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT .*fivenet_user_jobs.*WHERE .*user_id = \?.*ORDER BY .*`).
+		WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_job.job", "user_job.grade", "user_job.is_primary"}).
+			AddRow("police", int32(1), true))
+	mock.ExpectExec(`(?s)INSERT INTO .*fivenet_user_jobs.*ON DUPLICATE KEY UPDATE.*`).
+		WithArgs(int64(11), "police", int32(2), true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	user := &syncdata.DataUser{
+		UserId:   11,
+		Job:      "police",
+		JobGrade: 2,
+		Jobs:     []*users.UserJob{{Job: "police", Grade: 2, IsPrimary: true}},
+	}
+
+	tx, err := store.db.Begin()
+	require.NoError(t, err)
+
+	jobChange, err := store.handleUserJobs(t.Context(), tx, user)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	store.publishUserInfoChanged(t.Context(), &accountID, user.GetUserId(), jobChange)
+
+	require.Len(t, rec.events, 1)
+	evt := rec.events[0].GetUserInfoChanged()
+	require.NotNil(t, evt)
+	assert.Equal(t, "police", evt.GetNewJob())
+	assert.Equal(t, int32(2), evt.GetNewJobGrade())
+	assert.Equal(t, "Rank 2", evt.GetNewJobGradeLabel())
+
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleUserJobsIgnoresSecondaryJobChurn(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+	store.enricher = labelEnricher{}
+	accountID := int64(42)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT .*fivenet_user_jobs.*WHERE .*user_id = \?.*ORDER BY .*`).
+		WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_job.job", "user_job.grade", "user_job.is_primary"}).
+			AddRow("ems", int32(1), false).
+			AddRow("police", int32(1), true))
+	mock.ExpectExec(`(?s)INSERT INTO .*fivenet_user_jobs.*ON DUPLICATE KEY UPDATE.*`).
+		WithArgs(int64(11), "medic", int32(1), false).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectExec(`(?s)DELETE FROM .*fivenet_user_jobs.*job IN \(\?\).*LIMIT \?.*`).
+		WithArgs(int64(11), "ems", int64(1)).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	user := &syncdata.DataUser{
+		UserId:   11,
+		Job:      "police",
+		JobGrade: 1,
+		Jobs: []*users.UserJob{
+			{Job: "police", Grade: 1, IsPrimary: true},
+			{Job: "medic", Grade: 1, IsPrimary: false},
+		},
+	}
+
+	tx, err := store.db.Begin()
+	require.NoError(t, err)
+
+	jobChange, err := store.handleUserJobs(t.Context(), tx, user)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	store.publishUserInfoChanged(t.Context(), &accountID, user.GetUserId(), jobChange)
+
+	assert.Empty(t, rec.events)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleUserJobsNoopDoesNotPublish(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+	store.enricher = labelEnricher{}
+	accountID := int64(42)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT .*fivenet_user_jobs.*WHERE .*user_id = \?.*ORDER BY .*`).
+		WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_job.job", "user_job.grade", "user_job.is_primary"}).
+			AddRow("police", int32(1), true))
+	mock.ExpectCommit()
+
+	user := &syncdata.DataUser{
+		UserId:   11,
+		Job:      "police",
+		JobGrade: 1,
+		Jobs:     []*users.UserJob{{Job: "police", Grade: 1, IsPrimary: true}},
+	}
+
+	tx, err := store.db.Begin()
+	require.NoError(t, err)
+
+	jobChange, err := store.handleUserJobs(t.Context(), tx, user)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	store.publishUserInfoChanged(t.Context(), &accountID, user.GetUserId(), jobChange)
+
+	assert.Empty(t, rec.events)
+	require.NoError(t, mock.ExpectationsWereMet())
 }
 
 func TestSyncUserAccountUpsertsMapping(t *testing.T) {
@@ -274,7 +520,10 @@ func TestSyncUserAccountUpsertsMapping(t *testing.T) {
 
 	tx, err := store.db.Begin()
 	require.NoError(t, err)
-	require.NoError(t, store.syncUserAccount(t.Context(), tx, 11, "char1:license-42"))
+	accountID, err := store.syncUserAccount(t.Context(), tx, 11, "char1:license-42")
+	require.NoError(t, err)
+	require.NotNil(t, accountID)
+	require.Equal(t, int64(42), *accountID)
 	require.NoError(t, tx.Commit())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
@@ -298,7 +547,9 @@ func TestSyncUserAccountDeletesMappingWhenUnresolved(t *testing.T) {
 
 	tx, err := store.db.Begin()
 	require.NoError(t, err)
-	require.NoError(t, store.syncUserAccount(t.Context(), tx, 11, "char1:license-42"))
+	accountID, err := store.syncUserAccount(t.Context(), tx, 11, "char1:license-42")
+	require.NoError(t, err)
+	require.Nil(t, accountID)
 	require.NoError(t, tx.Commit())
 	require.NoError(t, mock.ExpectationsWereMet())
 }

--- a/stores/sync/users_test.go
+++ b/stores/sync/users_test.go
@@ -12,9 +12,11 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications"
 	notificationsclientview "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/clientview"
 	notificationsevents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/notifications/events"
+	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/settings"
 	syncdata "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/sync/data"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
 	"github.com/fivenet-app/fivenet/v2026/pkg/config"
+	"github.com/fivenet-app/fivenet/v2026/pkg/config/appconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -312,7 +314,7 @@ func newTestStore(t *testing.T) (*Store, sqlmock.Sqlmock) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 
-	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil, nil, nil).(*Store)
+	store := New(db, zap.NewNop(), &config.Config{}, &appconfig.TestConfig{}, nil, nil, nil, nil, nil).(*Store)
 	t.Cleanup(func() {
 		_ = db.Close()
 	})
@@ -501,6 +503,54 @@ func TestHandleUserJobsNoopDoesNotPublish(t *testing.T) {
 	store.publishUserInfoChanged(t.Context(), &accountID, user.GetUserId(), jobChange)
 
 	assert.Empty(t, rec.events)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestHandleUserJobsDefaultsToUnemployedWhenNoJobs(t *testing.T) {
+	t.Parallel()
+
+	store, mock := newTestStore(t)
+	rec := &recordingNotifi{}
+	store.notifi = rec
+	store.enricher = labelEnricher{}
+	accountID := int64(42)
+
+	cfg := &appconfig.Cfg{}
+	cfg.Default()
+	cfg.JobInfo.UnemployedJob = &settings.UnemployedJob{
+		Name:  "civilian",
+		Grade: 7,
+	}
+	store.appCfg.Set(cfg)
+
+	mock.ExpectBegin()
+	mock.ExpectQuery(`(?s)SELECT .*fivenet_user_jobs.*WHERE .*user_id = \?.*ORDER BY .*`).
+		WithArgs(int64(11)).
+		WillReturnRows(sqlmock.NewRows([]string{"user_job.job", "user_job.grade", "user_job.is_primary"}))
+	mock.ExpectExec(`(?s)INSERT INTO .*fivenet_user_jobs.*ON DUPLICATE KEY UPDATE.*`).
+		WithArgs(int64(11), "civilian", int32(7), true).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	mock.ExpectCommit()
+
+	user := &syncdata.DataUser{
+		UserId: 11,
+		Jobs:   []*users.UserJob{},
+	}
+
+	tx, err := store.db.Begin()
+	require.NoError(t, err)
+
+	jobChange, err := store.handleUserJobs(t.Context(), tx, user)
+	require.NoError(t, err)
+	require.NoError(t, tx.Commit())
+
+	store.publishUserInfoChanged(t.Context(), &accountID, user.GetUserId(), jobChange)
+
+	require.Len(t, rec.events, 1)
+	evt := rec.events[0].GetUserInfoChanged()
+	require.NotNil(t, evt)
+	assert.Equal(t, "civilian", evt.GetNewJob())
+	assert.Equal(t, int32(7), evt.GetNewJobGrade())
 	require.NoError(t, mock.ExpectationsWereMet())
 }
 

--- a/stores/sync/vehicles_test.go
+++ b/stores/sync/vehicles_test.go
@@ -7,6 +7,7 @@ import (
 	resourcesvehicles "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/vehicles"
 	pbsync "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/sync"
 	"github.com/fivenet-app/fivenet/v2026/pkg/config"
+	"github.com/fivenet-app/fivenet/v2026/pkg/config/appconfig"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -19,7 +20,17 @@ func TestSendVehicles(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil, nil, nil)
+	store := New(
+		db,
+		zap.NewNop(),
+		&config.Config{},
+		&appconfig.TestConfig{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
 
 	mock.ExpectExec(`(?s)INSERT INTO .*fivenet_owned_vehicles.*ON DUPLICATE KEY UPDATE.*`).
 		WithArgs(int32(3), "police", "ABC DEF1", "adder", "car").
@@ -47,7 +58,17 @@ func TestDeleteVehicles(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil, nil, nil)
+	store := New(
+		db,
+		zap.NewNop(),
+		&config.Config{},
+		&appconfig.TestConfig{},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
 
 	mock.ExpectExec(`(?s)DELETE FROM .*fivenet_owned_vehicles.*plate IN \(\?, \?\).*LIMIT \?.*`).
 		WithArgs("ABC DEF1", "XYZ 123", int64(2)).

--- a/stores/sync/vehicles_test.go
+++ b/stores/sync/vehicles_test.go
@@ -19,7 +19,7 @@ func TestSendVehicles(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil)
+	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil, nil, nil)
 
 	mock.ExpectExec(`(?s)INSERT INTO .*fivenet_owned_vehicles.*ON DUPLICATE KEY UPDATE.*`).
 		WithArgs(int32(3), "police", "ABC DEF1", "adder", "car").
@@ -47,7 +47,7 @@ func TestDeleteVehicles(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil)
+	store := New(db, zap.NewNop(), &config.Config{}, nil, nil, nil, nil, nil)
 
 	mock.ExpectExec(`(?s)DELETE FROM .*fivenet_owned_vehicles.*plate IN \(\?, \?\).*LIMIT \?.*`).
 		WithArgs("ABC DEF1", "XYZ 123", int64(2)).


### PR DESCRIPTION
**Description of changes:**

Implement "live" user job/grade and group notification events from dbsync data.
This also improves the notifications provider logic too use a event provider besides the previous "array watch" logic.

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [CONTRIBUTING.md](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Reviewed the contributor guide [here (CONTRIBUTING.md)](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated, if necessary. Please open a PR in the [website repository](https://github.com/fivenet-app/fivenet-app.github.io) and add a link to the PR here.
- [x] Tests have been added, if necessary.
Signed-off-by: Alexander Trost <galexrt@googlemail.com>