### PR TITLE
fix(auth): restore char session state on reload

### DIFF
--- a/app/composables/grpcws/auth.test.ts
+++ b/app/composables/grpcws/auth.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { authUserTokenKey } from '~/stores/auth_session';
-import { getGrpcRpcAuthToken, getGrpcWebsocketAuthToken } from './auth';
+import { getGrpcCharacterAuthToken, getGrpcWebsocketAuthToken } from './auth';
 
 const activeChar = { value: null as unknown | null };
 
@@ -16,10 +16,10 @@ describe('grpc auth token accessors', () => {
         sessionStorage.clear();
     });
 
-    it('returns the stored token for RPC auth even when no character is selected', () => {
+    it('returns the stored token for character-scoped auth even when no character is selected', () => {
         sessionStorage.setItem(authUserTokenKey, 'stale-char-token');
 
-        expect(getGrpcRpcAuthToken()).toBe('stale-char-token');
+        expect(getGrpcCharacterAuthToken()).toBe('stale-char-token');
     });
 
     it('keeps websocket control auth tokenless in account-only mode', () => {
@@ -33,6 +33,5 @@ describe('grpc auth token accessors', () => {
         sessionStorage.setItem(authUserTokenKey, 'char-token');
 
         expect(getGrpcWebsocketAuthToken()).toBe('char-token');
-        expect(getGrpcRpcAuthToken()).toBe('char-token');
     });
 });

--- a/app/composables/grpcws/auth.test.ts
+++ b/app/composables/grpcws/auth.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { authUserTokenKey } from '~/stores/auth_session';
-import { getGrpcAuthToken } from './auth';
+import { getGrpcRpcAuthToken, getGrpcWebsocketAuthToken } from './auth';
 
 const activeChar = { value: null as unknown | null };
 
@@ -10,22 +10,29 @@ vi.mock('~/composables/useAuth', () => ({
     }),
 }));
 
