### PR TITLE
feat(overview): add quick access bar with pinning context menu

### DIFF
--- a/app/components/HintsBox.vue
+++ b/app/components/HintsBox.vue
@@ -20,6 +20,9 @@ const hints = computed(() =>
                 to: '/user-settings?tab=settings#',
             },
             {
+                key: 'overview_quick_access',
+            },
+            {
                 key: 'sociallogin_discord',
                 to: '/auth/account-info?tab=oauth2Connections#',
                 hide: discord.botEnabled,

--- a/app/components/overview/QuickAccessList.vue
+++ b/app/components/overview/QuickAccessList.vue
@@ -1,0 +1,107 @@
+<script lang="ts" setup>
+import { useDraggable } from 'vue-draggable-plus';
+import { storeToRefs } from 'pinia';
+import DraggableHandle from '~/components/partials/DraggableHandle.vue';
+import type { OverviewFeature } from '~/composables/useOverviewFeatures';
+import ReorderButtons from '~/components/partials/ReorderButtons.vue';
+
+const settingsStore = useSettingsStore();
+const { overviewQuickAccess } = storeToRefs(settingsStore);
+const { reorderOverviewQuickAccess } = settingsStore;
+
+const items = useOverviewFeatures();
+
+const quickAccessItems = computed(() => {
+    const seen = new Set<string>();
+    return overviewQuickAccess.value
+        .map((path) => items.value.find((item) => item.to === path))
+        .filter((item): item is NonNullable<(typeof items.value)[number]> => item !== undefined)
+        .filter((item) => {
+            if (seen.has(item.to)) return false;
+            seen.add(item.to);
+            return true;
+        });
+});
+
+const reorderMode = ref<boolean>(false);
+const sortableQuickAccessItems = ref<OverviewFeature[]>([]);
+const listRef = useTemplateRef('listRef');
+const activeDraggableRoot = shallowRef<HTMLElement | null>(null);
+
+watch(quickAccessItems, (value) => (sortableQuickAccessItems.value = [...value]), { immediate: true });
+
+const draggable = useDraggable(listRef, sortableQuickAccessItems, {
+    immediate: false,
+    animation: 150,
+    handle: '.handle',
+    draggable: '> .quick-access-item',
+    onEnd: () => reorderOverviewQuickAccess(sortableQuickAccessItems.value.map((item) => item.to)),
+});
+
+const { moveUp, moveDown } = useListReorder(sortableQuickAccessItems, {
+    onMove: () => reorderOverviewQuickAccess(sortableQuickAccessItems.value.map((item) => item.to)),
+});
+
+watch(
+    [reorderMode, listRef],
+    ([enabled, root]) => {
+        if (!enabled || !root) {
+            draggable.pause();
+            activeDraggableRoot.value = null;
+            return;
+        }
+
+        if (activeDraggableRoot.value !== root) {
+            draggable.start(root);
+            activeDraggableRoot.value = root;
+        }
+
+        draggable.resume();
+    },
+    { immediate: true, flush: 'post' },
+);
+</script>
+
+<template>
+    <div v-if="quickAccessItems.length > 0">
+        <div class="mb-3 flex items-center justify-between gap-2">
+            <div class="flex flex-col">
+                <h2 class="text-base font-semibold text-highlighted">
+                    {{ $t('common.quick_access') }}
+                </h2>
+            </div>
+
+            <UButton
+                :icon="reorderMode ? 'i-mdi-check' : 'i-mdi-sort'"
+                color="gray"
+                variant="ghost"
+                :label="$t('common.change_order')"
+                :disabled="quickAccessItems.length < 2"
+                @click="() => (reorderMode = !reorderMode)"
+            />
+        </div>
+
+        <div class="rounded-2xl border border-default/60 bg-elevated/70 p-2 shadow-sm backdrop-blur-sm">
+            <div ref="listRef" class="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6">
+                <ULink
+                    v-for="(item, idx) in sortableQuickAccessItems"
+                    :key="item.to"
+                    :to="item.to"
+                    class="quick-access-item group relative flex min-h-20 flex-col items-center justify-center gap-2 rounded-2xl border border-transparent bg-default/70 px-2 py-3 text-center transition hover:-translate-y-0.5 hover:border-primary-500/30 hover:bg-primary-50/60 dark:bg-default/30 dark:hover:bg-primary-950/20"
+                >
+                    <template v-if="reorderMode">
+                        <DraggableHandle class="absolute top-1 left-1" size="xs" orientation="vertical" />
+                        <div class="absolute top-1 right-1">
+                            <ReorderButtons :idx="idx" :move-up="moveUp" :move-down="moveDown" orientation="horizontal" />
+                        </div>
+                    </template>
+
+                    <UIcon class="size-8 text-primary transition group-hover:scale-110" :name="item.icon ?? 'i-mdi-star'" />
+                    <span class="text-sm leading-tight font-medium text-highlighted">
+                        {{ item.title }}
+                    </span>
+                </ULink>
+            </div>
+        </div>
+    </div>
+</template>

--- a/app/components/partials/CardsList.vue
+++ b/app/components/partials/CardsList.vue
@@ -1,13 +1,16 @@
 <script lang="ts" setup>
+import type { ContextMenuItem } from '@nuxt/ui';
 import type { CardElement } from '~/utils/types';
 
 withDefaults(
     defineProps<{
         items: CardElement[];
         showIcon?: boolean;
+        getContextMenuItems?: (item: CardElement, idx: number) => ContextMenuItem[][];
     }>(),
     {
         showIcon: true,
+        getContextMenuItems: undefined,
     },
 );
 
@@ -20,42 +23,54 @@ const { can } = useAuth();
 
 <template>
     <UPageGrid>
-        <UPageCard
+        <template
             v-for="(module, index) in items.filter((i) => i.permission === undefined || can(i.permission).value)"
-            :key="index"
-            :to="module.to"
-            :title="module.title"
-            :icon="showIcon && module.icon?.startsWith('i-') ? module.icon : undefined"
-            :ui="{ title: 'w-full flex flex-row gap-2' }"
-            @click="
-                () => {
-                    !module.to && $emit('selected', index);
-                }
-            "
+            :key="module.to ?? index"
         >
-            <template #title>
-                <span>{{ module.title }}</span>
+            <UContextMenu
+                :items="getContextMenuItems?.(module, index) ?? []"
+                :disabled="(getContextMenuItems?.(module, index) ?? []).length === 0"
+            >
+                <UPageCard
+                    :to="module.to"
+                    :title="module.title"
+                    :icon="showIcon && module.icon?.startsWith('i-') ? module.icon : undefined"
+                    :ui="{ title: 'w-full flex flex-row gap-2' }"
+                    @click="
+                        () => {
+                            !module.to && $emit('selected', index);
+                        }
+                    "
+                >
+                    <template #title>
+                        <span>{{ module.title }}</span>
 
-                <UBadge v-if="module.deletedAt" icon="i-mdi-delete" :label="$t('common.deleted')" color="warning" />
-            </template>
+                        <UBadge v-if="module.deletedAt" icon="i-mdi-delete" :label="$t('common.deleted')" color="warning" />
+                    </template>
 
-            <template v-if="showIcon && module.icon" #leading>
-                <template v-if="!module.icon.startsWith('i-')">
-                    <UIcon
-                        v-if="module.icon"
-                        class="h-10 w-10 shrink-0"
-                        :class="`text-${module.color ?? 'primary'}`"
-                        :name="convertComponentIconNameToDynamic(module.icon)"
-                    />
-                </template>
-                <template v-else>
-                    <UIcon class="h-10 w-10 shrink-0" :class="`text-${module.color ?? 'primary'}`" :name="module.icon" />
-                </template>
-            </template>
+                    <template v-if="showIcon && module.icon" #leading>
+                        <template v-if="!module.icon.startsWith('i-')">
+                            <UIcon
+                                v-if="module.icon"
+                                class="h-10 w-10 shrink-0"
+                                :class="`text-${module.color ?? 'primary'}`"
+                                :name="convertComponentIconNameToDynamic(module.icon)"
+                            />
+                        </template>
+                        <template v-else>
+                            <UIcon
+                                class="h-10 w-10 shrink-0"
+                                :class="`text-${module.color ?? 'primary'}`"
+                                :name="module.icon"
+                            />
+                        </template>
+                    </template>
 
-            <template #description>
-                <span class="line-clamp-2">{{ module.description }}</span>
-            </template>
-        </UPageCard>
+                    <template #description>
+                        <span class="line-clamp-2">{{ module.description }}</span>
+                    </template>
+                </UPageCard>
+            </UContextMenu>
+        </template>
     </UPageGrid>
 </template>

--- a/app/composables/useOverviewFeatures.ts
+++ b/app/composables/useOverviewFeatures.ts
@@ -1,0 +1,85 @@
+import type { CardElement } from '~/utils/types';
+import type { Perms } from '~~/gen/ts/perms';
+
+export type OverviewFeature = CardElement & {
+    to: string;
+};
+
+export const useOverviewFeatures = () => {
+    const { t } = useI18n();
+    const { can } = useAuth();
+
+    return computed<OverviewFeature[]>(() =>
+        [
+            {
+                title: t('common.mail'),
+                description: t('pages.overview.features.mailer'),
+                to: '/mail',
+                permission: 'mailer.MailerService/ListEmails' as Perms,
+                icon: 'i-mdi-inbox-full-outline',
+            },
+            {
+                title: t('common.citizen', 2),
+                description: t('pages.overview.features.citizens'),
+                to: '/citizens',
+                permission: 'citizens.CitizensService/ListCitizens' as Perms,
+                icon: 'i-mdi-account-multiple-outline',
+            },
+            {
+                title: t('common.vehicle', 2),
+                description: t('pages.overview.features.vehicles'),
+                to: '/vehicles',
+                permission: 'vehicles.VehiclesService/ListVehicles' as Perms,
+                icon: 'i-mdi-car-outline',
+            },
+            {
+                title: t('common.document', 2),
+                description: t('pages.overview.features.documents'),
+                to: '/documents',
+                permission: 'documents.DocumentsService/ListDocuments' as Perms,
+                icon: 'i-mdi-file-document-box-multiple-outline',
+            },
+            {
+                title: t('common.job'),
+                description: t('pages.overview.features.jobs'),
+                to: '/jobs/overview',
+                permission: 'jobs.ColleaguesService/ListColleagues' as Perms,
+                icon: 'i-mdi-briefcase-outline',
+            },
+            {
+                title: t('common.calendar'),
+                description: t('pages.overview.features.calendar'),
+                to: '/calendar',
+                icon: 'i-mdi-calendar-outline',
+            },
+            {
+                title: t('common.qualification', 2),
+                description: t('pages.overview.features.qualifications'),
+                to: '/qualifications',
+                permission: 'qualifications.QualificationsService/ListQualifications' as Perms,
+                icon: 'i-mdi-school-outline',
+            },
+            {
+                title: t('common.livemap'),
+                description: t('pages.overview.features.livemap'),
+                to: '/livemap',
+                permission: 'livemap.LivemapService/Stream' as Perms,
+                icon: 'i-mdi-map-outline',
+            },
+            {
+                title: t('common.dispatch_center'),
+                description: t('pages.overview.features.centrum'),
+                to: '/dispatch',
+                permission: 'centrum.CentrumService/TakeControl' as Perms,
+                icon: 'i-mdi-car-emergency',
+            },
+            {
+                title: t('common.wiki'),
+                description: t('pages.overview.features.wiki'),
+                to: '/wiki',
+                permission: 'wiki.WikiService/ListPages' as Perms,
+                icon: 'i-mdi-brain',
+            },
+        ].filter((item) => item.permission === undefined || can(item.permission).value),
+    );
+};

--- a/app/pages/overview.vue
+++ b/app/pages/overview.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
+import type { ContextMenuItem } from '@nuxt/ui';
 import HintsBox from '~/components/HintsBox.vue';
 import CardsList from '~/components/partials/CardsList.vue';
+import QuickAccessList from '~/components/overview/QuickAccessList.vue';
 import type { CardElement } from '~/utils/types';
 
 useHead({
@@ -14,77 +16,25 @@ definePageMeta({
 
 const { t } = useI18n();
 
-const items = computed<CardElement[]>(() => [
-    {
-        title: t('common.mail'),
-        description: t('pages.overview.features.mailer'),
-        to: '/mail',
-        permission: 'mailer.MailerService/ListEmails',
-        icon: 'i-mdi-inbox-full-outline',
-    },
-    {
-        title: `${t('common.citizen', 2)} ${t('common.search')}`,
-        description: t('pages.overview.features.citizens'),
-        to: '/citizens',
-        permission: 'citizens.CitizensService/ListCitizens',
-        icon: 'i-mdi-account-multiple-outline',
-    },
-    {
-        title: t('common.vehicle', 2),
-        description: t('pages.overview.features.vehicles'),
-        to: '/vehicles',
-        permission: 'vehicles.VehiclesService/ListVehicles',
-        icon: 'i-mdi-car-outline',
-    },
-    {
-        title: t('common.document', 2),
-        description: t('pages.overview.features.documents'),
-        to: '/documents',
-        permission: 'documents.DocumentsService/ListDocuments',
-        icon: 'i-mdi-file-document-box-multiple-outline',
-    },
-    {
-        title: t('common.job', 2),
-        description: t('pages.overview.features.jobs'),
-        to: '/jobs/overview',
-        permission: 'jobs.ColleaguesService/ListColleagues',
-        icon: 'i-mdi-briefcase-outline',
-    },
-    {
-        title: t('common.calendar'),
-        description: t('pages.overview.features.calendar'),
-        to: '/calendar',
-        icon: 'i-mdi-calendar-outline',
-    },
-    {
-        title: t('common.qualification', 2),
-        description: t('pages.overview.features.qualifications'),
-        to: '/qualifications',
-        permission: 'qualifications.QualificationsService/ListQualifications',
-        icon: 'i-mdi-school-outline',
-    },
-    {
-        title: t('common.livemap'),
-        description: t('pages.overview.features.livemap'),
-        to: '/livemap',
-        permission: 'livemap.LivemapService/Stream',
-        icon: 'i-mdi-map-outline',
-    },
-    {
-        title: t('common.dispatch_center'),
-        description: t('pages.overview.features.centrum'),
-        to: '/dispatch',
-        permission: 'centrum.CentrumService/TakeControl',
-        icon: 'i-mdi-car-emergency',
-    },
-    {
-        title: t('common.wiki'),
-        description: t('pages.overview.features.wiki'),
-        to: '/wiki',
-        permission: 'wiki.WikiService/ListPages',
-        icon: 'i-mdi-brain',
-    },
-]);
+const items = useOverviewFeatures();
+
+const settingsStore = useSettingsStore();
+const { isOverviewQuickAccess, toggleOverviewQuickAccess } = settingsStore;
+
+const getContextMenuItems = (item: CardElement): ContextMenuItem[][] => {
+    if (!item.to) return [];
+
+    const pinned = isOverviewQuickAccess(item.to);
+    return [
+        [
+            {
+                label: pinned ? t('common.unpin') : t('common.pin'),
+                icon: pinned ? 'i-mdi-pin-off' : 'i-mdi-pin',
+                onSelect: () => item.to && toggleOverviewQuickAccess(item.to),
+            },
+        ],
+    ];
+};
 </script>
 
 <template>
@@ -98,7 +48,9 @@ const items = computed<CardElement[]>(() => [
         </template>
 
         <template #body>
-            <CardsList :items="items" />
+            <QuickAccessList />
+
+            <CardsList :items="items" :get-context-menu-items="getContextMenuItems" />
 
             <div class="max-w-(--breakpoint-lg) sm:mx-auto">
                 <HintsBox />

--- a/app/stores/settings.test.ts
+++ b/app/stores/settings.test.ts
@@ -1,0 +1,56 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useSettingsStore } from './settings';
+
+describe('useSettingsStore quick access helpers', () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it('pins routes idempotently', () => {
+        const settingsStore = useSettingsStore();
+
+        settingsStore.pinOverviewQuickAccess('/mail');
+        settingsStore.pinOverviewQuickAccess('/mail');
+        settingsStore.pinOverviewQuickAccess('/calendar');
+
+        expect(settingsStore.overviewQuickAccess).toEqual(['/mail', '/calendar']);
+        expect(settingsStore.isOverviewQuickAccess('/mail')).toBe(true);
+        expect(settingsStore.isOverviewQuickAccess('/wiki')).toBe(false);
+    });
+
+    it('unpins routes and toggles them back on', () => {
+        const settingsStore = useSettingsStore();
+
+        settingsStore.pinOverviewQuickAccess('/mail');
+        settingsStore.pinOverviewQuickAccess('/calendar');
+        settingsStore.unpinOverviewQuickAccess('/mail');
+
+        expect(settingsStore.overviewQuickAccess).toEqual(['/calendar']);
+
+        settingsStore.toggleOverviewQuickAccess('/calendar');
+        expect(settingsStore.overviewQuickAccess).toEqual([]);
+
+        settingsStore.toggleOverviewQuickAccess('/wiki');
+        expect(settingsStore.overviewQuickAccess).toEqual(['/wiki']);
+    });
+
+    it('normalizes duplicate entries while preserving order', () => {
+        const settingsStore = useSettingsStore();
+
+        settingsStore.overviewQuickAccess = ['/mail', '/calendar', '/mail', '/wiki', '/calendar'];
+        settingsStore.normalizeOverviewQuickAccess();
+
+        expect(settingsStore.overviewQuickAccess).toEqual(['/mail', '/calendar', '/wiki']);
+    });
+
+    it('reorders only visible quick access entries and keeps hidden ones in place', () => {
+        const settingsStore = useSettingsStore();
+
+        settingsStore.overviewQuickAccess = ['/mail', '/hidden-1', '/calendar', '/hidden-2', '/wiki'];
+
+        settingsStore.reorderOverviewQuickAccess(['/wiki', '/mail', '/calendar']);
+
+        expect(settingsStore.overviewQuickAccess).toEqual(['/wiki', '/hidden-1', '/mail', '/hidden-2', '/calendar']);
+    });
+});

--- a/app/stores/settings.ts
+++ b/app/stores/settings.ts
@@ -86,6 +86,8 @@ export const useSettingsStore = defineStore(
         const now = new Date();
         const eventsShowSnowflakes = computed(() => now.getMonth() + 1 === 12 && now.getDate() >= 21 && now.getDate() <= 26);
 
+        const overviewQuickAccess = ref<string[]>([]);
+
         const livemap = ref<LivemapSettings>({
             markerSize: 22,
             centerSelectedMarker: false,
@@ -157,6 +159,83 @@ export const useSettingsStore = defineStore(
             minStrokeWidth: 2,
             maxStrokeWidth: 6,
         });
+
+        /**
+         * Normalize the quick access list while preserving order.
+         * Deduplication is intentional so repeated pin actions stay idempotent.
+         */
+        const normalizeOverviewQuickAccess = (): void => {
+            const seen = new Set<string>();
+            overviewQuickAccess.value = overviewQuickAccess.value.filter((path) => {
+                if (seen.has(path)) return false;
+                seen.add(path);
+                return true;
+            });
+        };
+
+        /**
+         * Pin a route path to the overview quick access bar.
+         *
+         * @param {string} path - The route path to add.
+         */
+        const pinOverviewQuickAccess = (path: string): void => {
+            if (!path) return;
+            if (overviewQuickAccess.value.includes(path)) return;
+            overviewQuickAccess.value.push(path);
+        };
+
+        /**
+         * Remove a route path from the overview quick access bar.
+         *
+         * @param {string} path - The route path to remove.
+         */
+        const unpinOverviewQuickAccess = (path: string): void => {
+            const idx = overviewQuickAccess.value.indexOf(path);
+            if (idx === -1) return;
+            overviewQuickAccess.value.splice(idx, 1);
+        };
+
+        /**
+         * Toggle a route path in the overview quick access bar.
+         *
+         * @param {string} path - The route path to toggle.
+         */
+        const toggleOverviewQuickAccess = (path: string): void => {
+            if (overviewQuickAccess.value.includes(path)) {
+                unpinOverviewQuickAccess(path);
+                return;
+            }
+
+            pinOverviewQuickAccess(path);
+        };
+
+        /**
+         * Reorder the visible quick access routes while preserving hidden entries in place.
+         *
+         * @param {string[]} orderedPaths - The visible routes in their new order.
+         */
+        const reorderOverviewQuickAccess = (orderedPaths: string[]): void => {
+            const visiblePaths = [...new Set(orderedPaths)].filter((path) => overviewQuickAccess.value.includes(path));
+            if (visiblePaths.length === 0) return;
+
+            const visibleSet = new Set(visiblePaths);
+            let nextVisible = 0;
+
+            overviewQuickAccess.value = overviewQuickAccess.value.map((path) => {
+                if (!visibleSet.has(path)) return path;
+
+                const nextPath = visiblePaths[nextVisible];
+                nextVisible += 1;
+                return nextPath ?? path;
+            });
+        };
+
+        /**
+         * Check whether a route path is pinned to the overview quick access bar.
+         *
+         * @param {string} path - The route path to check.
+         */
+        const isOverviewQuickAccess = (path: string): boolean => overviewQuickAccess.value.includes(path);
 
         // Quick button Notepad fullscreen state
         const notepadFullscreen = ref<boolean>(false);
@@ -248,6 +327,8 @@ export const useSettingsStore = defineStore(
          * Migrate store
          */
         const migrateStore = (): void => {
+            normalizeOverviewQuickAccess();
+
             // Fixup livemap tile layer name
             if ((livemapTileLayer.value as string) === 'satelite') {
                 livemapTileLayer.value = 'satellite';
@@ -264,6 +345,7 @@ export const useSettingsStore = defineStore(
 
             eventsDisabled,
 
+            overviewQuickAccess,
             livemap,
             livemapLayerCategories,
             livemapLayers,
@@ -286,6 +368,12 @@ export const useSettingsStore = defineStore(
             addOrUpdateLivemapCategory,
             addOrUpdateLivemapLayer,
             removeLivemapLayer,
+            normalizeOverviewQuickAccess,
+            pinOverviewQuickAccess,
+            unpinOverviewQuickAccess,
+            toggleOverviewQuickAccess,
+            reorderOverviewQuickAccess,
+            isOverviewQuickAccess,
             migrateStore,
 
             eventsShowSnowflakes,

--- a/app/utils/types.ts
+++ b/app/utils/types.ts
@@ -1,11 +1,10 @@
-import type { RoutesNamedLocations } from '@typed-router';
 import type { Perms } from '~~/gen/ts/perms';
 import type { Timestamp } from '~~/gen/ts/resources/timestamp/timestamp';
 
 export type CardElement = {
     title: string;
     description?: string;
-    to?: RoutesNamedLocations | string;
+    to?: string;
     permission?: Perms;
     icon?: string;
     color?: string;

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -892,7 +892,8 @@
         "rotate_right": "Nach rechts rotieren",
         "change_order": "Reihenfolge ändern",
         "hidden": "Versteckt",
-        "treemap": "Kachelkarte"
+        "treemap": "Kachelkarte",
+        "quick_access": "Schnellzugriff"
     },
     "components": {
         "partials": {
@@ -1421,6 +1422,9 @@
             "click_me": "Klicke hier",
             "startpage": {
                 "content": "Die Startseite von FiveNet können Sie in Ihren Kontoinformationen festlegen."
+            },
+            "overview_quick_access": {
+                "content": "Über das Rechtsklick-Menü auf der Übersicht-Seite können Sie Funktionen an die Schnellzugriffsleiste anheften."
             },
             "template_editor_templating": {
                 "content": "Sie können Golang HTML Templating im oberen Feld benutzen. Für kopierbereite-Ausschnitte und Tricks folgen Sie dem Link."

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -892,7 +892,8 @@
         "rotate_right": "Rotate Right",
         "change_order": "Change Order",
         "hidden": "Hidden",
-        "treemap": "Tree map"
+        "treemap": "Tree map",
+        "quick_access": "Quick Access"
     },
     "components": {
         "partials": {
@@ -1421,6 +1422,9 @@
             "click_me": "Click here",
             "startpage": {
                 "content": "You can set the start page FiveNet opens up on in your Account information."
+            },
+            "overview_quick_access": {
+                "content": "Use the right click menu on overview cards to pin features to your quick access bar."
             },
             "template_editor_templating": {
                 "content": "You can use Golang HTML templating in the above field. For template snippets follow the link."


### PR DESCRIPTION
**Description of changes:**

Add quick access bar to the overview page with context menu for pinning/unpinning items.

<img width="1000" height="517" alt="image" src="https://github.com/user-attachments/assets/cf98843f-960c-44dd-8a1f-3003dd7013e5" />
<img width="999" height="317" alt="image" src="https://github.com/user-attachments/assets/6f7e67d6-6225-4fb3-8343-6ff2f1594b0b" />
<img width="1003" height="270" alt="image" src="https://github.com/user-attachments/assets/5323f5e7-d67e-4570-8a68-b96183354ea9" />


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [CONTRIBUTING.md](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Reviewed the contributor guide [here (CONTRIBUTING.md)](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated, if necessary. Please open a PR in the [website repository](https://github.com/fivenet-app/fivenet-app.github.io) and add a link to the PR here.
- [x] Tests have been added, if necessary.