-describe('getGrpcAuthToken', () => {
+describe('grpc auth token accessors', () => {
     beforeEach(() => {
         activeChar.value = null;
         sessionStorage.clear();
     });
 
-    it('returns null when no character is selected even if a token is stored', () => {
+    it('returns the stored token for RPC auth even when no character is selected', () => {
         sessionStorage.setItem(authUserTokenKey, 'stale-char-token');
 
-        expect(getGrpcAuthToken()).toBeNull();
+        expect(getGrpcRpcAuthToken()).toBe('stale-char-token');
     });
 
-    it('returns the stored token when a character is selected', () => {
+    it('keeps websocket control auth tokenless in account-only mode', () => {
+        sessionStorage.setItem(authUserTokenKey, 'stale-char-token');
+
+        expect(getGrpcWebsocketAuthToken()).toBeNull();
+    });
+
+    it('returns the stored websocket token when a character is selected', () => {
         activeChar.value = { userId: 123 } as never;
         sessionStorage.setItem(authUserTokenKey, 'char-token');
 
-        expect(getGrpcAuthToken()).toBe('char-token');
+        expect(getGrpcWebsocketAuthToken()).toBe('char-token');
+        expect(getGrpcRpcAuthToken()).toBe('char-token');
     });
 });

--- a/app/composables/grpcws/auth.ts
+++ b/app/composables/grpcws/auth.ts
@@ -1,6 +1,6 @@
 import { authUserTokenKey } from '~/stores/auth_session';
 
-export function getGrpcRpcAuthToken(): string | null {
+export function getGrpcCharacterAuthToken(): string | null {
     return sessionStorage.getItem(authUserTokenKey);
 }
 

--- a/app/composables/grpcws/auth.ts
+++ b/app/composables/grpcws/auth.ts
@@ -1,6 +1,10 @@
 import { authUserTokenKey } from '~/stores/auth_session';
 
-export function getGrpcAuthToken(): string | null {
+export function getGrpcRpcAuthToken(): string | null {
+    return sessionStorage.getItem(authUserTokenKey);
+}
+
+export function getGrpcWebsocketAuthToken(): string | null {
     const { activeChar } = useAuth();
     if (!activeChar.value) return null;
 

--- a/app/composables/grpcws/bridge/index.ts
+++ b/app/composables/grpcws/bridge/index.ts
@@ -318,7 +318,7 @@ export class GrpcWSTransport implements RpcTransport {
 
     updateUserToken(token: string): void {
         if (this.webSocket.status.value !== 'OPEN') {
-            logger.error("Websocket isn't connected, cannot update user token");
+            logger.debug("Websocket isn't connected yet, skipping user token update");
             return;
         }
 

--- a/app/composables/grpcws/transports/websocket/websocketChannel.ts
+++ b/app/composables/grpcws/transports/websocket/websocketChannel.ts
@@ -1,6 +1,6 @@
 import type { UseWebSocketReturn } from '@vueuse/core';
 import { Body, Cancel, GrpcFrame, Header, HeaderValue } from '~~/gen/ts/resources/grpcws/grpcws';
-import { getGrpcAuthToken } from '../../auth';
+import { getGrpcWebsocketAuthToken } from '../../auth';
 import { headersToMetadata } from '../../bridge/utils';
 import { errCancelled, errInternal } from '../../errors';
 import type { Metadata } from '../../metadata';
@@ -28,7 +28,7 @@ type AuthState =
 
 // Default token provider
 function defaultTokenProvider(): string | null {
-    return getGrpcAuthToken();
+    return getGrpcWebsocketAuthToken();
 }
 
 export function WebsocketChannelTransport(

--- a/app/composables/useGRPCTransport.test.ts
+++ b/app/composables/useGRPCTransport.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { authUserTokenKey } from '~/stores/auth_session';
+import { GrpcCombinedTransport } from './useGRPCTransport';
+
+const activeChar = { value: null as unknown | null };
+
+type MockUnaryClient = {
+    mock: {
+        calls: Array<[unknown, unknown, { meta: Record<string, string | undefined> }]>;
+    };
+};
+
+vi.mock('~/composables/useAuth', () => ({
+    useAuth: () => ({
+        activeChar,
+    }),
+}));
+
+function createTransport() {
+    const unaryClient = {
+        mergeOptions: vi.fn((options) => options),
+        unary: vi.fn(),
+    };
+    const streamClient = {
+        mergeOptions: vi.fn((options) => options),
+        serverStreaming: vi.fn(),
+        clientStreaming: vi.fn(),
+        duplex: vi.fn(),
+    };
+
+    return {
+        transport: new GrpcCombinedTransport(unaryClient as never, streamClient as never),
+        unaryClient,
+        streamClient,
+    };
+}
+
+describe('GrpcCombinedTransport auth headers', () => {
+    beforeEach(() => {
+        activeChar.value = null;
+        sessionStorage.clear();
+    });
+
+    it('keeps account-only unary calls tokenless when no character is active', () => {
+        sessionStorage.setItem(authUserTokenKey, 'stale-char-token');
+        const { transport, unaryClient } = createTransport();
+
+        transport.unary(
+            { name: 'GetAppConfig', service: { typeName: 'services.settings.ConfigService' } } as never,
+            {} as never,
+            {},
+        );
+
+        expect(unaryClient.unary).toHaveBeenCalled();
+        expect(unaryClient.mergeOptions).toHaveBeenCalledWith({ meta: {} });
+        const firstCall = (unaryClient.unary as MockUnaryClient).mock.calls[0];
+        expect(firstCall[2].meta.Authorization).toBeUndefined();
+    });
+
+    it('sends the stored token for choose-character restore even when no character is active', () => {
+        sessionStorage.setItem(authUserTokenKey, 'char-token');
+        const { transport, unaryClient } = createTransport();
+
+        transport.unary(
+            { name: 'ChooseCharacter', service: { typeName: 'services.auth.AuthService' } } as never,
+            {} as never,
+            {},
+        );
+
+        const firstCall = (unaryClient.unary as MockUnaryClient).mock.calls[0];
+        expect(firstCall[2].meta.Authorization).toBe('Bearer char-token');
+    });
+
+    it('sends the stored token for unary calls when a character is active', () => {
+        activeChar.value = { userId: 123 } as never;
+        sessionStorage.setItem(authUserTokenKey, 'char-token');
+        const { transport, unaryClient } = createTransport();
+
+        transport.unary(
+            { name: 'GetCharacters', service: { typeName: 'services.auth.AuthService' } } as never,
+            {} as never,
+            {},
+        );
+
+        const firstCall = (unaryClient.unary as MockUnaryClient).mock.calls[0];
+        expect(firstCall[2].meta.Authorization).toBe('Bearer char-token');
+    });
+});

--- a/app/composables/useGRPCTransport.test.ts
+++ b/app/composables/useGRPCTransport.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { authUserTokenKey } from '~/stores/auth_session';
 import { GrpcCombinedTransport } from './useGRPCTransport';
 
 const activeChar = { value: null as unknown | null };
+const accountId = { value: null as unknown | null };
+const userInfo = { accountId: null as number | null };
 
 type MockUnaryClient = {
     mock: {
@@ -13,6 +14,14 @@ type MockUnaryClient = {
 vi.mock('~/composables/useAuth', () => ({
     useAuth: () => ({
         activeChar,
+        accountId,
+    }),
+}));
+
+vi.mock('~/stores/auth_session', () => ({
+    authUserTokenKey: 'fivenet:user_token_v1',
+    useAuthSessionStore: () => ({
+        userInfo,
     }),
 }));
 
@@ -38,11 +47,15 @@ function createTransport() {
 describe('GrpcCombinedTransport auth headers', () => {
     beforeEach(() => {
         activeChar.value = null;
+        accountId.value = null;
+        userInfo.accountId = null;
         sessionStorage.clear();
     });
 
     it('keeps account-only unary calls tokenless when no character is active', () => {
         sessionStorage.setItem(authUserTokenKey, 'stale-char-token');
+        accountId.value = 123;
+        userInfo.accountId = 999;
         const { transport, unaryClient } = createTransport();
 
         transport.unary(
@@ -57,8 +70,27 @@ describe('GrpcCombinedTransport auth headers', () => {
         expect(firstCall[2].meta.Authorization).toBeUndefined();
     });
 
+    it('does not reuse a stale token for choose-character restore when the account does not match', () => {
+        sessionStorage.setItem(authUserTokenKey, 'char-token');
+        accountId.value = 456;
+        userInfo.accountId = 123;
+        const { transport, unaryClient } = createTransport();
+
+        transport.unary(
+            { name: 'ChooseCharacter', service: { typeName: 'services.auth.AuthService' } } as never,
+            {} as never,
+            {},
+        );
+
+        expect(unaryClient.unary).toHaveBeenCalled();
+        const firstCall = (unaryClient.unary as MockUnaryClient).mock.calls[0];
+        expect(firstCall[2].meta.Authorization).toBeUndefined();
+    });
+
     it('sends the stored token for choose-character restore even when no character is active', () => {
         sessionStorage.setItem(authUserTokenKey, 'char-token');
+        accountId.value = 123;
+        userInfo.accountId = 123;
         const { transport, unaryClient } = createTransport();
 
         transport.unary(
@@ -73,6 +105,8 @@ describe('GrpcCombinedTransport auth headers', () => {
 
     it('sends the stored token for unary calls when a character is active', () => {
         activeChar.value = { userId: 123 } as never;
+        accountId.value = 123;
+        userInfo.accountId = 123;
         sessionStorage.setItem(authUserTokenKey, 'char-token');
         const { transport, unaryClient } = createTransport();
 

--- a/app/composables/useGRPCTransport.test.ts
+++ b/app/composables/useGRPCTransport.test.ts
@@ -3,7 +3,7 @@ import { GrpcCombinedTransport } from './useGRPCTransport';
 
 const activeChar = { value: null as unknown | null };
 const accountId = { value: null as unknown | null };
-const userInfo = { accountId: null as number | null };
+const userInfo = { accountId: null as number | null, userId: null as number | null };
 
 type MockUnaryClient = {
     mock: {
@@ -49,6 +49,7 @@ describe('GrpcCombinedTransport auth headers', () => {
         activeChar.value = null;
         accountId.value = null;
         userInfo.accountId = null;
+        userInfo.userId = null;
         sessionStorage.clear();
     });
 
@@ -70,10 +71,11 @@ describe('GrpcCombinedTransport auth headers', () => {
         expect(firstCall[2].meta.Authorization).toBeUndefined();
     });
 
-    it('does not reuse a stale token for choose-character restore when the account does not match', () => {
+    it('does not attach a token for choose-character restore when the character does not match', () => {
         sessionStorage.setItem(authUserTokenKey, 'char-token');
-        accountId.value = 456;
+        accountId.value = 123;
         userInfo.accountId = 123;
+        userInfo.userId = 456;
         const { transport, unaryClient } = createTransport();
 
         transport.unary(
@@ -87,26 +89,11 @@ describe('GrpcCombinedTransport auth headers', () => {
         expect(firstCall[2].meta.Authorization).toBeUndefined();
     });
 
-    it('sends the stored token for choose-character restore even when no character is active', () => {
-        sessionStorage.setItem(authUserTokenKey, 'char-token');
-        accountId.value = 123;
-        userInfo.accountId = 123;
-        const { transport, unaryClient } = createTransport();
-
-        transport.unary(
-            { name: 'ChooseCharacter', service: { typeName: 'services.auth.AuthService' } } as never,
-            {} as never,
-            {},
-        );
-
-        const firstCall = (unaryClient.unary as MockUnaryClient).mock.calls[0];
-        expect(firstCall[2].meta.Authorization).toBe('Bearer char-token');
-    });
-
     it('sends the stored token for unary calls when a character is active', () => {
         activeChar.value = { userId: 123 } as never;
         accountId.value = 123;
         userInfo.accountId = 123;
+        userInfo.userId = 123;
         sessionStorage.setItem(authUserTokenKey, 'char-token');
         const { transport, unaryClient } = createTransport();
 

--- a/app/composables/useGRPCTransport.ts
+++ b/app/composables/useGRPCTransport.ts
@@ -9,7 +9,8 @@ import type {
     UnaryCall,
 } from '@protobuf-ts/runtime-rpc';
 import { useGRPCWebsocketTransport } from './grpcws';
-import { getGrpcRpcAuthToken } from './grpcws/auth';
+import { getGrpcCharacterAuthToken } from './grpcws/auth';
+import { useAuth } from './useAuth';
 
 // Lazy singleton instance
 let _transport: GrpcCombinedTransport | null = null;
@@ -28,19 +29,6 @@ export function useGRPCTransport() {
     return _transport;
 }
 
-function authInterceptor(options: RpcOptions): RpcOptions {
-    // Interceptros don't seem to work 100% of the time.. probably because of the "Frankenstein" transport setup.
-    if (!options) options = {};
-    if (!options.meta) options.meta = {};
-
-    const userToken = getGrpcRpcAuthToken();
-    if (userToken) {
-        options.meta['Authorization'] = `Bearer ${userToken}`;
-    }
-
-    return options;
-}
-
 export class GrpcCombinedTransport {
     private unaryClient: RpcTransport;
     private streamClient: RpcTransport;
@@ -57,7 +45,7 @@ export class GrpcCombinedTransport {
     unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): UnaryCall<I, O> {
         // Interceptors don't seem to work 100% of the time (at least for unary calls)..
         // probably because of the "Frankenstein" transport setup.
-        options = authInterceptor(options);
+        options = authInterceptor(method, options);
         return this.unaryClient.unary<I, O>(method, input, this.unaryClient.mergeOptions(options));
     }
 
@@ -66,7 +54,7 @@ export class GrpcCombinedTransport {
         input: I,
         options: RpcOptions,
     ): ServerStreamingCall<I, O> {
-        options = authInterceptor(options);
+        options = authInterceptor(method, options);
         return this.streamClient.serverStreaming<I, O>(method, input, options);
     }
 
@@ -74,12 +62,32 @@ export class GrpcCombinedTransport {
         method: MethodInfo<I, O>,
         options: RpcOptions,
     ): ClientStreamingCall<I, O> {
-        options = authInterceptor(options);
+        options = authInterceptor(method, options);
         return this.streamClient.clientStreaming<I, O>(method, options);
     }
 
     duplex<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): DuplexStreamingCall<I, O> {
-        options = authInterceptor(options);
+        options = authInterceptor(method, options);
         return this.streamClient.duplex<I, O>(method, options);
     }
+}
+
+function authInterceptor<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): RpcOptions {
+    if (!options) options = {};
+    if (!options.meta) options.meta = {};
+
+    const userToken = getGrpcCharacterAuthToken();
+    if (!userToken) return options;
+
+    const { activeChar } = useAuth();
+    const isCharacterRestore =
+        activeChar.value === null &&
+        method.service.typeName === 'services.auth.AuthService' &&
+        method.name === 'ChooseCharacter';
+
+    if (activeChar.value !== null || isCharacterRestore) {
+        options.meta['Authorization'] = `Bearer ${userToken}`;
+    }
+
+    return options;
 }

--- a/app/composables/useGRPCTransport.ts
+++ b/app/composables/useGRPCTransport.ts
@@ -9,7 +9,7 @@ import type {
     UnaryCall,
 } from '@protobuf-ts/runtime-rpc';
 import { useGRPCWebsocketTransport } from './grpcws';
-import { getGrpcAuthToken } from './grpcws/auth';
+import { getGrpcRpcAuthToken } from './grpcws/auth';
 
 // Lazy singleton instance
 let _transport: GrpcCombinedTransport | null = null;
@@ -33,7 +33,7 @@ function authInterceptor(options: RpcOptions): RpcOptions {
     if (!options) options = {};
     if (!options.meta) options.meta = {};
 
-    const userToken = getGrpcAuthToken();
+    const userToken = getGrpcRpcAuthToken();
     if (userToken) {
         options.meta['Authorization'] = `Bearer ${userToken}`;
     }

--- a/app/composables/useGRPCTransport.ts
+++ b/app/composables/useGRPCTransport.ts
@@ -46,7 +46,7 @@ export class GrpcCombinedTransport {
     unary<I extends object, O extends object>(method: MethodInfo<I, O>, input: I, options: RpcOptions): UnaryCall<I, O> {
         // Interceptors don't seem to work 100% of the time (at least for unary calls)..
         // probably because of the "Frankenstein" transport setup.
-        options = authInterceptor(method, options);
+        options = authInterceptor(options);
         return this.unaryClient.unary<I, O>(method, input, this.unaryClient.mergeOptions(options));
     }
 
@@ -55,7 +55,7 @@ export class GrpcCombinedTransport {
         input: I,
         options: RpcOptions,
     ): ServerStreamingCall<I, O> {
-        options = authInterceptor(method, options);
+        options = authInterceptor(options);
         return this.streamClient.serverStreaming<I, O>(method, input, options);
     }
 
@@ -63,17 +63,17 @@ export class GrpcCombinedTransport {
         method: MethodInfo<I, O>,
         options: RpcOptions,
     ): ClientStreamingCall<I, O> {
-        options = authInterceptor(method, options);
+        options = authInterceptor(options);
         return this.streamClient.clientStreaming<I, O>(method, options);
     }
 
     duplex<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): DuplexStreamingCall<I, O> {
-        options = authInterceptor(method, options);
+        options = authInterceptor(options);
         return this.streamClient.duplex<I, O>(method, options);
     }
 }
 
-function authInterceptor<I extends object, O extends object>(method: MethodInfo<I, O>, options: RpcOptions): RpcOptions {
+function authInterceptor(options: RpcOptions): RpcOptions {
     if (!options) options = {};
     if (!options.meta) options.meta = {};
 
@@ -83,18 +83,19 @@ function authInterceptor<I extends object, O extends object>(method: MethodInfo<
     const { activeChar, accountId } = useAuth();
     const authSessionStore = useAuthSessionStore();
     const tokenAccountId = authSessionStore.userInfo?.accountId;
-    if (tokenAccountId === undefined || accountId.value === null || tokenAccountId !== accountId.value) {
+    const tokenUserId = authSessionStore.userInfo?.userId;
+    if (
+        tokenAccountId === undefined ||
+        tokenUserId === undefined ||
+        accountId.value === null ||
+        tokenAccountId !== accountId.value ||
+        activeChar.value === null ||
+        tokenUserId !== activeChar.value.userId
+    ) {
         return options;
     }
 
-    const isCharacterRestore =
-        activeChar.value === null &&
-        method.service.typeName === 'services.auth.AuthService' &&
-        method.name === 'ChooseCharacter';
-
-    if (activeChar.value !== null || isCharacterRestore) {
-        options.meta['Authorization'] = `Bearer ${userToken}`;
-    }
+    options.meta['Authorization'] = `Bearer ${userToken}`;
 
     return options;
 }

--- a/app/composables/useGRPCTransport.ts
+++ b/app/composables/useGRPCTransport.ts
@@ -8,6 +8,7 @@ import type {
     ServerStreamingCall,
     UnaryCall,
 } from '@protobuf-ts/runtime-rpc';
+import { useAuthSessionStore } from '~/stores/auth_session';
 import { useGRPCWebsocketTransport } from './grpcws';
 import { getGrpcCharacterAuthToken } from './grpcws/auth';
 import { useAuth } from './useAuth';
@@ -79,7 +80,13 @@ function authInterceptor<I extends object, O extends object>(method: MethodInfo<
     const userToken = getGrpcCharacterAuthToken();
     if (!userToken) return options;
 
-    const { activeChar } = useAuth();
+    const { activeChar, accountId } = useAuth();
+    const authSessionStore = useAuthSessionStore();
+    const tokenAccountId = authSessionStore.userInfo?.accountId;
+    if (tokenAccountId === undefined || accountId.value === null || tokenAccountId !== accountId.value) {
+        return options;
+    }
+
     const isCharacterRestore =
         activeChar.value === null &&
         method.service.typeName === 'services.auth.AuthService' &&

--- a/app/stores/auth.test.ts
+++ b/app/stores/auth.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
     authSessionStore: {
         getUserToken: vi.fn(),
         setUserToken: vi.fn(),
+        userInfo: { accountId: null as number | null },
     },
     notificationsStore: {
         add: vi.fn(),
@@ -66,10 +67,12 @@ describe('useAuthStore', () => {
         setActivePinia(createPinia());
         vi.clearAllMocks();
         mocks.authSessionStore.getUserToken.mockReturnValue(null);
+        mocks.authSessionStore.userInfo.accountId = null;
     });
 
     it('clears account-level config-admin when selecting a character', async () => {
         mocks.authSessionStore.getUserToken.mockReturnValue('char-token');
+        mocks.authSessionStore.userInfo.accountId = 123;
         mocks.chooseCharacter.mockResolvedValueOnce({
             response: {
                 username: 'tester',
@@ -82,10 +85,12 @@ describe('useAuthStore', () => {
         });
 
         const authStore = useAuthStore();
+        authStore.accountId = 123;
         authStore.setAccountCanBeConfigAdmin(true);
 
         await authStore.chooseCharacter(123, false);
 
+        expect(authStore.accountId).toBe(123);
         expect(authStore.canBeConfigAdmin).toBe(false);
         expect(mocks.chooseCharacter).toHaveBeenCalledWith(
             { charId: 123 },
@@ -95,5 +100,28 @@ describe('useAuthStore', () => {
                 },
             },
         );
+    });
+
+    it('does not reuse a character token from another account when selecting a character', async () => {
+        mocks.authSessionStore.getUserToken.mockReturnValue('stale-char-token');
+        mocks.authSessionStore.userInfo.accountId = 123;
+        mocks.chooseCharacter.mockResolvedValueOnce({
+            response: {
+                username: 'tester',
+                token: 'fresh-token',
+                char: { userId: 123 } as never,
+                permissions: [],
+                attributes: [],
+                jobProps: undefined,
+            },
+        });
+
+        const authStore = useAuthStore();
+        authStore.accountId = 456;
+
+        await authStore.chooseCharacter(123, false);
+
+        expect(authStore.accountId).toBe(123);
+        expect(mocks.chooseCharacter).toHaveBeenCalledWith({ charId: 123 }, undefined);
     });
 });

--- a/app/stores/auth.test.ts
+++ b/app/stores/auth.test.ts
@@ -69,6 +69,7 @@ describe('useAuthStore', () => {
     });
 
     it('clears account-level config-admin when selecting a character', async () => {
+        mocks.authSessionStore.getUserToken.mockReturnValue('char-token');
         mocks.chooseCharacter.mockResolvedValueOnce({
             response: {
                 username: 'tester',
@@ -86,6 +87,13 @@ describe('useAuthStore', () => {
         await authStore.chooseCharacter(123, false);
 
         expect(authStore.canBeConfigAdmin).toBe(false);
-        expect(mocks.chooseCharacter).toHaveBeenCalledWith({ charId: 123 });
+        expect(mocks.chooseCharacter).toHaveBeenCalledWith(
+            { charId: 123 },
+            {
+                meta: {
+                    Authorization: 'Bearer char-token',
+                },
+            },
+        );
     });
 });

--- a/app/stores/auth.test.ts
+++ b/app/stores/auth.test.ts
@@ -4,10 +4,11 @@ import { useAuthStore } from './auth';
 
 const mocks = vi.hoisted(() => ({
     chooseCharacter: vi.fn(),
+    refreshAccountSession: vi.fn(),
     authSessionStore: {
         getUserToken: vi.fn(),
         setUserToken: vi.fn(),
-        userInfo: { accountId: null as number | null },
+        userInfo: { accountId: null as number | null, userId: null as number | null },
     },
     notificationsStore: {
         add: vi.fn(),
@@ -38,6 +39,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('~~/gen/ts/clients', () => ({
     getAuthAuthClient: vi.fn(async () => ({
         chooseCharacter: mocks.chooseCharacter,
+        refreshAccountSession: mocks.refreshAccountSession,
     })),
 }));
 
@@ -68,11 +70,20 @@ describe('useAuthStore', () => {
         vi.clearAllMocks();
         mocks.authSessionStore.getUserToken.mockReturnValue(null);
         mocks.authSessionStore.userInfo.accountId = null;
+        mocks.authSessionStore.userInfo.userId = null;
+        mocks.refreshAccountSession.mockResolvedValue({
+            response: {
+                accountId: 123,
+                canBeConfigAdmin: false,
+                username: 'tester',
+            },
+        });
     });
 
     it('clears account-level config-admin when selecting a character', async () => {
         mocks.authSessionStore.getUserToken.mockReturnValue('char-token');
         mocks.authSessionStore.userInfo.accountId = 123;
+        mocks.authSessionStore.userInfo.userId = 123;
         mocks.chooseCharacter.mockResolvedValueOnce({
             response: {
                 username: 'tester',
@@ -105,6 +116,7 @@ describe('useAuthStore', () => {
     it('does not reuse a character token from another account when selecting a character', async () => {
         mocks.authSessionStore.getUserToken.mockReturnValue('stale-char-token');
         mocks.authSessionStore.userInfo.accountId = 123;
+        mocks.authSessionStore.userInfo.userId = 999;
         mocks.chooseCharacter.mockResolvedValueOnce({
             response: {
                 username: 'tester',
@@ -123,5 +135,36 @@ describe('useAuthStore', () => {
 
         expect(authStore.accountId).toBe(123);
         expect(mocks.chooseCharacter).toHaveBeenCalledWith({ charId: 123 }, undefined);
+    });
+
+    it('refreshes the account session before restoring a character when accountId is missing', async () => {
+        mocks.authSessionStore.getUserToken.mockReturnValue('char-token');
+        mocks.authSessionStore.userInfo.accountId = 123;
+        mocks.authSessionStore.userInfo.userId = 123;
+        mocks.chooseCharacter.mockResolvedValueOnce({
+            response: {
+                username: 'tester',
+                token: 'char-token',
+                char: { userId: 123 } as never,
+                permissions: [],
+                attributes: [],
+                jobProps: undefined,
+            },
+        });
+
+        const authStore = useAuthStore();
+        authStore.accountId = null;
+
+        await authStore.chooseCharacter(123, false);
+
+        expect(mocks.refreshAccountSession).toHaveBeenCalled();
+        expect(mocks.chooseCharacter).toHaveBeenCalledWith(
+            { charId: 123 },
+            {
+                meta: {
+                    Authorization: 'Bearer char-token',
+                },
+            },
+        );
     });
 });

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -1,4 +1,4 @@
-import type { RpcError } from '@protobuf-ts/runtime-rpc';
+import type { RpcError, RpcOptions } from '@protobuf-ts/runtime-rpc';
 import { defineStore } from 'pinia';
 import { parseQuery } from 'vue-router';
 import { useGRPCWebsocketTransport } from '~/composables/grpcws';
@@ -24,6 +24,17 @@ export const useAuthStore = defineStore(
         const settingsStore = useSettingsStore();
         const notifications = useNotificationsStore();
         const authSessionStore = useAuthSessionStore();
+
+        const characterAuthOptions = (): RpcOptions | undefined => {
+            const token = authSessionStore.getUserToken();
+            if (!token) return undefined;
+
+            return {
+                meta: {
+                    Authorization: `Bearer ${token}`,
+                },
+            };
+        };
 
         // State
         /**
@@ -321,9 +332,12 @@ export const useAuthStore = defineStore(
             try {
                 const authAuthClient = await getAuthAuthClient();
 
-                const call = authAuthClient.chooseCharacter({
-                    charId: charId,
-                });
+                const call = authAuthClient.chooseCharacter(
+                    {
+                        charId: charId,
+                    },
+                    characterAuthOptions(),
+                );
                 const { response } = await call;
                 if (!response.char) {
                     throw new Error('Server Error! No character in choose character response.');
@@ -369,9 +383,12 @@ export const useAuthStore = defineStore(
         const impersonateJob = async (grade: number): Promise<ImpersonateJobResponse> => {
             const authAuthClient = await getAuthAuthClient();
 
-            const call = authAuthClient.impersonateJob({
-                jobGrade: grade,
-            });
+            const call = authAuthClient.impersonateJob(
+                {
+                    jobGrade: grade,
+                },
+                characterAuthOptions(),
+            );
             const { response } = await call;
             if (!response.char) {
                 throw new Error('Server Error! No character in impersonate job response.');
@@ -394,10 +411,13 @@ export const useAuthStore = defineStore(
             const authAuthClient = await getAuthAuthClient();
 
             try {
-                const call = authAuthClient.setSuperuserMode({
-                    superuser,
-                    job: job?.name,
-                });
+                const call = authAuthClient.setSuperuserMode(
+                    {
+                        superuser,
+                        job: job?.name,
+                    },
+                    characterAuthOptions(),
+                );
                 const { response } = await call;
                 // Update state with response data first so websocket reauth can pick up the active character.
                 setActiveChar(response.char!);

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -330,8 +330,8 @@ export const useAuthStore = defineStore(
                 }
 
                 setUsername(response.username);
-                setUserToken(response.token);
                 setActiveChar(response.char);
+                setUserToken(response.token);
                 setPermissions(response.permissions, response.attributes);
                 setAccountCanBeConfigAdmin(false);
                 setJobProps(response.jobProps);
@@ -399,12 +399,12 @@ export const useAuthStore = defineStore(
                     job: job?.name,
                 });
                 const { response } = await call;
+                // Update state with response data first so websocket reauth can pick up the active character.
+                setActiveChar(response.char!);
                 setUserToken(response.token);
                 setPermissions(response.permissions, response.attributes);
                 await navigateTo('/overview');
 
-                // Update state with response data
-                setActiveChar(response.char!);
                 setJobProps(response.jobProps);
 
                 // Notify user about the change

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -27,7 +27,9 @@ export const useAuthStore = defineStore(
 
         const characterAuthOptions = (): RpcOptions | undefined => {
             const token = authSessionStore.getUserToken();
-            if (!token) return undefined;
+            const tokenAccountId = authSessionStore.userInfo?.accountId;
+            if (!token || tokenAccountId === undefined) return undefined;
+            if (accountId.value === null || tokenAccountId !== accountId.value) return undefined;
 
             return {
                 meta: {
@@ -197,6 +199,7 @@ export const useAuthStore = defineStore(
             if (loggingIn.value) return;
 
             loginStart();
+            accountId.value = null;
             setActiveChar();
             setPermissions([], []);
 
@@ -461,6 +464,7 @@ export const useAuthStore = defineStore(
         const clearAuthInfo = (): void => {
             logger.info('Clearing auth info');
             setUsername(null);
+            accountId.value = null;
             setActiveChar(null);
             setPermissions([], []);
             setCanBeSuperuser(false);
@@ -485,11 +489,17 @@ export const useAuthStore = defineStore(
             const currentToken = authSessionStore.getUserToken();
             if (currentToken === token) {
                 logger.debug('User token is the same as the current one, skipping update');
+                if (authSessionStore.userInfo?.accountId !== undefined) {
+                    accountId.value = authSessionStore.userInfo.accountId;
+                }
                 return;
             }
 
             logger.debug('Setting user token in session storage');
             authSessionStore.setUserToken(token);
+            if (authSessionStore.userInfo?.accountId !== undefined) {
+                accountId.value = authSessionStore.userInfo.accountId;
+            }
 
             if (activeChar.value !== null) {
                 logger.info('User token updated, send WebSocket re-auth message');
@@ -567,7 +577,7 @@ export const useAuthStore = defineStore(
     },
     {
         persist: {
-            pick: ['username', 'lastCharID'],
+            pick: ['username', 'accountId', 'lastCharID'],
         },
     },
 );

--- a/app/stores/auth.ts
+++ b/app/stores/auth.ts
@@ -25,11 +25,14 @@ export const useAuthStore = defineStore(
         const notifications = useNotificationsStore();
         const authSessionStore = useAuthSessionStore();
 
-        const characterAuthOptions = (): RpcOptions | undefined => {
+        const characterAuthOptions = (charId?: number): RpcOptions | undefined => {
             const token = authSessionStore.getUserToken();
             const tokenAccountId = authSessionStore.userInfo?.accountId;
-            if (!token || tokenAccountId === undefined) return undefined;
+            const tokenUserId = authSessionStore.userInfo?.userId;
+            if (!token || tokenAccountId === undefined || tokenUserId === undefined) return undefined;
             if (accountId.value === null || tokenAccountId !== accountId.value) return undefined;
+            const expectedCharId = charId ?? activeChar.value?.userId;
+            if (expectedCharId === undefined || tokenUserId !== expectedCharId) return undefined;
 
             return {
                 meta: {
@@ -333,13 +336,21 @@ export const useAuthStore = defineStore(
             }
 
             try {
+                if (accountId.value === null) {
+                    try {
+                        await refreshAccountSession();
+                    } catch (_) {
+                        // Ignore refresh errors here; chooseCharacter can still proceed with the current session state.
+                    }
+                }
+
                 const authAuthClient = await getAuthAuthClient();
 
                 const call = authAuthClient.chooseCharacter(
                     {
                         charId: charId,
                     },
-                    characterAuthOptions(),
+                    characterAuthOptions(charId),
                 );
                 const { response } = await call;
                 if (!response.char) {

--- a/pkg/grpc/auth/token.go
+++ b/pkg/grpc/auth/token.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -97,7 +98,7 @@ func (t *TokenMgr) ParseUserToken(tokenString string) (*authclaims.UserInfoClaim
 		},
 	)
 	if err != nil {
-		return nil, errors.New("failed to parse jwt user token")
+		return nil, fmt.Errorf("failed to parse jwt user token: %w", err)
 	}
 
 	claims, ok := token.Claims.(*authclaims.UserInfoClaims)

--- a/pkg/grpc/auth/token.go
+++ b/pkg/grpc/auth/token.go
@@ -72,7 +72,7 @@ func (t *TokenMgr) ParseAccToken(tokenString string) (*authclaims.AccountInfoCla
 		},
 	)
 	if err != nil {
-		return nil, errors.New("failed to parse jwt acc token")
+		return nil, fmt.Errorf("failed to parse jwt acc token: %w", err)
 	}
 
 	claims, ok := token.Claims.(*authclaims.AccountInfoClaims)
@@ -124,7 +124,7 @@ func (t *TokenMgr) ParseCombinedToken(tokenString string) (*authclaims.CombinedC
 		},
 	)
 	if err != nil {
-		return nil, errors.New("failed to parse jwt user token")
+		return nil, fmt.Errorf("failed to parse jwt user token: %w", err)
 	}
 
 	claims, ok := token.Claims.(*authclaims.CombinedClaims)

--- a/pkg/grpc/auth/token_test.go
+++ b/pkg/grpc/auth/token_test.go
@@ -1,7 +1,9 @@
 package auth
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	accounts "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/accounts"
 	authclaims "github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth/claims"
@@ -72,4 +74,30 @@ func TestMapAccountToClaims(t *testing.T) {
 	assert.Equal(t, account.GetGroups().GetGroups(), claims.Groups)
 	assert.Equal(t, account.GetUsername(), claims.Username)
 	assert.Equal(t, account.GetLicense(), claims.Subject)
+}
+
+func TestParseUserTokenReturnsWrappedExpiryError(t *testing.T) {
+	t.Parallel()
+
+	tm := NewTokenMgr(jwtTokenTestSecret)
+	expiredClaims := &authclaims.UserInfoClaims{
+		AccID:  1,
+		UserID: 2,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(time.Now()),
+			NotBefore: jwt.NewNumericDate(time.Now().Add(-2 * time.Hour)),
+			Subject:   "license",
+			Audience:  []string{"fivenet"},
+			Issuer:    "fivenet",
+		},
+	}
+
+	token, err := tm.FromUserClaims(expiredClaims)
+	require.NoError(t, err)
+
+	parsed, err := tm.ParseUserToken(token)
+	require.Error(t, err)
+	assert.Nil(t, parsed)
+	assert.True(t, errors.Is(err, jwt.ErrTokenExpired))
 }

--- a/pkg/grpc/errswrap/errors.go
+++ b/pkg/grpc/errswrap/errors.go
@@ -26,6 +26,11 @@ type Error struct {
 	e error
 }
 
+// Unwrap returns the original wrapped error.
+func (e *Error) Unwrap() error {
+	return e.e
+}
+
 // OrigErr returns the original error wrapped by this Error.
 func (e *Error) OrigErr() error {
 	return e.e

--- a/pkg/grpc/errswrap/errors_test.go
+++ b/pkg/grpc/errswrap/errors_test.go
@@ -1,0 +1,20 @@
+package errswrap
+
+import (
+	"errors"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewErrorUnwrapsOriginalError(t *testing.T) {
+	t.Parallel()
+
+	orig := errors.New("base error")
+	wrapped := NewError(orig, status.Error(codes.InvalidArgument, "bad request"))
+
+	if !errors.Is(wrapped, orig) {
+		t.Fatalf("expected wrapped error to unwrap to original error")
+	}
+}

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -447,6 +447,10 @@ func (s *Server) ChooseCharacter(
 			currentUserClaims = nil
 		}
 	}
+	if currentUserClaims != nil &&
+		(currentUserClaims.AccID != currentAccClaims.AccID || currentUserClaims.UserID != req.GetCharId()) {
+		currentUserClaims = nil
+	}
 
 	// Load account data for token creation
 	acc, err := s.store.GetAccountByIDAndUsername(

--- a/services/auth/auth.go
+++ b/services/auth/auth.go
@@ -26,6 +26,7 @@ import (
 	pkguserinfo "github.com/fivenet-app/fivenet/v2026/pkg/userinfo"
 	errorsauth "github.com/fivenet-app/fivenet/v2026/services/auth/errors"
 	"github.com/go-jet/jet/v2/qrm"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"go.uber.org/zap"
 )
@@ -437,7 +438,13 @@ func (s *Server) ChooseCharacter(
 	if err == nil {
 		currentUserClaims, err = s.tm.ParseUserToken(userToken)
 		if err != nil {
-			return nil, errswrap.NewError(err, errorsgrpcauth.ErrInvalidToken)
+			if !errors.Is(err, jwt.ErrTokenExpired) {
+				s.logger.Warn(
+					"ignoring invalid user token while choosing character",
+					zap.Error(err),
+				)
+			}
+			currentUserClaims = nil
 		}
 	}
 

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -484,6 +484,25 @@ func TestChooseCharacterFallsBackToAccountSessionWhenUserTokenIsMissingOrInvalid
 	require.NotNil(parsedValidRestoreClaims.Superuser)
 	assert.True(*parsedValidRestoreClaims.Superuser)
 
+	mismatchedRestoreCtx := metadata.NewOutgoingContext(
+		ctx,
+		metadata.New(map[string]string{
+			"Cookie":        auth.AccCookieName + "=" + updatedAccountToken,
+			"Authorization": "Bearer " + superuserRes.GetToken(),
+		}),
+	)
+	mismatchedRestoreRes, err := client.ChooseCharacter(mismatchedRestoreCtx, &pbauth.ChooseCharacterRequest{
+		CharId: 5,
+	})
+	require.NoError(err)
+	require.NotNil(mismatchedRestoreRes)
+	assert.False(hasPermission(mismatchedRestoreRes.GetPermissions(), perms.PermJobAdmin))
+
+	parsedMismatchedRestoreClaims, err := srv.tm.ParseUserToken(mismatchedRestoreRes.GetToken())
+	require.NoError(err)
+	require.NotNil(parsedMismatchedRestoreClaims)
+	assert.Nil(parsedMismatchedRestoreClaims.Superuser)
+
 	invalidRestoreCtx := metadata.NewOutgoingContext(
 		ctx,
 		metadata.New(map[string]string{

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -365,6 +365,123 @@ func TestChooseCharacterConfigAdminEligibility(t *testing.T) {
 	assert.True(hasPermission(impersonateRes.GetPermissions(), perms.PermCanBeSuperuser))
 }
 
+func TestChooseCharacterFallsBackToAccountSessionWhenUserTokenIsMissingOrInvalid(t *testing.T) {
+	t.Parallel()
+	dbServer := servers.NewDBServer(t, true)
+	natsServer := servers.NewNATSServer(t, true)
+
+	ctx := t.Context()
+	assert := assert.New(t)
+	require := require.New(t)
+
+	clientConn, grpcSrvModule, err := modules.TestGRPCServer(ctx)
+	require.NoError(err)
+
+	var srv *Server
+	app := fxtest.New(t,
+		modules.GetFxTestOpts(
+			dbServer.FxProvide(),
+			natsServer.FxProvide(),
+			userinfo.RetrieverModule,
+			fx.Provide(notifi.New),
+			fx.Provide(grpcSrvModule),
+			fx.Provide(grpcserver.AsService(func(p Params) *Server {
+				srv = NewServer(p)
+				return srv
+			})),
+
+			fx.Invoke(func(*grpc.Server) {}),
+		)...,
+	)
+	assert.NotNil(app)
+
+	app.RequireStart()
+	defer app.RequireStop()
+	assert.NotNil(srv)
+
+	client := pbauth.NewAuthServiceClient(clientConn)
+	accountToken := loginAndGetAccountToken(t, client, ctx, "user-1")
+
+	baseCtx := metadata.NewOutgoingContext(
+		ctx,
+		metadata.New(map[string]string{
+			"Cookie": auth.AccCookieName + "=" + accountToken,
+		}),
+	)
+	baseHeaders := metadata.New(nil)
+	baseRes, err := client.ChooseCharacter(baseCtx, &pbauth.ChooseCharacterRequest{
+		CharId: 1,
+	}, grpc.Header(&baseHeaders))
+	require.NoError(err)
+	require.NotNil(baseRes)
+	assert.False(hasPermission(baseRes.GetPermissions(), perms.PermJobAdmin))
+
+	updatedAccountToken := accountToken
+	for _, cookieHeader := range baseHeaders.Get("set-cookie") {
+		cookie, err := http.ParseSetCookie(cookieHeader)
+		require.NoError(err)
+		if cookie.Name == auth.AccCookieName {
+			updatedAccountToken = cookie.Value
+			break
+		}
+	}
+
+	superuserCtx := metadata.NewOutgoingContext(
+		ctx,
+		metadata.New(map[string]string{
+			"Cookie":        auth.AccCookieName + "=" + updatedAccountToken,
+			"Authorization": "Bearer " + baseRes.GetToken(),
+		}),
+	)
+	superuserRes, err := client.SetSuperuserMode(superuserCtx, &pbauth.SetSuperuserModeRequest{
+		Superuser: true,
+	})
+	require.NoError(err)
+	require.NotNil(superuserRes)
+
+	parsedSuperuserClaims, err := srv.tm.ParseUserToken(superuserRes.GetToken())
+	require.NoError(err)
+	require.NotNil(parsedSuperuserClaims)
+	require.NotNil(parsedSuperuserClaims.Superuser)
+	assert.True(*parsedSuperuserClaims.Superuser)
+
+	validRestoreCtx := metadata.NewOutgoingContext(
+		ctx,
+		metadata.New(map[string]string{
+			"Cookie":        auth.AccCookieName + "=" + updatedAccountToken,
+			"Authorization": "Bearer " + superuserRes.GetToken(),
+		}),
+	)
+	validRestoreHeaders := metadata.New(nil)
+	validRestoreRes, err := client.ChooseCharacter(validRestoreCtx, &pbauth.ChooseCharacterRequest{
+		CharId: 1,
+	}, grpc.Header(&validRestoreHeaders))
+	require.NoError(err)
+	require.NotNil(validRestoreRes)
+	assert.True(hasPermission(validRestoreRes.GetPermissions(), perms.PermJobAdmin))
+
+	parsedValidRestoreClaims, err := srv.tm.ParseUserToken(validRestoreRes.GetToken())
+	require.NoError(err)
+	require.NotNil(parsedValidRestoreClaims)
+	require.NotNil(parsedValidRestoreClaims.Superuser)
+	assert.True(*parsedValidRestoreClaims.Superuser)
+
+	invalidRestoreCtx := metadata.NewOutgoingContext(
+		ctx,
+		metadata.New(map[string]string{
+			"Cookie":        auth.AccCookieName + "=" + updatedAccountToken,
+			"Authorization": "Bearer definitely-invalid-user-token",
+		}),
+	)
+	invalidRestoreHeaders := metadata.New(nil)
+	invalidRestoreRes, err := client.ChooseCharacter(invalidRestoreCtx, &pbauth.ChooseCharacterRequest{
+		CharId: 1,
+	}, grpc.Header(&invalidRestoreHeaders))
+	require.NoError(err)
+	require.NotNil(invalidRestoreRes)
+	assert.False(hasPermission(invalidRestoreRes.GetPermissions(), perms.PermJobAdmin))
+}
+
 func loginAndGetAccountToken(
 	t *testing.T,
 	client pbauth.AuthServiceClient,

--- a/services/auth/auth_test.go
+++ b/services/auth/auth_test.go
@@ -402,6 +402,23 @@ func TestChooseCharacterFallsBackToAccountSessionWhenUserTokenIsMissingOrInvalid
 	client := pbauth.NewAuthServiceClient(clientConn)
 	accountToken := loginAndGetAccountToken(t, client, ctx, "user-1")
 
+	srv.jobAdminGroups = nil
+	srv.jobAdminUsers = nil
+	srv.configAdminGroups = nil
+	srv.configAdminUsers = nil
+
+	currentCfg := srv.appCfg.Get()
+	require.NotNil(currentCfg)
+	if currentCfg.GetAuth() == nil {
+		currentCfg.Auth = &settings.Auth{}
+	}
+	currentCfg.GetAuth().SetLastCharLock(true)
+	currentCfg.GetAuth().SetJobAdminGroups(nil)
+	currentCfg.GetAuth().SetJobAdminUsers(nil)
+	currentCfg.GetAuth().SetConfigAdminGroups(nil)
+	currentCfg.GetAuth().SetConfigAdminUsers([]string{"3c7681d6f7ad895eb7b1cc05cf895c7f1d1622c4"})
+	srv.appCfg.Set(currentCfg)
+
 	baseCtx := metadata.NewOutgoingContext(
 		ctx,
 		metadata.New(map[string]string{
@@ -438,6 +455,7 @@ func TestChooseCharacterFallsBackToAccountSessionWhenUserTokenIsMissingOrInvalid
 	})
 	require.NoError(err)
 	require.NotNil(superuserRes)
+	assert.True(hasPermission(superuserRes.GetPermissions(), perms.PermCanBeSuperuser))
 
 	parsedSuperuserClaims, err := srv.tm.ParseUserToken(superuserRes.GetToken())
 	require.NoError(err)


### PR DESCRIPTION
**Description of changes:**

Fix user's session state not restored on page reload (e.g., user enables superuser, reloads page, back to without superuser).

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [CONTRIBUTING.md](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Reviewed the contributor guide [here (CONTRIBUTING.md)](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated, if necessary. Please open a PR in the [website repository](https://github.com/fivenet-app/fivenet-app.github.io) and add a link to the PR here.
- [x] Tests have been added, if necessary.
