### PR TITLE
feat(documents): resolve template selections server-side

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -631,35 +631,6 @@ html {
         cursor: col-resize;
     }
 
-    /* Tiptap Editor Extensions */
-    div.template-block {
-        border-left: 1px dashed var(--color-primary-500);
-        background-color: var(--color-gray-800);
-        padding: 0.25rem;
-        margin: 0.25rem 0;
-        font-family: monospace;
-        cursor: pointer;
-    }
-
-    .template-open,
-    .template-close {
-        font-weight: bold;
-        margin-bottom: 0.25rem;
-    }
-
-    span.template-var {
-        background-color: var(--color-gray-800);
-        border-radius: 4px;
-        padding: 2px 2px;
-        font-family: monospace;
-        border: 1px dashed var(--color-primary-500);
-        cursor: pointer;
-    }
-
-    span.template-var[data-hidden='true'] {
-        display: none;
-    }
-
     /* Details/Spoiler */
     .details {
         margin: 0.75rem 0;

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -638,6 +638,7 @@ html {
         padding: 0.25rem;
         margin: 0.25rem 0;
         font-family: monospace;
+        cursor: pointer;
     }
 
     .template-open,
@@ -652,6 +653,7 @@ html {
         padding: 2px 2px;
         font-family: monospace;
         border: 1px dashed var(--color-primary-500);
+        cursor: pointer;
     }
 
     span.template-var[data-hidden='true'] {

--- a/app/components/citizens/List.vue
+++ b/app/components/citizens/List.vue
@@ -25,6 +25,7 @@ const canTriggerUserSync = can('internal.Superuser/ConfigAdmin');
 const { display } = useAppConfig();
 
 const clipboardStore = useClipboardStore();
+const { open: openClipboardModal } = useClipboardModal();
 const notifications = useNotificationsStore();
 
 const citizensCitizensClient = await getCitizensCitizensClient();
@@ -110,13 +111,28 @@ async function listCitizens(values: Schema): Promise<ListCitizensResponse> {
 const numberFormatter = useDisplayNumberFormat();
 
 function addToClipboard(user: User): void {
-    clipboardStore.addUser(user);
+    const added = clipboardStore.addUser(user);
 
     notifications.add({
-        title: { key: 'notifications.clipboard.citizen_add.title', parameters: {} },
-        description: { key: 'notifications.clipboard.citizen_add.content', parameters: {} },
+        title: {
+            key: added ? 'notifications.clipboard.citizen_add.title' : 'notifications.clipboard.limit_reached.title',
+            parameters: {},
+        },
+        description: {
+            key: added ? 'notifications.clipboard.citizen_add.content' : 'notifications.clipboard.limit_reached.content',
+            parameters: {},
+        },
         duration: 3250,
-        type: NotificationType.INFO,
+        type: added ? NotificationType.INFO : NotificationType.WARNING,
+        actions: added
+            ? []
+            : [
+                  {
+                      label: { key: 'common.open', parameters: {} },
+                      icon: 'i-mdi-clipboard-list-outline',
+                      onClick: () => void openClipboardModal(),
+                  },
+              ],
     });
 }
 

--- a/app/components/citizens/info/Actions.vue
+++ b/app/components/citizens/info/Actions.vue
@@ -31,6 +31,7 @@ const emits = defineEmits<{
 const { attr, can, activeChar } = useAuth();
 
 const clipboardStore = useClipboardStore();
+const { open: openClipboardModal } = useClipboardModal();
 
 const notifications = useNotificationsStore();
 
@@ -45,7 +46,23 @@ const setMugshotModal = overlay.create(SetMugshotModal);
 function openTemplates(): void {
     if (!props.user) return;
 
-    clipboardStore.addUser(props.user, true);
+    const added = clipboardStore.addUser(props.user, true);
+
+    if (!added) {
+        notifications.add({
+            title: { key: 'notifications.clipboard.limit_reached.title', parameters: {} },
+            description: { key: 'notifications.clipboard.limit_reached.content', parameters: {} },
+            duration: 3250,
+            type: NotificationType.WARNING,
+            actions: [
+                {
+                    label: { key: 'common.open', parameters: {} },
+                    icon: 'i-mdi-clipboard-list-outline',
+                    onClick: () => void openClipboardModal(),
+                },
+            ],
+        });
+    }
 
     templateDrawer.open({});
 }

--- a/app/components/documents/View.vue
+++ b/app/components/documents/View.vue
@@ -49,6 +49,7 @@ const { t } = useI18n();
 const { attr, can, activeChar, isSuperuser } = useAuth();
 
 const clipboardStore = useClipboardStore();
+const { open: openClipboardModal } = useClipboardModal();
 
 const notifications = useNotificationsStore();
 
@@ -77,15 +78,28 @@ useHead({
 });
 
 function addToClipboard(): void {
-    if (doc.value?.document) {
-        clipboardStore.addDocument(doc.value.document);
-    }
+    const added = doc.value?.document ? clipboardStore.addDocument(doc.value.document) : false;
 
     notifications.add({
-        title: { key: 'notifications.clipboard.document_added.title', parameters: {} },
-        description: { key: 'notifications.clipboard.document_added.content', parameters: {} },
+        title: {
+            key: added ? 'notifications.clipboard.document_added.title' : 'notifications.clipboard.limit_reached.title',
+            parameters: {},
+        },
+        description: {
+            key: added ? 'notifications.clipboard.document_added.content' : 'notifications.clipboard.limit_reached.content',
+            parameters: {},
+        },
         duration: 3250,
-        type: NotificationType.INFO,
+        type: added ? NotificationType.INFO : NotificationType.WARNING,
+        actions: added
+            ? []
+            : [
+                  {
+                      label: { key: 'common.open', parameters: {} },
+                      icon: 'i-mdi-clipboard-list-outline',
+                      onClick: () => void openClipboardModal(),
+                  },
+              ],
     });
 }
 

--- a/app/components/documents/templates/PreviewModal.vue
+++ b/app/components/documents/templates/PreviewModal.vue
@@ -5,6 +5,7 @@ import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import CategoryBadge from '~/components/partials/documents/CategoryBadge.vue';
 import RefreshButton from '~/components/partials/RefreshButton.vue';
 import { useClipboardStore } from '~/stores/clipboard';
+import { localizeTemplateErrorParameters, parseError } from '~/utils/errors';
 import { getDocumentsTemplatesClient } from '~~/gen/ts/clients';
 import type { Template } from '~~/gen/ts/resources/documents/templates/templates';
 
@@ -30,6 +31,16 @@ const {
 } = useLazyAsyncData(`documents-templates-${props.templateId}`, () => getTemplate());
 
 const loading = computed(() => isRequestPending(status.value));
+
+const localizedError = computed(() => {
+    const currentError = error.value;
+    if (!currentError) return undefined;
+
+    const parsedError = parseError(currentError);
+    if (!parsedError) return currentError;
+
+    return new Error(JSON.stringify(localizeTemplateErrorParameters(parsedError, $t)));
+});
 
 async function getTemplate(): Promise<Template> {
     try {
@@ -58,7 +69,7 @@ async function getTemplate(): Promise<Template> {
             <DataErrorBlock
                 v-else-if="error"
                 :title="$t('common.unable_to_load', [$t('common.template', 2)])"
-                :error="error"
+                :error="localizedError"
                 :retry="refresh"
             />
             <DataNoDataBlock v-else-if="!template" :type="$t('common.template', 2)" />

--- a/app/components/documents/templates/PreviewModal.vue
+++ b/app/components/documents/templates/PreviewModal.vue
@@ -3,7 +3,6 @@ import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
 import DataNoDataBlock from '~/components/partials/data/DataNoDataBlock.vue';
 import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import CategoryBadge from '~/components/partials/documents/CategoryBadge.vue';
-import { useAuthStore } from '~/stores/auth';
 import { useClipboardStore } from '~/stores/clipboard';
 import { getDocumentsTemplatesClient } from '~~/gen/ts/clients';
 import type { Template } from '~~/gen/ts/resources/documents/templates/templates';
@@ -16,10 +15,7 @@ defineEmits<{
     (e: 'close', v: boolean): void;
 }>();
 
-const authStore = useAuthStore();
 const clipboardStore = useClipboardStore();
-
-const { activeChar } = storeToRefs(authStore);
 
 const logger = useLogger('📃 Doc Templates');
 
@@ -34,13 +30,12 @@ const {
 
 async function getTemplate(): Promise<Template> {
     try {
-        const data = clipboardStore.getTemplateData();
-        data.activeChar = activeChar.value!;
-        logger.debug('Documents: Editor - Clipboard Template Data', data);
+        const selection = clipboardStore.getTemplateSelection();
+        logger.debug('Documents: Editor - Clipboard Template Selection', selection);
 
         const call = documentsTemplatesClient.getTemplate({
             templateId: props.templateId,
-            data: data,
+            selection: selection,
             render: true,
         });
         const { response } = await call;

--- a/app/components/documents/templates/PreviewModal.vue
+++ b/app/components/documents/templates/PreviewModal.vue
@@ -3,6 +3,7 @@ import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
 import DataNoDataBlock from '~/components/partials/data/DataNoDataBlock.vue';
 import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import CategoryBadge from '~/components/partials/documents/CategoryBadge.vue';
+import RefreshButton from '~/components/partials/RefreshButton.vue';
 import { useClipboardStore } from '~/stores/clipboard';
 import { getDocumentsTemplatesClient } from '~~/gen/ts/clients';
 import type { Template } from '~~/gen/ts/resources/documents/templates/templates';
@@ -28,9 +29,11 @@ const {
     error,
 } = useLazyAsyncData(`documents-templates-${props.templateId}`, () => getTemplate());
 
+const loading = computed(() => isRequestPending(status.value));
+
 async function getTemplate(): Promise<Template> {
     try {
-        const selection = clipboardStore.getTemplateSelection();
+        const selection = clipboardStore.getTemplateSelection(false);
         logger.debug('Documents: Editor - Clipboard Template Selection', selection);
 
         const call = documentsTemplatesClient.getTemplate({
@@ -50,10 +53,8 @@ async function getTemplate(): Promise<Template> {
 
 <template>
     <UModal :title="`${$t('common.template', 1)} ${$t('common.preview')}`" fullscreen>
-        <!-- eslint-disable vue/no-v-html -->
-
         <template #body>
-            <DataPendingBlock v-if="isRequestPending(status)" :message="$t('common.loading', [$t('common.template', 2)])" />
+            <DataPendingBlock v-if="loading" :message="$t('common.loading', [$t('common.template', 2)])" />
             <DataErrorBlock
                 v-else-if="error"
                 :title="$t('common.unable_to_load', [$t('common.template', 2)])"
@@ -62,28 +63,27 @@ async function getTemplate(): Promise<Template> {
             />
             <DataNoDataBlock v-else-if="!template" :type="$t('common.template', 2)" />
 
-            <div v-else class="mx-auto w-full max-w-(--breakpoint-xl)">
-                <div class="mb-2">
-                    <UFormField name="title" :label="$t('common.title')">
-                        <UInput class="w-full" :model-value="template?.title" type="text" size="xl" disabled />
+            <div v-else class="mx-auto flex w-full max-w-(--breakpoint-xl) flex-col gap-2">
+                <UFormField name="title" :label="$t('common.title')">
+                    <UInput class="w-full" :model-value="template?.title" type="text" size="xl" disabled />
+                </UFormField>
+
+                <div class="flex flex-row gap-2">
+                    <UFormField class="flex-1" name="category" :label="$t('common.category', 1)">
+                        <CategoryBadge v-if="template?.category" :category="template.category" />
+                        <span v-else>{{ $t('common.categories', 0) }}</span>
                     </UFormField>
 
-                    <div class="flex flex-row gap-2">
-                        <UFormField class="flex-1" name="category" :label="$t('common.category', 1)">
-                            <CategoryBadge v-if="template?.category" :category="template.category" />
-                            <span v-else>{{ $t('common.categories', 0) }}</span>
-                        </UFormField>
-
-                        <UFormField class="flex-1" name="state" :label="$t('common.state')">
-                            <UInput class="w-full" :model-value="template?.state" type="text" disabled />
-                        </UFormField>
-                    </div>
+                    <UFormField class="flex-1" name="state" :label="$t('common.state')">
+                        <UInput class="w-full" :model-value="template?.state" type="text" disabled />
+                    </UFormField>
                 </div>
 
                 <UFormField name="content" :label="$t('common.content')">
                     <div
                         class="mx-auto w-full max-w-(--breakpoint-xl) rounded-lg bg-neutral-100 p-4 break-words dark:bg-neutral-800"
                     >
+                        <!-- eslint-disable vue/no-v-html -->
                         <div
                             class="tiptap prose prose-sm max-w-full min-w-full break-words sm:prose-base lg:prose-lg dark:prose-invert"
                             :class="[
@@ -118,14 +118,17 @@ async function getTemplate(): Promise<Template> {
                                 'prose-hr:mt-0.5',
                             ]"
                             v-html="template?.content"
-                        ></div>
+                        />
                     </div>
                 </UFormField>
             </div>
         </template>
 
         <template #footer>
-            <UButton class="flex-1" color="neutral" block :label="$t('common.close', 1)" @click="$emit('close', false)" />
+            <UFieldGroup class="inline-flex w-full">
+                <UButton class="flex-1" color="neutral" block :label="$t('common.close', 1)" @click="$emit('close', false)" />
+                <RefreshButton variant="solid" :loading="loading" :disabled="loading" @click="() => refresh()" />
+            </UFieldGroup>
         </template>
     </UModal>
 </template>

--- a/app/components/documents/templates/View.vue
+++ b/app/components/documents/templates/View.vue
@@ -8,6 +8,9 @@ import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
 import DataNoDataBlock from '~/components/partials/data/DataNoDataBlock.vue';
 import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import CategoryBadge from '~/components/partials/documents/CategoryBadge.vue';
+import TiptapEditor from '~/components/partials/editor/TiptapEditor.vue';
+import { TemplateBlock, TemplateBlockEnd } from '~/composables/tiptap/extensions/TemplateBlock';
+import { TemplateVar } from '~/composables/tiptap/extensions/TemplateVar';
 import type { ResponsiveActionEntry } from '~/components/partials/ResponsiveActions.types';
 import { getDocumentsTemplatesClient } from '~~/gen/ts/clients';
 import { AccessLevel } from '~~/gen/ts/resources/documents/access/access';
@@ -200,7 +203,13 @@ const templatePreviewModal = overlay.create(PreviewModal, { props: { templateId:
                 <template v-else>
                     <div class="flex flex-col gap-4">
                         <UPageCard :title="$t('common.detail', 2)">
-                            <UFormField v-if="template.jobAccess" :label="`${$t('common.template', 2)} ${$t('common.access')}`">
+                            <UFormField name="color" :label="$t('common.color')">
+                                <div class="flex flex-1 gap-1">
+                                    <ColorPickerTW v-model="template.color" class="flex-1" disabled />
+                                </div>
+                            </UFormField>
+
+                            <UFormField :label="`${$t('common.template', 2)} ${$t('common.access')}`">
                                 <AccessManager
                                     v-model:jobs="template.jobAccess"
                                     :target-id="templateId ?? 0"
@@ -214,12 +223,6 @@ const templatePreviewModal = overlay.create(PreviewModal, { props: { templateId:
                                     name="jobAccess"
                                     full-name
                                 />
-                            </UFormField>
-
-                            <UFormField name="color" :label="$t('common.color')">
-                                <div class="flex flex-1 gap-1">
-                                    <ColorPickerTW v-model="template.color" class="flex-1" disabled />
-                                </div>
                             </UFormField>
                         </UPageCard>
 
@@ -243,16 +246,30 @@ const templatePreviewModal = overlay.create(PreviewModal, { props: { templateId:
                                 <CategoryBadge :category="template.category" />
                             </UFormField>
 
-                            <UFormField :label="$t('common.content')">
-                                <UTextarea
-                                    class="w-full whitespace-pre-wrap"
-                                    name="content"
-                                    disabled
-                                    resize
-                                    :rows="4"
-                                    :value="template.content"
+                            <UCollapsible>
+                                <UButton
+                                    class="group"
+                                    block
+                                    color="neutral"
+                                    variant="subtle"
+                                    trailing-icon="i-mdi-chevron-down"
+                                    :label="$t('common.content')"
+                                    :ui="{
+                                        trailingIcon: 'group-data-[state=open]:rotate-180 transition-transform duration-200',
+                                    }"
                                 />
-                            </UFormField>
+
+                                <template #content>
+                                    <TiptapEditor
+                                        :model-value="template.content"
+                                        class="mt-2 min-h-64"
+                                        content-type="html"
+                                        disabled
+                                        hide-toolbar
+                                        :extensions="[TemplateVar, TemplateBlock, TemplateBlockEnd]"
+                                    />
+                                </template>
+                            </UCollapsible>
 
                             <UFormField v-if="template.contentAccess" :label="$t('common.access')">
                                 <AccessManager

--- a/app/components/documents/templates/editor/Editor.vue
+++ b/app/components/documents/templates/editor/Editor.vue
@@ -10,8 +10,11 @@ import SelectMenu from '~/components/partials/SelectMenu.vue';
 import AccessManager from '~/components/partials/access/AccessManager.vue';
 import { enumToAccessLevelEnums, type AccessType } from '~/components/partials/access/helpers';
 import CategoryBadge from '~/components/partials/documents/CategoryBadge.vue';
+import DataErrorBlock from '~/components/partials/data/DataErrorBlock.vue';
+import DataNoDataBlock from '~/components/partials/data/DataNoDataBlock.vue';
+import DataPendingBlock from '~/components/partials/data/DataPendingBlock.vue';
 import TiptapEditor from '~/components/partials/editor/TiptapEditor.vue';
-import { TemplateBlock } from '~/composables/tiptap/extensions/TemplateBlock';
+import { TemplateBlock, TemplateBlockEnd } from '~/composables/tiptap/extensions/TemplateBlock';
 import { TemplateVar } from '~/composables/tiptap/extensions/TemplateVar';
 import { useAuthStore } from '~/stores/auth';
 import { useCompletorStore } from '~/stores/completor';
@@ -165,6 +168,12 @@ const state = reactive<Schema>({
 });
 
 const canSubmit = ref<boolean>(true);
+const template = ref<Template>();
+const loading = ref<boolean>(!!props.templateId);
+const loadError = ref<Error>();
+
+const canEdit = computed(() => !props.templateId || (!loading.value && !loadError.value && !!template.value));
+
 const onSubmitThrottle = useThrottleFn(async (event: FormSubmitEvent<Schema>) => {
     if (event.submitter?.getAttribute('role') === 'tab') return;
 
@@ -405,31 +414,37 @@ function setValuesFromTemplate(tpl: Template): void {
     syncSnapshot();
 }
 
-const extensions = [TemplateVar.configure(), TemplateBlock.configure()];
+const extensions = [TemplateVar.configure(), TemplateBlock.configure(), TemplateBlockEnd.configure()];
+
+async function loadTemplate(): Promise<void> {
+    loading.value = true;
+    loadError.value = undefined;
+
+    try {
+        const call = documentsTemplatesClient.getTemplate({
+            templateId: props.templateId!,
+            render: false,
+        });
+        const { response } = await call;
+        template.value = response.template;
+
+        if (template.value) {
+            setValuesFromTemplate(template.value);
+            useHead({
+                title: () => `${template.value?.title} - ${t('pages.documents.templates.edit.title')}`,
+            });
+        }
+    } catch (e) {
+        loadError.value = e as Error;
+        handleGRPCError(e as RpcError);
+    } finally {
+        loading.value = false;
+    }
+}
 
 onBeforeMount(async () => {
     if (props.templateId) {
-        try {
-            const call = documentsTemplatesClient.getTemplate({
-                templateId: props.templateId,
-                render: false,
-            });
-            const { response } = await call;
-
-            const tpl = response.template;
-            if (!tpl) return;
-
-            setValuesFromTemplate(tpl);
-
-            useHead({
-                title: () =>
-                    tpl?.title
-                        ? `${tpl.title} - ${t('pages.documents.templates.edit.title')}`
-                        : t('pages.documents.templates.edit.title'),
-            });
-        } catch (e) {
-            handleGRPCError(e as RpcError);
-        }
+        await loadTemplate();
     } else {
         state.jobAccess.push({
             id: 0,
@@ -500,8 +515,8 @@ const formRef = useTemplateRef('formRef');
 
                     <UButton
                         trailing-icon="i-mdi-content-save"
-                        :disabled="!canSubmit"
-                        :loading="!canSubmit"
+                        :disabled="!canSubmit || !canEdit"
+                        :loading="!canSubmit || loading"
                         @click="formRef?.submit()"
                     >
                         <span class="hidden truncate sm:block">
@@ -520,7 +535,17 @@ const formRef = useTemplateRef('formRef');
                 :state="state"
                 @submit="onSubmitThrottle"
             >
+                <DataPendingBlock v-if="templateId && loading" :message="$t('common.loading', [$t('common.template', 2)])" />
+                <DataErrorBlock
+                    v-else-if="templateId && loadError"
+                    :title="$t('common.unable_to_load', [$t('common.template', 2)])"
+                    :error="loadError"
+                    :retry="loadTemplate"
+                />
+                <DataNoDataBlock v-else-if="templateId && !template" :type="$t('common.template', 2)" :retry="loadTemplate" />
+
                 <UTabs
+                    v-else
                     v-model="selectedTab"
                     class="flex-1 flex-col overflow-y-hidden"
                     :items="items"

--- a/app/components/documents/templates/editor/TemplateBlockEndForm.vue
+++ b/app/components/documents/templates/editor/TemplateBlockEndForm.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import TemplateTrimControls from './TemplateTrimControls.vue';
+
+const props = withDefaults(defineProps<{ leftTrim?: boolean; rightTrim?: boolean }>(), {
+    leftTrim: false,
+    rightTrim: false,
+});
+
+const emit = defineEmits<{
+    (e: 'submit', value: { value: string; leftTrim: boolean; rightTrim: boolean }): void;
+    (e: 'delete'): void;
+}>();
+
+const leftTrim = ref(props.leftTrim);
+const rightTrim = ref(props.rightTrim);
+
+function submit(): void {
+    emit('submit', { value: 'end', leftTrim: leftTrim.value, rightTrim: rightTrim.value });
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-3">
+        <TemplateTrimControls v-model:left-trim="leftTrim" v-model:right-trim="rightTrim" />
+
+        <UFieldGroup>
+            <UButton block :label="$t('common.save')" @click="submit" />
+            <UTooltip :text="$t('common.delete')">
+                <UButton color="error" icon="i-mdi-trash-can" @click="$emit('delete')" />
+            </UTooltip>
+        </UFieldGroup>
+    </div>
+</template>

--- a/app/components/documents/templates/editor/TemplateBlockInsert.vue
+++ b/app/components/documents/templates/editor/TemplateBlockInsert.vue
@@ -41,10 +41,20 @@ const insertBlock = () => {
         </UTooltip>
 
         <template #content>
-            <div class="flex flex-col gap-2 p-4">
+            <div class="flex w-full max-w-86 flex-col gap-2 p-4">
                 <h3 class="block font-medium">
                     {{ $t('components.partials.tiptap_editor.extensions.template_block.title') }}
                 </h3>
+
+                <UAlert icon="i-mdi-information-outline" variant="subtle">
+                    <template #description>
+                        <I18nT keypath="components.partials.tiptap_editor.extensions.template_block.close_info">
+                            <template #end>
+                                <code class="font-mono" v-text="'{{ end }}'" />
+                            </template>
+                        </I18nT>
+                    </template>
+                </UAlert>
 
                 <div class="flex flex-col gap-2">
                     <UFormField name="selected">
@@ -90,6 +100,14 @@ const insertBlock = () => {
                             @click="insertBlock"
                         />
                     </UFormField>
+
+                    <UButton block variant="outline" @click="props.editor?.commands.insertTemplateBlockEnd()">
+                        <I18nT keypath="components.partials.tiptap_editor.extensions.template_block.insert_end">
+                            <template #end>
+                                <code class="font-mono" v-text="'{{ end }}'" />
+                            </template>
+                        </I18nT>
+                    </UButton>
                 </div>
             </div>
         </template>

--- a/app/components/documents/templates/editor/TemplateBlockInsert.vue
+++ b/app/components/documents/templates/editor/TemplateBlockInsert.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core';
+import TemplateTrimControls from '~/components/documents/templates/editor/TemplateTrimControls.vue';
 
 const props = defineProps<{
     editor: Editor;
@@ -61,23 +62,7 @@ const insertBlock = () => {
                         <USelectMenu v-model="selected" class="w-full" :items="options" value-key="value" />
                     </UFormField>
 
-                    <div class="flex flex-row gap-2">
-                        <UFormField
-                            class="justify-center"
-                            name="leftTrim"
-                            :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_left')"
-                        >
-                            <USwitch v-model="leftTrim" />
-                        </UFormField>
-
-                        <UFormField
-                            class="justify-center"
-                            name="rightTrim"
-                            :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_right')"
-                        >
-                            <USwitch v-model="rightTrim" />
-                        </UFormField>
-                    </div>
+                    <TemplateTrimControls v-model:left-trim="leftTrim" v-model:right-trim="rightTrim" />
 
                     <UFormField name="expression">
                         <UInput

--- a/app/components/documents/templates/editor/TemplateBlockInsertForm.vue
+++ b/app/components/documents/templates/editor/TemplateBlockInsertForm.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { isTemplateBlockActionValid } from '~/composables/tiptap/extensions/TemplateBlockValidation';
+import TemplateTrimControls from './TemplateTrimControls.vue';
+
+const props = withDefaults(defineProps<{ editing?: boolean; value?: string; leftTrim?: boolean; rightTrim?: boolean }>(), {
+    editing: false,
+    value: '',
+    leftTrim: false,
+    rightTrim: false,
+});
+
+const emit = defineEmits<{
+    (e: 'submit', value: { value: string; leftTrim: boolean; rightTrim: boolean }): void;
+    (e: 'delete'): void;
+}>();
+
+const value = ref(props.value);
+const leftTrim = ref(props.leftTrim);
+const rightTrim = ref(props.rightTrim);
+
+const isValid = computed(() => isTemplateBlockActionValid(value.value));
+
+watch(
+    () => [props.value, props.leftTrim, props.rightTrim] as const,
+    ([v, l, r]) => {
+        value.value = v;
+        leftTrim.value = l;
+        rightTrim.value = r;
+    },
+    { immediate: true },
+);
+
+function submit(): void {
+    if (!isValid.value) return;
+    emit('submit', { value: value.value.trim(), leftTrim: leftTrim.value, rightTrim: rightTrim.value });
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-3">
+        <UTextarea v-model="value" :rows="3" autofocus />
+        <TemplateTrimControls v-model:left-trim="leftTrim" v-model:right-trim="rightTrim" />
+
+        <UFieldGroup>
+            <UButton block :disabled="!isValid" :label="$t('common.save')" @click="submit" />
+            <UTooltip :text="$t('common.delete')">
+                <UButton color="error" icon="i-mdi-trash-can" @click="$emit('delete')" />
+            </UTooltip>
+        </UFieldGroup>
+    </div>
+</template>

--- a/app/components/documents/templates/editor/TemplateBlockNodeView.vue
+++ b/app/components/documents/templates/editor/TemplateBlockNodeView.vue
@@ -66,9 +66,14 @@ function deleteNode(): void {
                         </template>
                     </UAlert>
 
-                    <UAlert v-if="!isValid" class="mb-3" color="error" icon="i-mdi-alert-outline" variant="subtle">
-                        {{ $t('components.partials.tiptap_editor.extensions.template_block.invalid') }}
-                    </UAlert>
+                    <UAlert
+                        v-if="!isValid"
+                        class="mb-3"
+                        color="error"
+                        icon="i-mdi-alert-outline"
+                        :description="$t('components.partials.tiptap_editor.extensions.template_block.invalid')"
+                        variant="subtle"
+                    />
 
                     <TemplateBlockInsertForm
                         v-if="!isEnd"

--- a/app/components/documents/templates/editor/TemplateBlockNodeView.vue
+++ b/app/components/documents/templates/editor/TemplateBlockNodeView.vue
@@ -1,0 +1,93 @@
+<script setup lang="ts">
+import { NodeViewWrapper, nodeViewProps } from '@tiptap/vue-3';
+import TemplateBlockEndForm from '~/components/documents/templates/editor/TemplateBlockEndForm.vue';
+import TemplateBlockInsertForm from '~/components/documents/templates/editor/TemplateBlockInsertForm.vue';
+import { isTemplateBlockActionValid } from '~/composables/tiptap/extensions/TemplateBlockValidation';
+
+const props = defineProps(nodeViewProps);
+
+const open = ref(false);
+const editable = computed(() => props.editor?.isEditable ?? false);
+
+const isEnd = computed(() => props.node.type.name === 'templateBlockEnd');
+const isValid = computed(() => isEnd.value || isTemplateBlockActionValid(props.node.attrs['data-template-block']));
+const displayValue = computed(() => {
+    const opening = props.node.attrs['data-left-trim'] ? '{{-' : '{{';
+    const closing = props.node.attrs['data-right-trim'] ? '-}}' : '}}';
+    return `${opening} ${isEnd.value ? 'end' : props.node.attrs['data-template-block']} ${closing}`;
+});
+
+function save(value: { value: string; leftTrim: boolean; rightTrim: boolean }): void {
+    props.updateAttributes({
+        ...(isEnd.value ? {} : { 'data-template-block': value.value }),
+        'data-left-trim': value.leftTrim,
+        'data-right-trim': value.rightTrim,
+    });
+    open.value = false;
+}
+
+function deleteNode(): void {
+    open.value = false;
+    props.deleteNode();
+}
+</script>
+
+<template>
+    <NodeViewWrapper
+        as="span"
+        class="template-block inline-block rounded border border-dashed border-amber-400 !bg-amber-950 px-0.5 font-mono !text-amber-100"
+        :class="{
+            'cursor-pointer': editable,
+            'template-block-invalid border-red-400 !bg-red-950 !text-red-100 motion-safe:animate-pulse': !isValid,
+        }"
+        contenteditable="false"
+    >
+        <template v-if="!editable">
+            <span>{{ displayValue }}</span>
+        </template>
+        <UPopover v-else v-model:open="open" :content="{ side: 'top', sideOffset: 8 }">
+            <button type="button" class="font-mono" contenteditable="false" @mousedown.prevent>
+                {{ displayValue }}
+            </button>
+
+            <template #content>
+                <div class="w-full max-w-86 p-4">
+                    <div class="mb-3 font-medium">
+                        {{ $t('components.partials.tiptap_editor.extensions.template_block.title') }}
+                    </div>
+
+                    <UAlert class="mb-3" icon="i-mdi-information-outline" variant="subtle">
+                        <template #description>
+                            <I18nT keypath="components.partials.tiptap_editor.extensions.template_block.close_info">
+                                <template #end>
+                                    <code class="font-mono" v-text="'{{ end }}'" />
+                                </template>
+                            </I18nT>
+                        </template>
+                    </UAlert>
+
+                    <UAlert v-if="!isValid" class="mb-3" color="error" icon="i-mdi-alert-outline" variant="subtle">
+                        {{ $t('components.partials.tiptap_editor.extensions.template_block.invalid') }}
+                    </UAlert>
+
+                    <TemplateBlockInsertForm
+                        v-if="!isEnd"
+                        editing
+                        :value="node.attrs['data-template-block']"
+                        :left-trim="node.attrs['data-left-trim']"
+                        :right-trim="node.attrs['data-right-trim']"
+                        @delete="deleteNode"
+                        @submit="save"
+                    />
+                    <TemplateBlockEndForm
+                        v-else
+                        :left-trim="node.attrs['data-left-trim']"
+                        :right-trim="node.attrs['data-right-trim']"
+                        @delete="deleteNode"
+                        @submit="save"
+                    />
+                </div>
+            </template>
+        </UPopover>
+    </NodeViewWrapper>
+</template>

--- a/app/components/documents/templates/editor/TemplateTrimControls.vue
+++ b/app/components/documents/templates/editor/TemplateTrimControls.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const leftTrim = defineModel<boolean>('leftTrim', { default: false });
+const rightTrim = defineModel<boolean>('rightTrim', { default: false });
+</script>
+
+<template>
+    <div class="flex flex-row gap-2">
+        <UFormField
+            class="justify-center"
+            name="leftTrim"
+            :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_left')"
+        >
+            <USwitch v-model="leftTrim" />
+        </UFormField>
+
+        <UFormField
+            class="justify-center"
+            name="rightTrim"
+            :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_right')"
+        >
+            <USwitch v-model="rightTrim" />
+        </UFormField>
+    </div>
+</template>

--- a/app/components/documents/templates/editor/TemplateVarForm.vue
+++ b/app/components/documents/templates/editor/TemplateVarForm.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+const props = withDefaults(
+    defineProps<{
+        editing?: boolean;
+        value?: string;
+        leftTrim?: boolean;
+        rightTrim?: boolean;
+    }>(),
+    {
+        editing: false,
+        value: '',
+        leftTrim: false,
+        rightTrim: false,
+    },
+);
+
+const emit = defineEmits<{
+    (e: 'submit', value: { value: string; leftTrim: boolean; rightTrim: boolean }): void;
+}>();
+
+const { t } = useI18n();
+
+type Category = { label: string; value: string; key: string };
+
+const categories: Category[] = [
+    { label: t('common.date'), value: 'now', key: 'date' },
+    { label: t('common.active_user'), value: '.ActiveChar', key: 'activeChar' },
+    { label: t('common.first_citizen'), value: '(first .Users)', key: 'user' },
+];
+
+const baseUserProperties: { label: string; value: string }[] = [
+    { label: t('common.firstname'), value: '.Firstname' },
+    { label: t('common.lastname'), value: '.Lastname' },
+    { label: t('common.date_of_birth'), value: '.Dateofbirth' },
+];
+
+const templateVars = computed<Record<string, { label: string; value: string }[]>>(() => ({
+    date: [
+        { label: `${t('common.date')} "02.01.2006 15:04"`, value: ' | date "02.01.2006 15:04"' },
+        { label: `${t('common.date')} "02.01.2006"`, value: ' | date "02.01.2006"' },
+        { label: `${t('common.time')} "15:04"`, value: ' | date "15:04"' },
+    ],
+    activeChar: [
+        ...baseUserProperties,
+        { label: t('common.phone'), value: '.PhoneNumber' },
+        { label: t('common.prefix'), value: '.Props.NamePrefix' },
+        { label: t('common.suffix'), value: '.Props.NameSuffix' },
+        { label: t('common.mail'), value: '.Email' },
+    ],
+    user: [...baseUserProperties],
+}));
+
+const selectedCategory = ref<Category>();
+const selectedProperty = ref<string>();
+const draftValue = ref(props.value);
+const customInput = ref('');
+const draftLeftTrim = ref(props.leftTrim);
+const draftRightTrim = ref(props.rightTrim);
+
+watch(
+    () => [props.value, props.leftTrim, props.rightTrim] as const,
+    ([value, leftTrim, rightTrim]) => {
+        draftValue.value = value;
+        draftLeftTrim.value = leftTrim;
+        draftRightTrim.value = rightTrim;
+    },
+    { immediate: true },
+);
+
+function submit(value: string): void {
+    if (!value.trim()) return;
+
+    emit('submit', {
+        value: value.trim(),
+        leftTrim: draftLeftTrim.value,
+        rightTrim: draftRightTrim.value,
+    });
+}
+
+function insertSelected(): void {
+    if (!selectedCategory.value || !selectedProperty.value) return;
+    submit(selectedCategory.value.value + selectedProperty.value);
+    selectedCategory.value = undefined;
+    selectedProperty.value = undefined;
+}
+
+function insertCustom(): void {
+    submit(customInput.value);
+    customInput.value = '';
+}
+</script>
+
+<template>
+    <div class="flex flex-col gap-2">
+        <template v-if="!editing">
+            <UFormField name="category" :label="$t('common.category', 1)">
+                <USelectMenu v-model="selectedCategory" class="w-full" :items="categories" />
+            </UFormField>
+
+            <UFormField name="property" :label="$t('common.property', 1)">
+                <USelectMenu
+                    v-model="selectedProperty"
+                    class="w-full"
+                    :items="templateVars[selectedCategory?.key ?? '']"
+                    :disabled="!templateVars[selectedCategory?.key ?? '']"
+                    value-key="value"
+                />
+            </UFormField>
+        </template>
+
+        <UFormField
+            v-if="editing"
+            name="templateValue"
+            :label="$t('components.partials.tiptap_editor.extensions.template_var.custom_template')"
+        >
+            <UTextarea v-model="draftValue" class="w-full" :rows="3" autofocus />
+        </UFormField>
+
+        <div class="flex flex-row gap-2">
+            <UFormField
+                class="justify-center"
+                name="leftTrim"
+                :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_left')"
+            >
+                <USwitch v-model="draftLeftTrim" />
+            </UFormField>
+
+            <UFormField
+                class="justify-center"
+                name="rightTrim"
+                :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_right')"
+            >
+                <USwitch v-model="draftRightTrim" />
+            </UFormField>
+        </div>
+
+        <UButton v-if="editing" block :label="$t('common.save')" :disabled="!draftValue.trim()" @click="submit(draftValue)" />
+
+        <template v-else>
+            <UButton
+                block
+                :label="$t('components.partials.tiptap_editor.insert')"
+                :disabled="!selectedCategory || !selectedProperty"
+                @click="insertSelected"
+            />
+
+            <UFormField
+                name="customInput"
+                :label="$t('components.partials.tiptap_editor.extensions.template_var.custom_template')"
+            >
+                <UInput
+                    v-model="customInput"
+                    class="w-full"
+                    :placeholder="$t('components.partials.tiptap_editor.extensions.template_var.custom_placeholder')"
+                />
+            </UFormField>
+
+            <UButton
+                block
+                :label="$t('components.partials.tiptap_editor.extensions.template_var.insert_custom')"
+                :disabled="!customInput"
+                @click="insertCustom"
+            />
+        </template>
+    </div>
+</template>

--- a/app/components/documents/templates/editor/TemplateVarForm.vue
+++ b/app/components/documents/templates/editor/TemplateVarForm.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import TemplateTrimControls from './TemplateTrimControls.vue';
+
 const props = withDefaults(
     defineProps<{
         editing?: boolean;
@@ -16,6 +18,7 @@ const props = withDefaults(
 
 const emit = defineEmits<{
     (e: 'submit', value: { value: string; leftTrim: boolean; rightTrim: boolean }): void;
+    (e: 'delete'): void;
 }>();
 
 const { t } = useI18n();
@@ -32,6 +35,8 @@ const baseUserProperties: { label: string; value: string }[] = [
     { label: t('common.firstname'), value: '.Firstname' },
     { label: t('common.lastname'), value: '.Lastname' },
     { label: t('common.date_of_birth'), value: '.Dateofbirth' },
+    { label: t('common.sex'), value: '.Sex' },
+    { label: t('common.height'), value: '.Height' },
 ];
 
 const templateVars = computed<Record<string, { label: string; value: string }[]>>(() => ({
@@ -47,7 +52,11 @@ const templateVars = computed<Record<string, { label: string; value: string }[]>
         { label: t('common.suffix'), value: '.Props.NameSuffix' },
         { label: t('common.mail'), value: '.Email' },
     ],
-    user: [...baseUserProperties],
+    user: [
+        ...baseUserProperties,
+        { label: t('common.wanted'), value: '.Props.Wanted' },
+        { label: t('common.phone'), value: '.PhoneNumber' },
+    ],
 }));
 
 const selectedCategory = ref<Category>();
@@ -116,25 +125,12 @@ function insertCustom(): void {
             <UTextarea v-model="draftValue" class="w-full" :rows="3" autofocus />
         </UFormField>
 
-        <div class="flex flex-row gap-2">
-            <UFormField
-                class="justify-center"
-                name="leftTrim"
-                :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_left')"
-            >
-                <USwitch v-model="draftLeftTrim" />
-            </UFormField>
-
-            <UFormField
-                class="justify-center"
-                name="rightTrim"
-                :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_right')"
-            >
-                <USwitch v-model="draftRightTrim" />
-            </UFormField>
-        </div>
-
-        <UButton v-if="editing" block :label="$t('common.save')" :disabled="!draftValue.trim()" @click="submit(draftValue)" />
+        <UFieldGroup v-if="editing">
+            <UButton block :label="$t('common.save')" :disabled="!draftValue.trim()" @click="submit(draftValue)" />
+            <UTooltip :text="$t('common.delete')">
+                <UButton color="error" icon="i-mdi-trash-can" @click="$emit('delete')" />
+            </UTooltip>
+        </UFieldGroup>
 
         <template v-else>
             <UButton
@@ -143,6 +139,8 @@ function insertCustom(): void {
                 :disabled="!selectedCategory || !selectedProperty"
                 @click="insertSelected"
             />
+
+            <USeparator class="my-2" />
 
             <UFormField
                 name="customInput"
@@ -162,5 +160,9 @@ function insertCustom(): void {
                 @click="insertCustom"
             />
         </template>
+
+        <USeparator class="my-2" />
+
+        <TemplateTrimControls v-model:left-trim="draftLeftTrim" v-model:right-trim="draftRightTrim" />
     </div>
 </template>

--- a/app/components/documents/templates/editor/TemplateVarInsert.vue
+++ b/app/components/documents/templates/editor/TemplateVarInsert.vue
@@ -11,23 +11,32 @@ const { t } = useI18n();
 type Category = { label: string; value: string; key: string };
 
 const categories: Category[] = [
-    { label: t('common.date'), value: '', key: 'date' },
-    { label: t('common.active_user'), value: '.ActiveChar', key: 'user' },
+    { label: t('common.date'), value: 'now', key: 'date' },
+    { label: t('common.active_user'), value: '.ActiveChar', key: 'activeChar' },
     { label: t('common.first_citizen'), value: '(first .Users)', key: 'user' },
 ];
 
-const templateVars: Record<string, { label: string; value: string }[]> = {
+const baseUserProperties: { label: string; value: string }[] = [
+    { label: t('common.firstname'), value: '.Firstname' },
+    { label: t('common.lastname'), value: '.Lastname' },
+    { label: t('common.date_of_birth'), value: '.Dateofbirth' },
+];
+
+const templateVars = computed<Record<string, { label: string; value: string }[]>>(() => ({
     date: [
-        { label: `${t('common.date')} "02.01.2006 15:04"`, value: 'now | date "02.01.2006 15:04"' },
-        { label: `${t('common.date')} "02.01.2006"`, value: 'now | date "02.01.2006"' },
-        { label: `${t('common.time')} "15:04"`, value: 'now | date "15:04"' },
+        { label: `${t('common.date')} "02.01.2006 15:04"`, value: ' | date "02.01.2006 15:04"' },
+        { label: `${t('common.date')} "02.01.2006"`, value: ' | date "02.01.2006"' },
+        { label: `${t('common.time')} "15:04"`, value: ' | date "15:04"' },
     ],
-    user: [
-        { label: t('common.firstname'), value: '.Firstname' },
-        { label: t('common.lastname'), value: '.Lastname' },
-        { label: t('common.date_of_birth'), value: '.Dateofbirth' },
+    activeChar: [
+        ...baseUserProperties,
+        { label: t('common.phone'), value: '.PhoneNumber' },
+        { label: t('common.prefix'), value: '.Props.NamePrefix' },
+        { label: t('common.suffix'), value: '.Props.NameSuffix' },
+        { label: t('common.mail'), value: '.Email' },
     ],
-};
+    user: [...baseUserProperties],
+}));
 
 const selectedCategory = ref<(typeof categories)[0] | undefined>(undefined);
 const selectedProperty = ref<string | undefined>(undefined);
@@ -80,6 +89,7 @@ const insertCustom = () => {
                             v-model="selectedProperty"
                             class="w-full"
                             :items="templateVars[selectedCategory?.key ?? '']"
+                            :disabled="!templateVars[selectedCategory?.key ?? '']"
                             value-key="value"
                         />
                     </UFormField>

--- a/app/components/documents/templates/editor/TemplateVarInsert.vue
+++ b/app/components/documents/templates/editor/TemplateVarInsert.vue
@@ -23,7 +23,7 @@ function insert(value: { value: string; leftTrim: boolean; rightTrim: boolean })
         </UTooltip>
 
         <template #content>
-            <div class="flex flex-col gap-2 p-4">
+            <div class="flex w-full max-w-86 flex-col gap-2 p-4">
                 <h3 class="block font-medium">
                     {{ $t('components.partials.tiptap_editor.extensions.template_var.title') }}
                 </h3>

--- a/app/components/documents/templates/editor/TemplateVarInsert.vue
+++ b/app/components/documents/templates/editor/TemplateVarInsert.vue
@@ -1,70 +1,19 @@
 <script setup lang="ts">
 import type { Editor } from '@tiptap/core';
+import TemplateVarForm from './TemplateVarForm.vue';
 
 const props = defineProps<{
     editor: Editor;
     disabled?: boolean;
 }>();
 
-const { t } = useI18n();
-
-type Category = { label: string; value: string; key: string };
-
-const categories: Category[] = [
-    { label: t('common.date'), value: 'now', key: 'date' },
-    { label: t('common.active_user'), value: '.ActiveChar', key: 'activeChar' },
-    { label: t('common.first_citizen'), value: '(first .Users)', key: 'user' },
-];
-
-const baseUserProperties: { label: string; value: string }[] = [
-    { label: t('common.firstname'), value: '.Firstname' },
-    { label: t('common.lastname'), value: '.Lastname' },
-    { label: t('common.date_of_birth'), value: '.Dateofbirth' },
-];
-
-const templateVars = computed<Record<string, { label: string; value: string }[]>>(() => ({
-    date: [
-        { label: `${t('common.date')} "02.01.2006 15:04"`, value: ' | date "02.01.2006 15:04"' },
-        { label: `${t('common.date')} "02.01.2006"`, value: ' | date "02.01.2006"' },
-        { label: `${t('common.time')} "15:04"`, value: ' | date "15:04"' },
-    ],
-    activeChar: [
-        ...baseUserProperties,
-        { label: t('common.phone'), value: '.PhoneNumber' },
-        { label: t('common.prefix'), value: '.Props.NamePrefix' },
-        { label: t('common.suffix'), value: '.Props.NameSuffix' },
-        { label: t('common.mail'), value: '.Email' },
-    ],
-    user: [...baseUserProperties],
-}));
-
-const selectedCategory = ref<(typeof categories)[0] | undefined>(undefined);
-const selectedProperty = ref<string | undefined>(undefined);
-const customInput = ref('');
-const leftTrim = ref<boolean>(false);
-const rightTrim = ref<boolean>(false);
-
-const insert = () => {
-    if (!selectedCategory.value || !selectedProperty.value) return;
+function insert(value: { value: string; leftTrim: boolean; rightTrim: boolean }): void {
     props.editor?.commands.insertTemplateVar({
-        value: selectedCategory.value.value + selectedProperty.value,
-        leftTrim: leftTrim.value,
-        rightTrim: rightTrim.value,
+        value: value.value,
+        leftTrim: value.leftTrim,
+        rightTrim: value.rightTrim,
     });
-    selectedCategory.value = undefined;
-    selectedProperty.value = undefined;
-};
-
-const insertCustom = () => {
-    if (!customInput.value) return;
-
-    props.editor?.commands.insertTemplateVar({
-        value: customInput.value,
-        leftTrim: leftTrim.value,
-        rightTrim: rightTrim.value,
-    });
-    customInput.value = '';
-};
+}
 </script>
 
 <template>
@@ -79,68 +28,7 @@ const insertCustom = () => {
                     {{ $t('components.partials.tiptap_editor.extensions.template_var.title') }}
                 </h3>
 
-                <div class="flex flex-col gap-2">
-                    <UFormField name="category" :label="$t('common.category', 1)">
-                        <USelectMenu v-model="selectedCategory" class="w-full" :items="categories" />
-                    </UFormField>
-
-                    <UFormField name="property" :label="$t('common.property', 1)">
-                        <USelectMenu
-                            v-model="selectedProperty"
-                            class="w-full"
-                            :items="templateVars[selectedCategory?.key ?? '']"
-                            :disabled="!templateVars[selectedCategory?.key ?? '']"
-                            value-key="value"
-                        />
-                    </UFormField>
-
-                    <div class="flex flex-row gap-2">
-                        <UFormField
-                            class="justify-center"
-                            name="leftTrim"
-                            :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_left')"
-                        >
-                            <USwitch v-model="leftTrim" />
-                        </UFormField>
-
-                        <UFormField
-                            class="justify-center"
-                            name="rightTrim"
-                            :label="$t('components.partials.tiptap_editor.extensions.template_var.trim_right')"
-                        >
-                            <USwitch v-model="rightTrim" />
-                        </UFormField>
-                    </div>
-
-                    <UFormField>
-                        <UButton
-                            block
-                            :label="$t('components.partials.tiptap_editor.insert')"
-                            :disabled="!selectedCategory || !selectedProperty"
-                            @click="insert"
-                        />
-                    </UFormField>
-
-                    <UFormField
-                        name="customInput"
-                        :label="$t('components.partials.tiptap_editor.extensions.template_var.custom_template')"
-                    >
-                        <UInput
-                            v-model="customInput"
-                            class="w-full"
-                            :placeholder="$t('components.partials.tiptap_editor.extensions.template_var.custom_placeholder')"
-                        />
-                    </UFormField>
-
-                    <UFormField>
-                        <UButton
-                            block
-                            :label="$t('components.partials.tiptap_editor.extensions.template_var.insert_custom')"
-                            :disabled="!customInput"
-                            @click="insertCustom"
-                        />
-                    </UFormField>
-                </div>
+                <TemplateVarForm @submit="insert" />
             </div>
         </template>
     </UPopover>

--- a/app/components/documents/templates/editor/TemplateVarNodeView.vue
+++ b/app/components/documents/templates/editor/TemplateVarNodeView.vue
@@ -5,6 +5,7 @@ import TemplateVarForm from './TemplateVarForm.vue';
 const props = defineProps(nodeViewProps);
 
 const open = ref(false);
+const editable = computed(() => props.editor?.isEditable ?? false);
 
 const displayValue = computed(() => {
     const opening = props.node.attrs['data-left-trim'] ? '{{-' : '{{';
@@ -23,14 +24,22 @@ function save(value: { value: string; leftTrim: boolean; rightTrim: boolean }): 
 </script>
 
 <template>
-    <NodeViewWrapper as="span" class="template-var" contenteditable="false">
-        <UPopover v-model:open="open" :content="{ side: 'top', sideOffset: 8 }">
+    <NodeViewWrapper
+        as="span"
+        class="template-var inline-block rounded border border-dashed border-sky-400 !bg-gray-800 px-0.5 font-mono !text-gray-100"
+        :class="{ 'cursor-pointer': editable }"
+        contenteditable="false"
+    >
+        <template v-if="!editable">
+            <span>{{ displayValue }}</span>
+        </template>
+        <UPopover v-else v-model:open="open" :content="{ side: 'top', sideOffset: 8 }">
             <button type="button" class="font-mono" contenteditable="false" @mousedown.prevent>
                 {{ displayValue }}
             </button>
 
             <template #content>
-                <div class="w-80 p-4">
+                <div class="w-full max-w-86 p-4">
                     <div class="mb-3 font-medium">
                         {{ $t('components.partials.tiptap_editor.extensions.template_var.title') }}
                     </div>
@@ -39,6 +48,12 @@ function save(value: { value: string; leftTrim: boolean; rightTrim: boolean }): 
                         :value="node.attrs['data-template-var']"
                         :left-trim="node.attrs['data-left-trim']"
                         :right-trim="node.attrs['data-right-trim']"
+                        @delete="
+                            () => {
+                                open = false;
+                                props.deleteNode();
+                            }
+                        "
                         @submit="save"
                     />
                 </div>

--- a/app/components/documents/templates/editor/TemplateVarNodeView.vue
+++ b/app/components/documents/templates/editor/TemplateVarNodeView.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import { NodeViewWrapper, nodeViewProps } from '@tiptap/vue-3';
+import TemplateVarForm from './TemplateVarForm.vue';
+
+const props = defineProps(nodeViewProps);
+
+const open = ref(false);
+
+const displayValue = computed(() => {
+    const opening = props.node.attrs['data-left-trim'] ? '{{-' : '{{';
+    const closing = props.node.attrs['data-right-trim'] ? '-}}' : '}}';
+    return `${opening} ${props.node.attrs['data-template-var']} ${closing}`;
+});
+
+function save(value: { value: string; leftTrim: boolean; rightTrim: boolean }): void {
+    props.updateAttributes({
+        'data-template-var': value.value,
+        'data-left-trim': value.leftTrim,
+        'data-right-trim': value.rightTrim,
+    });
+    open.value = false;
+}
+</script>
+
+<template>
+    <NodeViewWrapper as="span" class="template-var" contenteditable="false">
+        <UPopover v-model:open="open" :content="{ side: 'top', sideOffset: 8 }">
+            <button type="button" class="font-mono" contenteditable="false" @mousedown.prevent>
+                {{ displayValue }}
+            </button>
+
+            <template #content>
+                <div class="w-80 p-4">
+                    <div class="mb-3 font-medium">
+                        {{ $t('components.partials.tiptap_editor.extensions.template_var.title') }}
+                    </div>
+                    <TemplateVarForm
+                        editing
+                        :value="node.attrs['data-template-var']"
+                        :left-trim="node.attrs['data-left-trim']"
+                        :right-trim="node.attrs['data-right-trim']"
+                        @submit="save"
+                    />
+                </div>
+            </template>
+        </UPopover>
+    </NodeViewWrapper>
+</template>

--- a/app/components/partials/PageFooter.vue
+++ b/app/components/partials/PageFooter.vue
@@ -47,11 +47,7 @@ const year = new Date().getFullYear();
         <UFooter class="bg-default/75">
             <template #left>
                 <p class="text-sm text-muted">
-                    <I18nT keypath="copyright">
-                        <template #year>
-                            {{ year }}
-                        </template>
-                    </I18nT>
+                    {{ $t('copyright', { year: year }) }}
                 </p>
             </template>
 

--- a/app/components/partials/editor/TiptapEditor.vue
+++ b/app/components/partials/editor/TiptapEditor.vue
@@ -136,7 +136,7 @@ function seedDocument(schema: Schema, value: JSONContent | string): void {
         if (value === '') return;
 
         // HTML -> ProseMirror JSON
-        const json = generateJSON(value, extensions, { preserveWhitespace: 'full' });
+        const json = generateJSON(value, [...extensions, ...markRaw(props.extensions)], { preserveWhitespace: 'full' });
         // ProseMirror JSON -> Yjs update in-place
         seedDoc = prosemirrorJSONToYDoc(schema, json, 'content');
     } else {
@@ -164,7 +164,7 @@ if (props.enableCollab && ydoc && yjsProvider) {
         color: stringToColor(ourName),
     };
 
-    yjsSchema = getSchema(extensions);
+    yjsSchema = getSchema([...extensions, ...markRaw(props.extensions)]);
 
     const yXml = ydoc.getXmlFragment('content');
     const { mapping } = initProseMirrorDoc(yXml, yjsSchema!);
@@ -251,7 +251,9 @@ function normalizeToJSONContent(value: JSONContent | string | undefined): JSONCo
     if (!value) return { type: 'doc', content: [{ type: 'paragraph' }] };
 
     if (typeof value === 'string') {
-        return generateJSON(value, extensions, { preserveWhitespace: 'full' }) as JSONContent;
+        return generateJSON(value, [...extensions, ...markRaw(props.extensions)], {
+            preserveWhitespace: 'full',
+        }) as JSONContent;
     }
 
     return value;
@@ -369,7 +371,7 @@ const stopWatch = watch(modelValue, (value) => {
 
     const normalizedValue = normalizeToJSONContent(value);
 
-    const isSame = isSameDoc(editorJSON, normalizedValue, extensions);
+    const isSame = isSameDoc(editorJSON, normalizedValue, [...extensions, ...markRaw(props.extensions)]);
     if (isSame) return;
 
     if (props.enableCollab && ydoc && yjsProvider) {

--- a/app/components/partials/editor/TiptapEditor.vue
+++ b/app/components/partials/editor/TiptapEditor.vue
@@ -410,6 +410,8 @@ const reference = computed(() => ({
 }));
 
 function onClickContent(event: MouseEvent): void {
+    if (disabled.value) return;
+
     let element: HTMLElement | null = event.target as HTMLElement;
     if (element.tagName.toLowerCase() !== 'a' && !element.hasAttribute('href')) {
         element = element.parentElement as HTMLElement;
@@ -612,14 +614,14 @@ defineExpose<{
         </template>
 
         <!-- Nuxt UI Editor parts  that work with our wonderful "TiptapEditor" component -->
-        <UEditorEmojiMenu :editor="editor" :items="emojiItems" />
+        <UEditorEmojiMenu v-if="editor && !disabled" :editor="editor" :items="emojiItems" />
 
-        <UEditorDragHandle v-if="editor" :editor="editor" />
+        <UEditorDragHandle v-if="editor && !disabled" :editor="editor" />
 
-        <UEditorSuggestionMenu :editor="editor" :items="items" />
+        <UEditorSuggestionMenu v-if="editor && !disabled" :editor="editor" :items="items" />
 
         <UPopover
-            :open="openLinkPopover"
+            :open="!disabled && openLinkPopover"
             :reference="reference"
             :content="{ side: 'top', sideOffset: 16, updatePositionStrategy: 'always' }"
         >

--- a/app/components/vehicles/List.vue
+++ b/app/components/vehicles/List.vue
@@ -44,6 +44,7 @@ const props = withDefaults(
 );
 
 const clipboardStore = useClipboardStore();
+const { open: openClipboardModal } = useClipboardModal();
 
 const notifications = useNotificationsStore();
 
@@ -120,13 +121,28 @@ async function listVehicles(values: Schema): Promise<ListVehiclesResponse> {
 }
 
 function addToClipboard(vehicle: Vehicle): void {
-    clipboardStore.addVehicle(vehicle);
+    const added = clipboardStore.addVehicle(vehicle);
 
     notifications.add({
-        title: { key: 'notifications.clipboard.vehicle_added.title', parameters: {} },
-        description: { key: 'notifications.clipboard.vehicle_added.content', parameters: {} },
+        title: {
+            key: added ? 'notifications.clipboard.vehicle_added.title' : 'notifications.clipboard.limit_reached.title',
+            parameters: {},
+        },
+        description: {
+            key: added ? 'notifications.clipboard.vehicle_added.content' : 'notifications.clipboard.limit_reached.content',
+            parameters: {},
+        },
         duration: 3250,
-        type: NotificationType.INFO,
+        type: added ? NotificationType.INFO : NotificationType.WARNING,
+        actions: added
+            ? []
+            : [
+                  {
+                      label: { key: 'common.open', parameters: {} },
+                      icon: 'i-mdi-clipboard-list-outline',
+                      onClick: () => void openClipboardModal(),
+                  },
+              ],
     });
 }
 

--- a/app/composables/grpc.ts
+++ b/app/composables/grpc.ts
@@ -102,9 +102,7 @@ function applyTranslatedError(notification: Notification, message: string): void
     }
 
     const parsed = parseErrorMessage(message);
-    if (!parsed) {
-        return;
-    }
+    if (!parsed) return;
 
     const localized = localizeTemplateErrorParameters(parsed, (key) => useNuxtApp().$i18n.t(key));
 

--- a/app/composables/grpc.ts
+++ b/app/composables/grpc.ts
@@ -1,7 +1,7 @@
 import type { RpcError } from '#imports';
 import { useAuthStore } from '~/stores/auth';
 import type { Notification } from '~/types/notifications';
-import { isTranslatedError, parseErrorMessage } from '~/utils/errors';
+import { isTranslatedError, localizeTemplateErrorParameters, parseErrorMessage } from '~/utils/errors';
 import { NotificationType } from '~~/gen/ts/resources/notifications/notifications';
 
 const logger = useLogger('📡 GRPC');
@@ -102,11 +102,17 @@ function applyTranslatedError(notification: Notification, message: string): void
     }
 
     const parsed = parseErrorMessage(message);
-    if (parsed?.title) {
-        notification.title = parsed.title;
+    if (!parsed) {
+        return;
     }
-    if (parsed?.content) {
-        notification.description = parsed.content;
+
+    const localized = localizeTemplateErrorParameters(parsed, (key) => useNuxtApp().$i18n.t(key));
+
+    if (localized.title) {
+        notification.title = localized.title;
+    }
+    if (localized.content) {
+        notification.description = localized.content;
     }
 }
 

--- a/app/composables/tiptap/extensions/TemplateBlock.test.ts
+++ b/app/composables/tiptap/extensions/TemplateBlock.test.ts
@@ -252,7 +252,7 @@ describe('TemplateBlock', () => {
         ['with .Profile', true],
         ['break', true],
         ['continue', true],
-        ['end', true],
+        ['end', false],
         ['else arbitrary', false],
         ['else if', false],
         ['range', false],

--- a/app/composables/tiptap/extensions/TemplateBlock.test.ts
+++ b/app/composables/tiptap/extensions/TemplateBlock.test.ts
@@ -1,0 +1,264 @@
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { generateHTML, generateJSON } from '@tiptap/html';
+import { describe, expect, it } from 'vitest';
+import { classifyTemplateAction, TemplateBlock, TemplateBlockEnd } from './TemplateBlock';
+import { isTemplateBlockActionValid } from './TemplateBlockValidation';
+import { TemplateVar } from './TemplateVar';
+
+describe('TemplateBlock', () => {
+    it('normalizes supported Go block actions into template block nodes', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateBlock, TemplateBlockEnd],
+            content: '',
+        });
+
+        editor.commands.setContent(
+            '<p>{{ range .Users }}{{ if .Active }}{{ else if .Pending }}{{ else }}{{ with .Profile }}{{ break }}{{ continue }}</p>',
+            { emitUpdate: false },
+        );
+
+        expect(editor.getJSON().content?.[0]?.content).toEqual([
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'range .Users',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'if .Active',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'else if .Pending',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'else',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'with .Profile',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'break',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'continue',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+        ]);
+
+        editor.destroy();
+    });
+
+    it('preserves trim markers and normalizes block end actions', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateBlock, TemplateBlockEnd],
+            content: '',
+        });
+
+        editor.commands.setContent('<p>before {{- if   .Active -}}inside{{- end -}} after</p>', { emitUpdate: false });
+
+        expect(editor.getJSON().content?.[0]?.content).toEqual([
+            { type: 'text', text: 'before ' },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'if .Active',
+                    'data-left-trim': true,
+                    'data-right-trim': true,
+                },
+            },
+            { type: 'text', text: 'inside' },
+            {
+                type: 'templateBlockEnd',
+                attrs: {
+                    'data-left-trim': true,
+                    'data-right-trim': true,
+                },
+            },
+            { type: 'text', text: ' after' },
+        ]);
+
+        editor.destroy();
+    });
+
+    it('does not normalize unsupported template actions', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateBlock, TemplateBlockEnd],
+            content: '<p>{{ define "item" }}{{ .Name }}{{ template "item" . }}</p>',
+        });
+
+        expect(editor.getText()).toBe('{{ define "item" }}{{ .Name }}{{ template "item" . }}');
+        expect(editor.getJSON().content?.[0]?.content).toEqual([
+            { type: 'text', text: '{{ define "item" }}{{ .Name }}{{ template "item" . }}' },
+        ]);
+
+        editor.destroy();
+    });
+
+    it('normalizes break and continue as blocks when TemplateVar is also enabled', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateVar, TemplateBlock, TemplateBlockEnd],
+            content: '',
+        });
+
+        editor.commands.setContent('<p>{{ break }}{{ continue }}{{ .Name }}</p>', { emitUpdate: false });
+
+        expect(editor.getJSON().content?.[0]?.content).toEqual([
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'break',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateBlock',
+                attrs: {
+                    'data-template-block': 'continue',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+            {
+                type: 'templateVar',
+                attrs: {
+                    'data-template-var': '.Name',
+                    'data-left-trim': false,
+                    'data-right-trim': false,
+                },
+            },
+        ]);
+
+        editor.destroy();
+    });
+
+    it('includes configured HTML attributes when serializing block actions', () => {
+        const extensions = [
+            Document,
+            Paragraph,
+            Text,
+            TemplateBlock.configure({ HTMLAttributes: { 'data-template-editor': 'true' } }),
+            TemplateBlockEnd.configure({ HTMLAttributes: { 'data-template-editor': 'true' } }),
+        ];
+        const document = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'templateBlock', attrs: { 'data-template-block': 'if .Active' } },
+                        { type: 'templateBlockEnd', attrs: {} },
+                    ],
+                },
+            ],
+        };
+
+        const html = generateHTML(document, extensions);
+
+        expect(html.match(/data-template-editor="true"/g)).toHaveLength(2);
+    });
+
+    it('round-trips start and end actions through HTML without changing node types', () => {
+        const extensions = [Document, Paragraph, Text, TemplateBlock, TemplateBlockEnd];
+        const document = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        {
+                            type: 'templateBlock',
+                            attrs: {
+                                'data-template-block': 'if .Active',
+                                'data-left-trim': true,
+                                'data-right-trim': false,
+                            },
+                        },
+                        { type: 'text', text: 'Hello' },
+                        {
+                            type: 'templateBlockEnd',
+                            attrs: {
+                                'data-left-trim': false,
+                                'data-right-trim': true,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const html = generateHTML(document, extensions);
+        expect(html).toContain('data-template-block-end="end"');
+        expect(html).not.toContain('data-template-block="end"');
+
+        const parsed = generateJSON(html, extensions);
+        expect(parsed.content?.[0]?.content).toEqual(document.content?.[0]?.content);
+    });
+
+    it.each([
+        ['range .Users', 'block-start'],
+        ['else if .Pending', 'block-start'],
+        ['break', 'block-start'],
+        ['continue', 'block-start'],
+        ['end', 'block-end'],
+        ['/* comment */', 'comment'],
+        ['define "item"', 'raw-control'],
+        ['template "item" .', 'raw-control'],
+        ['end anything', 'raw-control'],
+        ['.Firstname | upper', 'variable'],
+    ] as const)('classifies %s as %s', (action, kind) => {
+        expect(classifyTemplateAction(action)).toBe(kind);
+    });
+
+    it.each([
+        ['else', true],
+        ['else if .Pending', true],
+        ['range .Users', true],
+        ['if and .Active .Ready', true],
+        ['with .Profile', true],
+        ['break', true],
+        ['continue', true],
+        ['end', true],
+        ['else arbitrary', false],
+        ['else if', false],
+        ['range', false],
+        ['break .Item', false],
+        ['end anything', false],
+    ] as const)('validates %s as %s', (action, valid) => {
+        expect(isTemplateBlockActionValid(action)).toBe(valid);
+    });
+});

--- a/app/composables/tiptap/extensions/TemplateBlock.ts
+++ b/app/composables/tiptap/extensions/TemplateBlock.ts
@@ -27,7 +27,7 @@ declare module '@tiptap/core' {
     }
 }
 
-export const TemplateBlock = Node.create({
+export const TemplateBlock = Node.create<TemplateBlockOptions>({
     name: 'templateBlock',
 
     group: 'block',

--- a/app/composables/tiptap/extensions/TemplateBlock.ts
+++ b/app/composables/tiptap/extensions/TemplateBlock.ts
@@ -1,4 +1,91 @@
 import { Node, mergeAttributes } from '@tiptap/core';
+import type { DOMOutputSpec, Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
+import { VueNodeViewRenderer } from '@tiptap/vue-3';
+import TemplateBlockNodeView from '~/components/documents/templates/editor/TemplateBlockNodeView.vue';
+import { isTemplateBlockActionValid } from './TemplateBlockValidation';
+
+export type TemplateActionKind = 'block-start' | 'block-end' | 'comment' | 'raw-control' | 'variable';
+
+const templateActionPattern = /\{\{(-)?\s*([^{}]*?)\s*(-)?\}\}/g;
+
+export function createTemplateActionMatcher(): RegExp {
+    return new RegExp(templateActionPattern.source, templateActionPattern.flags);
+}
+
+const blockStartActions = new Set(['range', 'if', 'else', 'with', 'break', 'continue']);
+const rawControlActions = new Set(['define', 'template', 'block', 'end']);
+
+export function classifyTemplateAction(value: string): TemplateActionKind {
+    const action = value.trim();
+    const actionName = action.split(/\s+/, 1)[0] ?? '';
+
+    if (action === 'end') return 'block-end';
+    if (action.startsWith('/*') && action.endsWith('*/')) return 'comment';
+    if (blockStartActions.has(actionName)) return 'block-start';
+    if (rawControlActions.has(actionName)) return 'raw-control';
+
+    return 'variable';
+}
+
+function createBlockNormalizationTransaction(state: EditorState): Transaction | null {
+    const templateAction = createTemplateActionMatcher();
+    const replacements: Array<{
+        from: number;
+        to: number;
+        type: 'start' | 'end';
+        value: string;
+        leftTrim: boolean;
+        rightTrim: boolean;
+        marks: ProseMirrorNode['marks'];
+    }> = [];
+
+    state.doc.descendants((node, pos) => {
+        if (!node.isText || !node.text) return;
+
+        templateAction.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = templateAction.exec(node.text)) !== null) {
+            const value = match[2]?.trim() ?? '';
+            const actionKind = classifyTemplateAction(value);
+            if (actionKind !== 'block-start' && actionKind !== 'block-end') continue;
+
+            replacements.push({
+                from: pos + match.index,
+                to: pos + match.index + match[0].length,
+                type: actionKind === 'block-start' ? 'start' : 'end',
+                value: actionKind === 'block-start' ? value : 'end',
+                leftTrim: Boolean(match[1]),
+                rightTrim: Boolean(match[3]),
+                marks: node.marks,
+            });
+        }
+    });
+
+    if (replacements.length === 0) return null;
+
+    const transaction = state.tr;
+    replacements.reverse().forEach((replacement) => {
+        const nodeType = state.schema.nodes[replacement.type === 'start' ? 'templateBlock' : 'templateBlockEnd'];
+        if (!nodeType) return;
+
+        transaction.replaceWith(
+            replacement.from,
+            replacement.to,
+            nodeType.create(
+                {
+                    ...(replacement.type === 'start' ? { 'data-template-block': replacement.value } : {}),
+                    'data-left-trim': replacement.leftTrim,
+                    'data-right-trim': replacement.rightTrim,
+                },
+                null,
+                replacement.marks,
+            ),
+        );
+    });
+
+    return transaction;
+}
 
 export interface TemplateBlockOptions {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -6,51 +93,68 @@ export interface TemplateBlockOptions {
 }
 
 declare module '@tiptap/core' {
-    /**
-     * Commands for managing template blocks.
-     */
     interface Commands<ReturnType> {
         templateBlock: {
-            /**
-             * Represents a set of commands for managing template blocks within the editor.
-             *
-             *
-             * @param payload - The data required to insert the template block.
-             * @param payload.value - The string value of the template block to be inserted.
-             * @param payload.leftTrim - Optional. Whether to trim whitespace from the left side of the variable. Defaults to `false`.
-             * @param payload.rightTrim - Optional. Whether to trim whitespace from the right side of the variable. Defaults to `false`.
-             *
-             * @returns ReturnType - The result of the command execution.
-             */
             insertTemplateBlock: (payload: { value: string; leftTrim?: boolean; rightTrim?: boolean }) => ReturnType;
+            insertTemplateBlockEnd: (payload?: { leftTrim?: boolean; rightTrim?: boolean }) => ReturnType;
         };
     }
 }
 
+function renderActionHTML(
+    attributes: Record<string, unknown>,
+    value: string,
+    leftTrim: boolean,
+    rightTrim: boolean,
+    end = false,
+): DOMOutputSpec {
+    const opening = leftTrim ? '{{-' : '{{';
+    const closing = rightTrim ? '-}}' : '}}';
+    const actionAttributes = { ...attributes };
+    delete actionAttributes['data-template-block'];
+    delete actionAttributes['data-template-block-end'];
+
+    return [
+        'span',
+        mergeAttributes(actionAttributes, {
+            ...(end ? { 'data-template-block-end': 'end' } : { 'data-template-block': value }),
+            'data-left-trim': leftTrim,
+            'data-right-trim': rightTrim,
+            class: 'template-block',
+        }),
+        `${opening} ${value} ${closing}`,
+    ];
+}
+
 export const TemplateBlock = Node.create<TemplateBlockOptions>({
     name: 'templateBlock',
-
-    group: 'block',
-    content: 'block+',
-    defining: true,
-    isolating: true,
+    inline: true,
+    group: 'inline',
+    atom: true,
 
     addOptions() {
-        return {
-            HTMLAttributes: {},
-        };
+        return { HTMLAttributes: {} };
+    },
+
+    onCreate({ editor }) {
+        const transaction = createBlockNormalizationTransaction(editor.state);
+        if (transaction) editor.view.dispatch(transaction);
+    },
+
+    addNodeView() {
+        return VueNodeViewRenderer(TemplateBlockNodeView);
     },
 
     addAttributes() {
         return {
-            'data-template-block': { default: '' }, // e.g. "range .Items"
+            'data-template-block': { default: '' },
             'data-left-trim': {
                 default: false,
-                parseHTML: (element) => element.getAttribute('data-left-trim') === 'true',
+                parseHTML: (element: Element) => element.getAttribute('data-left-trim') === 'true',
             },
             'data-right-trim': {
                 default: false,
-                parseHTML: (element) => element.getAttribute('data-right-trim') === 'true',
+                parseHTML: (element: Element) => element.getAttribute('data-right-trim') === 'true',
             },
         };
     },
@@ -58,39 +162,91 @@ export const TemplateBlock = Node.create<TemplateBlockOptions>({
     parseHTML() {
         return [
             {
-                tag: 'div[data-template-block]',
+                tag: 'span[data-template-block]',
+                getAttrs: (element) => (element.hasAttribute('data-template-block-end') ? false : null),
             },
         ];
     },
 
-    renderHTML(element) {
-        const { HTMLAttributes } = element;
-        const { 'data-template-block': value, 'data-left-trim': leftTrim, 'data-right-trim': rightTrim } = HTMLAttributes;
-        const opening = leftTrim ? '{{-' : '{{';
-        const closing = rightTrim ? '-}}' : '}}';
-
-        return [
-            'div',
-            mergeAttributes(HTMLAttributes, {
-                'data-template-block': value,
-                class: 'template-block',
-            }),
-            ['div', { class: 'template-open' }, `${opening} ${value} ${closing}`],
-            ['div', { class: 'template-inner' }, 0],
-            ['div', { class: 'template-close' }, `{{ end }}`],
-        ];
+    renderHTML({ HTMLAttributes }) {
+        return renderActionHTML(
+            mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+            HTMLAttributes['data-template-block'] as string,
+            HTMLAttributes['data-left-trim'] as boolean,
+            HTMLAttributes['data-right-trim'] as boolean,
+        );
     },
 
     addCommands() {
         return {
             insertTemplateBlock:
                 ({ value, leftTrim = false, rightTrim = false }) =>
-                ({ commands }) =>
-                    commands.insertContent({
+                ({ commands }) => {
+                    if (!isTemplateBlockActionValid(value)) return false;
+
+                    return commands.insertContent({
                         type: this.name,
                         attrs: { 'data-template-block': value, 'data-left-trim': leftTrim, 'data-right-trim': rightTrim },
-                        content: [{ type: 'paragraph' }],
+                    });
+                },
+            insertTemplateBlockEnd:
+                ({ leftTrim = false, rightTrim = false } = {}) =>
+                ({ commands }) =>
+                    commands.insertContent({
+                        type: 'templateBlockEnd',
+                        attrs: { 'data-left-trim': leftTrim, 'data-right-trim': rightTrim },
                     }),
         };
+    },
+
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: new PluginKey('templateBlockNormalize'),
+                appendTransaction: (_transactions, _oldState, newState) => createBlockNormalizationTransaction(newState),
+            }),
+        ];
+    },
+});
+
+export const TemplateBlockEnd = Node.create<TemplateBlockOptions>({
+    name: 'templateBlockEnd',
+    inline: true,
+    group: 'inline',
+    atom: true,
+
+    addOptions() {
+        return { HTMLAttributes: {} };
+    },
+
+    addNodeView() {
+        return VueNodeViewRenderer(TemplateBlockNodeView);
+    },
+
+    addAttributes() {
+        return {
+            'data-left-trim': {
+                default: false,
+                parseHTML: (element: Element) => element.getAttribute('data-left-trim') === 'true',
+            },
+            'data-right-trim': {
+                default: false,
+                parseHTML: (element: Element) => element.getAttribute('data-right-trim') === 'true',
+            },
+        };
+    },
+
+    parseHTML() {
+        return [{ tag: 'span[data-template-block-end]' }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return renderActionHTML(
+            mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+            'end',
+            HTMLAttributes['data-left-trim'] as boolean,
+            HTMLAttributes['data-right-trim'] as boolean,
+            true,
+        );
     },
 });

--- a/app/composables/tiptap/extensions/TemplateBlockValidation.ts
+++ b/app/composables/tiptap/extensions/TemplateBlockValidation.ts
@@ -1,0 +1,9 @@
+export function isTemplateBlockActionValid(value: string): boolean {
+    const action = value.trim();
+
+    if (action === 'else' || action === 'break' || action === 'continue' || action === 'end') return true;
+    if (/^else\s+if\s+\S/.test(action)) return true;
+    if (/^(range|if|with)\s+\S/.test(action)) return true;
+
+    return false;
+}

--- a/app/composables/tiptap/extensions/TemplateBlockValidation.ts
+++ b/app/composables/tiptap/extensions/TemplateBlockValidation.ts
@@ -1,7 +1,7 @@
 export function isTemplateBlockActionValid(value: string): boolean {
     const action = value.trim();
 
-    if (action === 'else' || action === 'break' || action === 'continue' || action === 'end') return true;
+    if (action === 'else' || action === 'break' || action === 'continue') return true;
     if (/^else\s+if\s+\S/.test(action)) return true;
     if (/^(range|if|with)\s+\S/.test(action)) return true;
 

--- a/app/composables/tiptap/extensions/TemplateVar.test.ts
+++ b/app/composables/tiptap/extensions/TemplateVar.test.ts
@@ -1,0 +1,60 @@
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import { Paragraph } from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { describe, expect, it } from 'vitest';
+import { TemplateVar } from './TemplateVar';
+
+describe('TemplateVar', () => {
+    it('normalizes raw Go template actions into template variable nodes', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateVar],
+            content: '',
+        });
+
+        editor.commands.setContent('<p>Hello {{ .Firstname }} {{- .Lastname -}}</p>', { emitUpdate: false });
+
+        expect(editor.getJSON()).toEqual({
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        { type: 'text', text: 'Hello ' },
+                        {
+                            type: 'templateVar',
+                            attrs: {
+                                'data-template-var': '.Firstname',
+                                'data-left-trim': false,
+                                'data-right-trim': false,
+                            },
+                        },
+                        { type: 'text', text: ' ' },
+                        {
+                            type: 'templateVar',
+                            attrs: {
+                                'data-template-var': '.Lastname',
+                                'data-left-trim': true,
+                                'data-right-trim': true,
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        editor.destroy();
+    });
+
+    it('does not normalize Go control actions as variables', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateVar],
+            content: '<p>{{ range .Users }}Hello{{ end }}</p>',
+        });
+
+        expect(editor.getText()).toBe('{{ range .Users }}Hello{{ end }}');
+        expect(editor.getJSON().content?.[0]?.content).toEqual([{ type: 'text', text: '{{ range .Users }}Hello{{ end }}' }]);
+
+        editor.destroy();
+    });
+});

--- a/app/composables/tiptap/extensions/TemplateVar.test.ts
+++ b/app/composables/tiptap/extensions/TemplateVar.test.ts
@@ -2,7 +2,9 @@ import { Editor } from '@tiptap/core';
 import Document from '@tiptap/extension-document';
 import { Paragraph } from '@tiptap/extension-paragraph';
 import Text from '@tiptap/extension-text';
+import { generateHTML, generateJSON } from '@tiptap/html';
 import { describe, expect, it } from 'vitest';
+import { TemplateBlock, TemplateBlockEnd } from './TemplateBlock';
 import { TemplateVar } from './TemplateVar';
 
 describe('TemplateVar', () => {
@@ -56,5 +58,47 @@ describe('TemplateVar', () => {
         expect(editor.getJSON().content?.[0]?.content).toEqual([{ type: 'text', text: '{{ range .Users }}Hello{{ end }}' }]);
 
         editor.destroy();
+    });
+
+    it('leaves raw control actions and comments available for advanced users', () => {
+        const editor = new Editor({
+            extensions: [Document, Paragraph, Text, TemplateVar, TemplateBlock, TemplateBlockEnd],
+            content: '',
+        });
+
+        const content = '{{ define "item" }}{{ template "item" . }}{{ block "item" . }}{{/* comment */}}';
+        editor.commands.setContent(`<p>${content}</p>`, { emitUpdate: false });
+
+        expect(editor.getText()).toBe(content);
+        expect(editor.getJSON().content?.[0]?.content).toEqual([{ type: 'text', text: content }]);
+
+        editor.destroy();
+    });
+
+    it('round-trips template variables through HTML with their attributes intact', () => {
+        const extensions = [Document, Paragraph, Text, TemplateVar];
+        const document = {
+            type: 'doc',
+            content: [
+                {
+                    type: 'paragraph',
+                    content: [
+                        {
+                            type: 'templateVar',
+                            attrs: {
+                                'data-template-var': '.Firstname',
+                                'data-left-trim': true,
+                                'data-right-trim': true,
+                            },
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const html = generateHTML(document, extensions);
+        const parsed = generateJSON(html, extensions);
+
+        expect(parsed.content?.[0]?.content).toEqual(document.content?.[0]?.content);
     });
 });

--- a/app/composables/tiptap/extensions/TemplateVar.ts
+++ b/app/composables/tiptap/extensions/TemplateVar.ts
@@ -30,7 +30,7 @@ declare module '@tiptap/core' {
     }
 }
 
-export const TemplateVar = Node.create({
+export const TemplateVar = Node.create<TemplateVarOptions>({
     name: 'templateVar',
 
     inline: true,

--- a/app/composables/tiptap/extensions/TemplateVar.ts
+++ b/app/composables/tiptap/extensions/TemplateVar.ts
@@ -1,4 +1,69 @@
 import { Node, mergeAttributes } from '@tiptap/core';
+import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
+import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
+import { VueNodeViewRenderer } from '@tiptap/vue-3';
+import TemplateVarNodeView from '~/components/documents/templates/editor/TemplateVarNodeView.vue';
+
+const templateVarAction = /\{\{(-)?\s*([^{}]*?)\s*(-)?\}\}/g;
+
+function isTemplateControl(value: string): boolean {
+    return /^(end|else|range|if|with|define|template)\b/.test(value.trim());
+}
+
+function createTemplateVarNormalizationTransaction(state: EditorState, nodeName: string): Transaction | null {
+    const replacements: Array<{
+        from: number;
+        to: number;
+        expression: string;
+        leftTrim: boolean;
+        rightTrim: boolean;
+        marks: ProseMirrorNode['marks'];
+    }> = [];
+
+    state.doc.descendants((node, pos) => {
+        if (!node.isText || !node.text) return;
+
+        templateVarAction.lastIndex = 0;
+        let match: RegExpExecArray | null;
+        while ((match = templateVarAction.exec(node.text)) !== null) {
+            const expression = match[2]?.trim() ?? '';
+            if (!expression || isTemplateControl(expression)) continue;
+
+            replacements.push({
+                from: pos + match.index,
+                to: pos + match.index + match[0].length,
+                expression,
+                leftTrim: Boolean(match[1]),
+                rightTrim: Boolean(match[3]),
+                marks: node.marks,
+            });
+        }
+    });
+
+    if (replacements.length === 0) return null;
+
+    const templateVarNode = state.schema.nodes[nodeName];
+    if (!templateVarNode) return null;
+
+    const transaction = state.tr;
+    replacements.reverse().forEach((replacement) => {
+        transaction.replaceWith(
+            replacement.from,
+            replacement.to,
+            templateVarNode.create(
+                {
+                    'data-template-var': replacement.expression,
+                    'data-left-trim': replacement.leftTrim,
+                    'data-right-trim': replacement.rightTrim,
+                },
+                null,
+                replacement.marks,
+            ),
+        );
+    });
+
+    return transaction;
+}
 
 export interface TemplateVarOptions {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,10 +104,30 @@ export const TemplateVar = Node.create<TemplateVarOptions>({
 
     atom: true,
 
+    addNodeView() {
+        return VueNodeViewRenderer(TemplateVarNodeView);
+    },
+
     addOptions() {
         return {
             HTMLAttributes: {},
         };
+    },
+
+    onCreate({ editor }) {
+        const transaction = createTemplateVarNormalizationTransaction(editor.state, this.name);
+        if (transaction) editor.view.dispatch(transaction);
+    },
+
+    addProseMirrorPlugins() {
+        return [
+            new Plugin({
+                key: new PluginKey('templateVarNormalize'),
+                appendTransaction: (_transactions, _oldState, newState) => {
+                    return createTemplateVarNormalizationTransaction(newState, this.name);
+                },
+            }),
+        ];
     },
 
     addAttributes() {

--- a/app/composables/tiptap/extensions/TemplateVar.ts
+++ b/app/composables/tiptap/extensions/TemplateVar.ts
@@ -3,14 +3,10 @@ import type { Node as ProseMirrorNode } from '@tiptap/pm/model';
 import { Plugin, PluginKey, type EditorState, type Transaction } from '@tiptap/pm/state';
 import { VueNodeViewRenderer } from '@tiptap/vue-3';
 import TemplateVarNodeView from '~/components/documents/templates/editor/TemplateVarNodeView.vue';
-
-const templateVarAction = /\{\{(-)?\s*([^{}]*?)\s*(-)?\}\}/g;
-
-function isTemplateControl(value: string): boolean {
-    return /^(end|else|range|if|with|define|template)\b/.test(value.trim());
-}
+import { classifyTemplateAction, createTemplateActionMatcher } from './TemplateBlock';
 
 function createTemplateVarNormalizationTransaction(state: EditorState, nodeName: string): Transaction | null {
+    const templateAction = createTemplateActionMatcher();
     const replacements: Array<{
         from: number;
         to: number;
@@ -23,11 +19,11 @@ function createTemplateVarNormalizationTransaction(state: EditorState, nodeName:
     state.doc.descendants((node, pos) => {
         if (!node.isText || !node.text) return;
 
-        templateVarAction.lastIndex = 0;
+        templateAction.lastIndex = 0;
         let match: RegExpExecArray | null;
-        while ((match = templateVarAction.exec(node.text)) !== null) {
+        while ((match = templateAction.exec(node.text)) !== null) {
             const expression = match[2]?.trim() ?? '';
-            if (!expression || isTemplateControl(expression)) continue;
+            if (!expression || classifyTemplateAction(expression) !== 'variable') continue;
 
             replacements.push({
                 from: pos + match.index,

--- a/app/composables/useClipboardModal.ts
+++ b/app/composables/useClipboardModal.ts
@@ -1,0 +1,10 @@
+import ClipboardModal from '~/components/clipboard/modal/ClipboardModal.vue';
+
+export function useClipboardModal() {
+    const overlay = useOverlay();
+    const clipboardModal = overlay.create(ClipboardModal);
+
+    return {
+        open: () => clipboardModal.open(),
+    };
+}

--- a/app/composables/useDocumentsDocuments.ts
+++ b/app/composables/useDocumentsDocuments.ts
@@ -16,7 +16,7 @@ export async function useDocumentsDocuments() {
     const notifications = useNotificationsStore();
 
     const clipboardStore = useClipboardStore();
-    const { getTemplateData } = clipboardStore;
+    const { getTemplateSelection } = clipboardStore;
 
     const documents = ref<ListDocumentsResponse | undefined>();
     const pinnedDocuments = ref<ListDocumentPinsResponse | undefined>();
@@ -52,16 +52,13 @@ export async function useDocumentsDocuments() {
     };
 
     const createDocument = async (templateId?: number): Promise<CreateDocumentResponse> => {
-        const { activeChar } = useAuth();
-
-        const templateData = getTemplateData();
-        templateData.activeChar = unref(activeChar.value!);
+        const templateSelection = getTemplateSelection();
 
         try {
             const call = documentsDocumentsClient.createDocument({
                 contentType: ContentType.HTML,
                 templateId: templateId,
-                templateData: templateData,
+                templateSelection: templateSelection,
             });
             const { response } = await call;
 

--- a/app/pages/citizens/[id].vue
+++ b/app/pages/citizens/[id].vue
@@ -38,6 +38,7 @@ const { t } = useI18n();
 const { attr, can } = useAuth();
 
 const clipboardStore = useClipboardStore();
+const { open: openClipboardModal } = useClipboardModal();
 
 const notifications = useNotificationsStore();
 
@@ -82,13 +83,28 @@ useHead({
 function addToClipboard(): void {
     if (!user.value) return;
 
-    clipboardStore.addUser(user.value);
+    const added = clipboardStore.addUser(user.value);
 
     notifications.add({
-        title: { key: 'notifications.clipboard.citizen_add.title', parameters: {} },
-        description: { key: 'notifications.clipboard.citizen_add.content', parameters: {} },
+        title: {
+            key: added ? 'notifications.clipboard.citizen_add.title' : 'notifications.clipboard.limit_reached.title',
+            parameters: {},
+        },
+        description: {
+            key: added ? 'notifications.clipboard.citizen_add.content' : 'notifications.clipboard.limit_reached.content',
+            parameters: {},
+        },
         duration: 3250,
-        type: NotificationType.INFO,
+        type: added ? NotificationType.INFO : NotificationType.WARNING,
+        actions: added
+            ? []
+            : [
+                  {
+                      label: { key: 'common.open', parameters: {} },
+                      icon: 'i-mdi-clipboard-list-outline',
+                      onClick: () => void openClipboardModal(),
+                  },
+              ],
     });
 }
 

--- a/app/stores/clipboard.ts
+++ b/app/stores/clipboard.ts
@@ -204,6 +204,8 @@ export interface ClipboardData {
 
 export type ListType = 'citizens' | 'documents' | 'vehicles';
 
+export const CLIPBOARD_MAX_ITEMS = 12;
+
 export const useClipboardStore = defineStore(
     'clipboard',
     () => {
@@ -222,11 +224,16 @@ export const useClipboardStore = defineStore(
          * @returns {TemplateSelection} The selected document, user, and vehicle identifiers.
          */
         const getTemplateSelection = (activeOnly: boolean = true): TemplateSelection => ({
-            documentIds: (activeOnly ? activeStack.value.documents : documents.value).map((document) => document.id),
+            documentIds: (activeOnly ? activeStack.value.documents : documents.value)
+                .slice(0, CLIPBOARD_MAX_ITEMS)
+                .map((document) => document.id),
             userIds: (activeOnly ? activeStack.value.users : users.value)
+                .slice(0, CLIPBOARD_MAX_ITEMS)
                 .map((user) => user.userId)
                 .filter((userId): userId is number => userId !== undefined && userId > 0),
-            plates: (activeOnly ? activeStack.value.vehicles : vehicles.value).map((vehicle) => vehicle.plate),
+            plates: (activeOnly ? activeStack.value.vehicles : vehicles.value)
+                .slice(0, CLIPBOARD_MAX_ITEMS)
+                .map((vehicle) => vehicle.plate),
         });
 
         /**
@@ -262,10 +269,12 @@ export const useClipboardStore = defineStore(
          * Adds a document to the clipboard.
          * @param {Document} document - The document to add.
          */
-        const addDocument = (document: Document): void => {
-            if (!documents.value.find((o) => o.id === document.id)) {
-                documents.value.unshift(new ClipboardDocument(unref(document)));
-            }
+        const addDocument = (document: Document): boolean => {
+            if (documents.value.find((o) => o.id === document.id)) return true;
+            if (documents.value.length >= CLIPBOARD_MAX_ITEMS) return false;
+
+            documents.value.unshift(new ClipboardDocument(unref(document)));
+            return true;
         };
 
         /**
@@ -288,11 +297,16 @@ export const useClipboardStore = defineStore(
          * @param {User} user - The user to add.
          * @param {boolean} [active] - Whether to promote the user to the active stack.
          */
-        const addUser = (user: User, active?: boolean): void => {
-            if (!users.value.find((o) => o.userId === user.userId)) {
-                users.value.unshift(new ClipboardUser(unref(user)));
+        const addUser = (user: User, active?: boolean): boolean => {
+            if (users.value.find((o) => o.userId === user.userId)) {
+                if (active) promoteToActiveStack('citizens');
+                return true;
             }
+            if (users.value.length >= CLIPBOARD_MAX_ITEMS) return false;
+
+            users.value.unshift(new ClipboardUser(unref(user)));
             if (active) promoteToActiveStack('citizens');
+            return true;
         };
 
         /**
@@ -314,10 +328,12 @@ export const useClipboardStore = defineStore(
          * Adds a vehicle to the clipboard.
          * @param {Vehicle} vehicle - The vehicle to add.
          */
-        const addVehicle = (vehicle: Vehicle): void => {
-            if (!vehicles.value.find((o) => o.plate === vehicle.plate)) {
-                vehicles.value.unshift(new ClipboardVehicle(unref(vehicle)));
-            }
+        const addVehicle = (vehicle: Vehicle): boolean => {
+            if (vehicles.value.find((o) => o.plate === vehicle.plate)) return true;
+            if (vehicles.value.length >= CLIPBOARD_MAX_ITEMS) return false;
+
+            vehicles.value.unshift(new ClipboardVehicle(unref(vehicle)));
+            return true;
         };
 
         /**

--- a/app/stores/clipboard.ts
+++ b/app/stores/clipboard.ts
@@ -3,7 +3,7 @@ import { stringToDate } from '~/utils/time';
 import { ContentType } from '~~/gen/ts/resources/common/content/content';
 import type { Category } from '~~/gen/ts/resources/documents/category/category';
 import type { Document, DocumentShort } from '~~/gen/ts/resources/documents/documents';
-import type { ObjectSpecs, TemplateData } from '~~/gen/ts/resources/documents/templates/templates';
+import type { ObjectSpecs, TemplateSelection } from '~~/gen/ts/resources/documents/templates/templates';
 import type { UserShort } from '~~/gen/ts/resources/users/short/user';
 import type { User } from '~~/gen/ts/resources/users/user';
 import type { Vehicle } from '~~/gen/ts/resources/vehicles/vehicles';
@@ -218,12 +218,14 @@ export const useClipboardStore = defineStore(
 
         /**
          * Retrieves template data from the active stack.
-         * @returns {TemplateData} The template data containing documents, users, and vehicles.
+         * @returns {TemplateSelection} The selected document, user, and vehicle identifiers.
          */
-        const getTemplateData = (): TemplateData => ({
-            documents: activeStack.value.documents.map(getDocument),
-            users: activeStack.value.users.map(getUser),
-            vehicles: activeStack.value.vehicles.map(getVehicle),
+        const getTemplateSelection = (): TemplateSelection => ({
+            documentIds: activeStack.value.documents.map((document) => document.id),
+            userIds: activeStack.value.users
+                .map((user) => user.userId)
+                .filter((userId): userId is number => userId !== undefined && userId > 0),
+            plates: activeStack.value.vehicles.map((vehicle) => vehicle.plate),
         });
 
         /**
@@ -377,7 +379,7 @@ export const useClipboardStore = defineStore(
             vehicles,
             activeStack,
 
-            getTemplateData,
+            getTemplateSelection,
             promoteToActiveStack,
             clearActiveStack,
             addDocument,

--- a/app/stores/clipboard.ts
+++ b/app/stores/clipboard.ts
@@ -210,6 +210,7 @@ export const useClipboardStore = defineStore(
         const users = ref<ClipboardUser[]>([]);
         const documents = ref<ClipboardDocument[]>([]);
         const vehicles = ref<ClipboardVehicle[]>([]);
+        // Active stack is used to store the currently selected items for template generation.
         const activeStack = ref<ClipboardData>({
             users: [],
             documents: [],
@@ -220,12 +221,12 @@ export const useClipboardStore = defineStore(
          * Retrieves template data from the active stack.
          * @returns {TemplateSelection} The selected document, user, and vehicle identifiers.
          */
-        const getTemplateSelection = (): TemplateSelection => ({
-            documentIds: activeStack.value.documents.map((document) => document.id),
-            userIds: activeStack.value.users
+        const getTemplateSelection = (activeOnly: boolean = true): TemplateSelection => ({
+            documentIds: (activeOnly ? activeStack.value.documents : documents.value).map((document) => document.id),
+            userIds: (activeOnly ? activeStack.value.users : users.value)
                 .map((user) => user.userId)
                 .filter((userId): userId is number => userId !== undefined && userId > 0),
-            plates: activeStack.value.vehicles.map((vehicle) => vehicle.plate),
+            plates: (activeOnly ? activeStack.value.vehicles : vehicles.value).map((vehicle) => vehicle.plate),
         });
 
         /**

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -34,16 +34,17 @@ export function localizeTemplateErrorParameters(error: CommonError, translate: (
     const localizeItem = (item: I18NItem | undefined): I18NItem | undefined => {
         if (!item) return undefined;
 
-        const kind = item.parameters.kind;
+        const parameters = item.parameters ?? {};
+        const kind = parameters.kind;
         const translationKey = kind ? templateKindTranslationKeys[kind] : undefined;
         if (!translationKey) {
-            return { ...item, parameters: { ...item.parameters } };
+            return { ...item, parameters: { ...parameters } };
         }
 
         return {
             ...item,
             parameters: {
-                ...item.parameters,
+                ...parameters,
                 kind: translate(translationKey),
             },
         };

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -1,4 +1,11 @@
 import type { Error as CommonError } from '~~/gen/ts/resources/common/error';
+import type { I18NItem } from '~~/gen/ts/resources/common/i18n';
+
+const templateKindTranslationKeys: Record<string, string> = {
+    users: 'errors.documents.DocumentsService.TemplateKinds.users',
+    documents: 'errors.documents.DocumentsService.TemplateKinds.documents',
+    vehicles: 'errors.documents.DocumentsService.TemplateKinds.vehicles',
+};
 
 export function getErrorMessage(err: RpcError): I18NItem {
     if (isTranslatedError(err.message)) {
@@ -21,6 +28,34 @@ export function parseErrorMessage(message: string): CommonError | undefined {
     } catch (_) {
         return undefined;
     }
+}
+
+export function localizeTemplateErrorParameters(error: CommonError, translate: (key: string) => string): CommonError {
+    const localizeItem = (item: I18NItem | undefined): I18NItem | undefined => {
+        if (!item) {
+            return undefined;
+        }
+
+        const kind = item.parameters.kind;
+        const translationKey = kind ? templateKindTranslationKeys[kind] : undefined;
+        if (!translationKey) {
+            return { ...item, parameters: { ...item.parameters } };
+        }
+
+        return {
+            ...item,
+            parameters: {
+                ...item.parameters,
+                kind: translate(translationKey),
+            },
+        };
+    };
+
+    return {
+        ...error,
+        title: localizeItem(error.title),
+        content: localizeItem(error.content),
+    };
 }
 
 export function isTranslatedError(message: string): boolean {

--- a/app/utils/errors.ts
+++ b/app/utils/errors.ts
@@ -32,9 +32,7 @@ export function parseErrorMessage(message: string): CommonError | undefined {
 
 export function localizeTemplateErrorParameters(error: CommonError, translate: (key: string) => string): CommonError {
     const localizeItem = (item: I18NItem | undefined): I18NItem | undefined => {
-        if (!item) {
-            return undefined;
-        }
+        if (!item) return undefined;
 
         const kind = item.parameters.kind;
         const translationKey = kind ? templateKindTranslationKeys[kind] : undefined;

--- a/gen/go/proto/resources/documents/templates/templates.pb.go
+++ b/gen/go/proto/resources/documents/templates/templates.pb.go
@@ -12,14 +12,10 @@ import (
 	_ "github.com/fivenet-app/fivenet/v2026/gen/go/proto/codegen/dbscanner"
 	_ "github.com/fivenet-app/fivenet/v2026/gen/go/proto/codegen/sanitizer"
 	access "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/access"
-	documents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents"
 	approval "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/approval"
 	category "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/category"
 	workflow "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/workflow"
 	timestamp "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
-	users "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
-	short "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users/short"
-	vehicles "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/vehicles"
 	_ "github.com/srikrsna/protoc-gen-gotag/tagger"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -1092,30 +1088,29 @@ func (b0 ObjectSpecs_builder) Build() *ObjectSpecs {
 	return m0
 }
 
-type TemplateData struct {
-	state         protoimpl.MessageState     `protogen:"hybrid.v1"`
-	ActiveChar    *users.User                `protobuf:"bytes,1,opt,name=active_char,json=activeChar,proto3" json:"active_char,omitempty"`
-	Documents     []*documents.DocumentShort `protobuf:"bytes,2,rep,name=documents,proto3" json:"documents,omitempty"`
-	Users         []*short.UserShort         `protobuf:"bytes,3,rep,name=users,proto3" json:"users,omitempty"`
-	Vehicles      []*vehicles.Vehicle        `protobuf:"bytes,4,rep,name=vehicles,proto3" json:"vehicles,omitempty"`
+type TemplateSelection struct {
+	state         protoimpl.MessageState `protogen:"hybrid.v1"`
+	UserIds       []int32                `protobuf:"varint,1,rep,packed,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty"`
+	DocumentIds   []int64                `protobuf:"varint,2,rep,packed,name=document_ids,json=documentIds,proto3" json:"document_ids,omitempty"`
+	Plates        []string               `protobuf:"bytes,3,rep,name=plates,proto3" json:"plates,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *TemplateData) Reset() {
-	*x = TemplateData{}
+func (x *TemplateSelection) Reset() {
+	*x = TemplateSelection{}
 	mi := &file_resources_documents_templates_templates_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TemplateData) String() string {
+func (x *TemplateSelection) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TemplateData) ProtoMessage() {}
+func (*TemplateSelection) ProtoMessage() {}
 
-func (x *TemplateData) ProtoReflect() protoreflect.Message {
+func (x *TemplateSelection) ProtoReflect() protoreflect.Message {
 	mi := &file_resources_documents_templates_templates_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1127,78 +1122,54 @@ func (x *TemplateData) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *TemplateData) GetActiveChar() *users.User {
+func (x *TemplateSelection) GetUserIds() []int32 {
 	if x != nil {
-		return x.ActiveChar
+		return x.UserIds
 	}
 	return nil
 }
 
-func (x *TemplateData) GetDocuments() []*documents.DocumentShort {
+func (x *TemplateSelection) GetDocumentIds() []int64 {
 	if x != nil {
-		return x.Documents
+		return x.DocumentIds
 	}
 	return nil
 }
 
-func (x *TemplateData) GetUsers() []*short.UserShort {
+func (x *TemplateSelection) GetPlates() []string {
 	if x != nil {
-		return x.Users
+		return x.Plates
 	}
 	return nil
 }
 
-func (x *TemplateData) GetVehicles() []*vehicles.Vehicle {
-	if x != nil {
-		return x.Vehicles
-	}
-	return nil
+func (x *TemplateSelection) SetUserIds(v []int32) {
+	x.UserIds = v
 }
 
-func (x *TemplateData) SetActiveChar(v *users.User) {
-	x.ActiveChar = v
+func (x *TemplateSelection) SetDocumentIds(v []int64) {
+	x.DocumentIds = v
 }
 
-func (x *TemplateData) SetDocuments(v []*documents.DocumentShort) {
-	x.Documents = v
+func (x *TemplateSelection) SetPlates(v []string) {
+	x.Plates = v
 }
 
-func (x *TemplateData) SetUsers(v []*short.UserShort) {
-	x.Users = v
-}
-
-func (x *TemplateData) SetVehicles(v []*vehicles.Vehicle) {
-	x.Vehicles = v
-}
-
-func (x *TemplateData) HasActiveChar() bool {
-	if x == nil {
-		return false
-	}
-	return x.ActiveChar != nil
-}
-
-func (x *TemplateData) ClearActiveChar() {
-	x.ActiveChar = nil
-}
-
-type TemplateData_builder struct {
+type TemplateSelection_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ActiveChar *users.User
-	Documents  []*documents.DocumentShort
-	Users      []*short.UserShort
-	Vehicles   []*vehicles.Vehicle
+	UserIds     []int32
+	DocumentIds []int64
+	Plates      []string
 }
 
-func (b0 TemplateData_builder) Build() *TemplateData {
-	m0 := &TemplateData{}
+func (b0 TemplateSelection_builder) Build() *TemplateSelection {
+	m0 := &TemplateSelection{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.ActiveChar = b.ActiveChar
-	x.Documents = b.Documents
-	x.Users = b.Users
-	x.Vehicles = b.Vehicles
+	x.UserIds = b.UserIds
+	x.DocumentIds = b.DocumentIds
+	x.Plates = b.Plates
 	return m0
 }
 
@@ -1624,7 +1595,7 @@ var File_resources_documents_templates_templates_proto protoreflect.FileDescript
 
 const file_resources_documents_templates_templates_proto_rawDesc = "" +
 	"\n" +
-	"-resources/documents/templates/templates.proto\x12\x1dresources.documents.templates\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a\x1dresources/access/access.proto\x1a+resources/documents/approval/approval.proto\x1a+resources/documents/category/category.proto\x1a#resources/documents/documents.proto\x1a+resources/documents/workflow/workflow.proto\x1a#resources/timestamp/timestamp.proto\x1a resources/users/short/user.proto\x1a\x1aresources/users/user.proto\x1a!resources/vehicles/vehicles.proto\x1a\x13tagger/tagger.proto\"\xda\t\n" +
+	"-resources/documents/templates/templates.proto\x12\x1dresources.documents.templates\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a\x1dresources/access/access.proto\x1a+resources/documents/approval/approval.proto\x1a+resources/documents/category/category.proto\x1a+resources/documents/workflow/workflow.proto\x1a#resources/timestamp/timestamp.proto\x1a\x13tagger/tagger.proto\"\xda\t\n" +
 	"\bTemplate\x12\x1f\n" +
 	"\x02id\x18\x01 \x01(\x03B\x0f\x9a\x84\x9e\x03\n" +
 	"alias:\"id\"R\x02id\x12B\n" +
@@ -1703,13 +1674,11 @@ const file_resources_documents_templates_templates_proto_rawDesc = "" +
 	"\x03max\x18\x03 \x01(\x05H\x02R\x03max\x88\x01\x01B\v\n" +
 	"\t_requiredB\x06\n" +
 	"\x04_minB\x06\n" +
-	"\x04_max\"\xf9\x01\n" +
-	"\fTemplateData\x126\n" +
-	"\vactive_char\x18\x01 \x01(\v2\x15.resources.users.UserR\n" +
-	"activeChar\x12@\n" +
-	"\tdocuments\x18\x02 \x03(\v2\".resources.documents.DocumentShortR\tdocuments\x126\n" +
-	"\x05users\x18\x03 \x03(\v2 .resources.users.short.UserShortR\x05users\x127\n" +
-	"\bvehicles\x18\x04 \x03(\v2\x1b.resources.vehicles.VehicleR\bvehicles\"\xe2\x01\n" +
+	"\x04_max\"i\n" +
+	"\x11TemplateSelection\x12\x19\n" +
+	"\buser_ids\x18\x01 \x03(\x05R\auserIds\x12!\n" +
+	"\fdocument_ids\x18\x02 \x03(\x03R\vdocumentIds\x12\x16\n" +
+	"\x06plates\x18\x03 \x03(\tR\x06plates\"\xe2\x01\n" +
 	"\x10TemplateApproval\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12R\n" +
 	"\x06policy\x18\x02 \x01(\v25.resources.documents.templates.TemplateApprovalPolicyH\x00R\x06policy\x88\x01\x01\x12M\n" +
@@ -1743,7 +1712,7 @@ var file_resources_documents_templates_templates_proto_goTypes = []any{
 	(*TemplateSchema)(nil),           // 2: resources.documents.templates.TemplateSchema
 	(*TemplateRequirements)(nil),     // 3: resources.documents.templates.TemplateRequirements
 	(*ObjectSpecs)(nil),              // 4: resources.documents.templates.ObjectSpecs
-	(*TemplateData)(nil),             // 5: resources.documents.templates.TemplateData
+	(*TemplateSelection)(nil),        // 5: resources.documents.templates.TemplateSelection
 	(*TemplateApproval)(nil),         // 6: resources.documents.templates.TemplateApproval
 	(*TemplateApprovalPolicy)(nil),   // 7: resources.documents.templates.TemplateApprovalPolicy
 	(*TemplateApprovalTaskSeed)(nil), // 8: resources.documents.templates.TemplateApprovalTaskSeed
@@ -1752,12 +1721,8 @@ var file_resources_documents_templates_templates_proto_goTypes = []any{
 	(*access.JobAccess)(nil),         // 11: resources.access.JobAccess
 	(*access.Access)(nil),            // 12: resources.access.Access
 	(*workflow.Workflow)(nil),        // 13: resources.documents.workflow.Workflow
-	(*users.User)(nil),               // 14: resources.users.User
-	(*documents.DocumentShort)(nil),  // 15: resources.documents.DocumentShort
-	(*short.UserShort)(nil),          // 16: resources.users.short.UserShort
-	(*vehicles.Vehicle)(nil),         // 17: resources.vehicles.Vehicle
-	(approval.ApprovalRuleKind)(0),   // 18: resources.documents.approval.ApprovalRuleKind
-	(approval.OnEditBehavior)(0),     // 19: resources.documents.approval.OnEditBehavior
+	(approval.ApprovalRuleKind)(0),   // 14: resources.documents.approval.ApprovalRuleKind
+	(approval.OnEditBehavior)(0),     // 15: resources.documents.approval.OnEditBehavior
 }
 var file_resources_documents_templates_templates_proto_depIdxs = []int32{
 	9,  // 0: resources.documents.templates.Template.created_at:type_name -> resources.timestamp.Timestamp
@@ -1779,19 +1744,15 @@ var file_resources_documents_templates_templates_proto_depIdxs = []int32{
 	4,  // 16: resources.documents.templates.TemplateRequirements.documents:type_name -> resources.documents.templates.ObjectSpecs
 	4,  // 17: resources.documents.templates.TemplateRequirements.users:type_name -> resources.documents.templates.ObjectSpecs
 	4,  // 18: resources.documents.templates.TemplateRequirements.vehicles:type_name -> resources.documents.templates.ObjectSpecs
-	14, // 19: resources.documents.templates.TemplateData.active_char:type_name -> resources.users.User
-	15, // 20: resources.documents.templates.TemplateData.documents:type_name -> resources.documents.DocumentShort
-	16, // 21: resources.documents.templates.TemplateData.users:type_name -> resources.users.short.UserShort
-	17, // 22: resources.documents.templates.TemplateData.vehicles:type_name -> resources.vehicles.Vehicle
-	7,  // 23: resources.documents.templates.TemplateApproval.policy:type_name -> resources.documents.templates.TemplateApprovalPolicy
-	8,  // 24: resources.documents.templates.TemplateApproval.tasks:type_name -> resources.documents.templates.TemplateApprovalTaskSeed
-	18, // 25: resources.documents.templates.TemplateApprovalPolicy.rule_kind:type_name -> resources.documents.approval.ApprovalRuleKind
-	19, // 26: resources.documents.templates.TemplateApprovalPolicy.on_edit_behavior:type_name -> resources.documents.approval.OnEditBehavior
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	7,  // 19: resources.documents.templates.TemplateApproval.policy:type_name -> resources.documents.templates.TemplateApprovalPolicy
+	8,  // 20: resources.documents.templates.TemplateApproval.tasks:type_name -> resources.documents.templates.TemplateApprovalTaskSeed
+	14, // 21: resources.documents.templates.TemplateApprovalPolicy.rule_kind:type_name -> resources.documents.approval.ApprovalRuleKind
+	15, // 22: resources.documents.templates.TemplateApprovalPolicy.on_edit_behavior:type_name -> resources.documents.approval.OnEditBehavior
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_resources_documents_templates_templates_proto_init() }

--- a/gen/go/proto/resources/documents/templates/templates.pb.sanitizer.go
+++ b/gen/go/proto/resources/documents/templates/templates.pb.sanitizer.go
@@ -190,61 +190,6 @@ func (m *TemplateApprovalTaskSeed) Sanitize() error {
 
 // Sanitize sanitizes the message's fields, in case of complex types it calls
 // their Sanitize() method recursively.
-func (m *TemplateData) Sanitize() error {
-	if m == nil {
-		return nil
-	}
-
-	// Field: ActiveChar
-	if m.ActiveChar != nil {
-		if v, ok := any(m.GetActiveChar()).(interface{ Sanitize() error }); ok {
-			if err := v.Sanitize(); err != nil {
-				return err
-			}
-		}
-	}
-
-	// Field: Documents
-	for idx, item := range m.Documents {
-		_, _ = idx, item
-
-		if v, ok := any(item).(interface{ Sanitize() error }); ok {
-			if err := v.Sanitize(); err != nil {
-				return err
-			}
-		}
-
-	}
-
-	// Field: Users
-	for idx, item := range m.Users {
-		_, _ = idx, item
-
-		if v, ok := any(item).(interface{ Sanitize() error }); ok {
-			if err := v.Sanitize(); err != nil {
-				return err
-			}
-		}
-
-	}
-
-	// Field: Vehicles
-	for idx, item := range m.Vehicles {
-		_, _ = idx, item
-
-		if v, ok := any(item).(interface{ Sanitize() error }); ok {
-			if err := v.Sanitize(); err != nil {
-				return err
-			}
-		}
-
-	}
-
-	return nil
-}
-
-// Sanitize sanitizes the message's fields, in case of complex types it calls
-// their Sanitize() method recursively.
 func (m *TemplateRequirements) Sanitize() error {
 	if m == nil {
 		return nil
@@ -294,6 +239,24 @@ func (m *TemplateSchema) Sanitize() error {
 				return err
 			}
 		}
+	}
+
+	return nil
+}
+
+// Sanitize sanitizes the message's fields, in case of complex types it calls
+// their Sanitize() method recursively.
+func (m *TemplateSelection) Sanitize() error {
+	if m == nil {
+		return nil
+	}
+
+	// Field: Plates
+	for idx, item := range m.Plates {
+		_, _ = idx, item
+
+		m.Plates[idx] = htmlsanitizer.SanitizeAndUnescape(m.Plates[idx])
+
 	}
 
 	return nil

--- a/gen/go/proto/resources/documents/templates/templates_protoopaque.pb.go
+++ b/gen/go/proto/resources/documents/templates/templates_protoopaque.pb.go
@@ -12,14 +12,10 @@ import (
 	_ "github.com/fivenet-app/fivenet/v2026/gen/go/proto/codegen/dbscanner"
 	_ "github.com/fivenet-app/fivenet/v2026/gen/go/proto/codegen/sanitizer"
 	access "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/access"
-	documents "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents"
 	approval "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/approval"
 	category "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/category"
 	workflow "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/workflow"
 	timestamp "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
-	users "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
-	short "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users/short"
-	vehicles "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/vehicles"
 	_ "github.com/srikrsna/protoc-gen-gotag/tagger"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
@@ -1163,30 +1159,29 @@ func (b0 ObjectSpecs_builder) Build() *ObjectSpecs {
 	return m0
 }
 
-type TemplateData struct {
-	state                 protoimpl.MessageState      `protogen:"opaque.v1"`
-	xxx_hidden_ActiveChar *users.User                 `protobuf:"bytes,1,opt,name=active_char,json=activeChar,proto3"`
-	xxx_hidden_Documents  *[]*documents.DocumentShort `protobuf:"bytes,2,rep,name=documents,proto3"`
-	xxx_hidden_Users      *[]*short.UserShort         `protobuf:"bytes,3,rep,name=users,proto3"`
-	xxx_hidden_Vehicles   *[]*vehicles.Vehicle        `protobuf:"bytes,4,rep,name=vehicles,proto3"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+type TemplateSelection struct {
+	state                  protoimpl.MessageState `protogen:"opaque.v1"`
+	xxx_hidden_UserIds     []int32                `protobuf:"varint,1,rep,packed,name=user_ids,json=userIds,proto3"`
+	xxx_hidden_DocumentIds []int64                `protobuf:"varint,2,rep,packed,name=document_ids,json=documentIds,proto3"`
+	xxx_hidden_Plates      []string               `protobuf:"bytes,3,rep,name=plates,proto3"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
-func (x *TemplateData) Reset() {
-	*x = TemplateData{}
+func (x *TemplateSelection) Reset() {
+	*x = TemplateSelection{}
 	mi := &file_resources_documents_templates_templates_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *TemplateData) String() string {
+func (x *TemplateSelection) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*TemplateData) ProtoMessage() {}
+func (*TemplateSelection) ProtoMessage() {}
 
-func (x *TemplateData) ProtoReflect() protoreflect.Message {
+func (x *TemplateSelection) ProtoReflect() protoreflect.Message {
 	mi := &file_resources_documents_templates_templates_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -1198,84 +1193,54 @@ func (x *TemplateData) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-func (x *TemplateData) GetActiveChar() *users.User {
+func (x *TemplateSelection) GetUserIds() []int32 {
 	if x != nil {
-		return x.xxx_hidden_ActiveChar
+		return x.xxx_hidden_UserIds
 	}
 	return nil
 }
 
-func (x *TemplateData) GetDocuments() []*documents.DocumentShort {
+func (x *TemplateSelection) GetDocumentIds() []int64 {
 	if x != nil {
-		if x.xxx_hidden_Documents != nil {
-			return *x.xxx_hidden_Documents
-		}
+		return x.xxx_hidden_DocumentIds
 	}
 	return nil
 }
 
-func (x *TemplateData) GetUsers() []*short.UserShort {
+func (x *TemplateSelection) GetPlates() []string {
 	if x != nil {
-		if x.xxx_hidden_Users != nil {
-			return *x.xxx_hidden_Users
-		}
+		return x.xxx_hidden_Plates
 	}
 	return nil
 }
 
-func (x *TemplateData) GetVehicles() []*vehicles.Vehicle {
-	if x != nil {
-		if x.xxx_hidden_Vehicles != nil {
-			return *x.xxx_hidden_Vehicles
-		}
-	}
-	return nil
+func (x *TemplateSelection) SetUserIds(v []int32) {
+	x.xxx_hidden_UserIds = v
 }
 
-func (x *TemplateData) SetActiveChar(v *users.User) {
-	x.xxx_hidden_ActiveChar = v
+func (x *TemplateSelection) SetDocumentIds(v []int64) {
+	x.xxx_hidden_DocumentIds = v
 }
 
-func (x *TemplateData) SetDocuments(v []*documents.DocumentShort) {
-	x.xxx_hidden_Documents = &v
+func (x *TemplateSelection) SetPlates(v []string) {
+	x.xxx_hidden_Plates = v
 }
 
-func (x *TemplateData) SetUsers(v []*short.UserShort) {
-	x.xxx_hidden_Users = &v
-}
-
-func (x *TemplateData) SetVehicles(v []*vehicles.Vehicle) {
-	x.xxx_hidden_Vehicles = &v
-}
-
-func (x *TemplateData) HasActiveChar() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_ActiveChar != nil
-}
-
-func (x *TemplateData) ClearActiveChar() {
-	x.xxx_hidden_ActiveChar = nil
-}
-
-type TemplateData_builder struct {
+type TemplateSelection_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ActiveChar *users.User
-	Documents  []*documents.DocumentShort
-	Users      []*short.UserShort
-	Vehicles   []*vehicles.Vehicle
+	UserIds     []int32
+	DocumentIds []int64
+	Plates      []string
 }
 
-func (b0 TemplateData_builder) Build() *TemplateData {
-	m0 := &TemplateData{}
+func (b0 TemplateSelection_builder) Build() *TemplateSelection {
+	m0 := &TemplateSelection{}
 	b, x := &b0, m0
 	_, _ = b, x
-	x.xxx_hidden_ActiveChar = b.ActiveChar
-	x.xxx_hidden_Documents = &b.Documents
-	x.xxx_hidden_Users = &b.Users
-	x.xxx_hidden_Vehicles = &b.Vehicles
+	x.xxx_hidden_UserIds = b.UserIds
+	x.xxx_hidden_DocumentIds = b.DocumentIds
+	x.xxx_hidden_Plates = b.Plates
 	return m0
 }
 
@@ -1728,7 +1693,7 @@ var File_resources_documents_templates_templates_proto protoreflect.FileDescript
 
 const file_resources_documents_templates_templates_proto_rawDesc = "" +
 	"\n" +
-	"-resources/documents/templates/templates.proto\x12\x1dresources.documents.templates\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a\x1dresources/access/access.proto\x1a+resources/documents/approval/approval.proto\x1a+resources/documents/category/category.proto\x1a#resources/documents/documents.proto\x1a+resources/documents/workflow/workflow.proto\x1a#resources/timestamp/timestamp.proto\x1a resources/users/short/user.proto\x1a\x1aresources/users/user.proto\x1a!resources/vehicles/vehicles.proto\x1a\x13tagger/tagger.proto\"\xda\t\n" +
+	"-resources/documents/templates/templates.proto\x12\x1dresources.documents.templates\x1a!codegen/dbscanner/dbscanner.proto\x1a!codegen/sanitizer/sanitizer.proto\x1a\x1dresources/access/access.proto\x1a+resources/documents/approval/approval.proto\x1a+resources/documents/category/category.proto\x1a+resources/documents/workflow/workflow.proto\x1a#resources/timestamp/timestamp.proto\x1a\x13tagger/tagger.proto\"\xda\t\n" +
 	"\bTemplate\x12\x1f\n" +
 	"\x02id\x18\x01 \x01(\x03B\x0f\x9a\x84\x9e\x03\n" +
 	"alias:\"id\"R\x02id\x12B\n" +
@@ -1807,13 +1772,11 @@ const file_resources_documents_templates_templates_proto_rawDesc = "" +
 	"\x03max\x18\x03 \x01(\x05H\x02R\x03max\x88\x01\x01B\v\n" +
 	"\t_requiredB\x06\n" +
 	"\x04_minB\x06\n" +
-	"\x04_max\"\xf9\x01\n" +
-	"\fTemplateData\x126\n" +
-	"\vactive_char\x18\x01 \x01(\v2\x15.resources.users.UserR\n" +
-	"activeChar\x12@\n" +
-	"\tdocuments\x18\x02 \x03(\v2\".resources.documents.DocumentShortR\tdocuments\x126\n" +
-	"\x05users\x18\x03 \x03(\v2 .resources.users.short.UserShortR\x05users\x127\n" +
-	"\bvehicles\x18\x04 \x03(\v2\x1b.resources.vehicles.VehicleR\bvehicles\"\xe2\x01\n" +
+	"\x04_max\"i\n" +
+	"\x11TemplateSelection\x12\x19\n" +
+	"\buser_ids\x18\x01 \x03(\x05R\auserIds\x12!\n" +
+	"\fdocument_ids\x18\x02 \x03(\x03R\vdocumentIds\x12\x16\n" +
+	"\x06plates\x18\x03 \x03(\tR\x06plates\"\xe2\x01\n" +
 	"\x10TemplateApproval\x12\x18\n" +
 	"\aenabled\x18\x01 \x01(\bR\aenabled\x12R\n" +
 	"\x06policy\x18\x02 \x01(\v25.resources.documents.templates.TemplateApprovalPolicyH\x00R\x06policy\x88\x01\x01\x12M\n" +
@@ -1847,7 +1810,7 @@ var file_resources_documents_templates_templates_proto_goTypes = []any{
 	(*TemplateSchema)(nil),           // 2: resources.documents.templates.TemplateSchema
 	(*TemplateRequirements)(nil),     // 3: resources.documents.templates.TemplateRequirements
 	(*ObjectSpecs)(nil),              // 4: resources.documents.templates.ObjectSpecs
-	(*TemplateData)(nil),             // 5: resources.documents.templates.TemplateData
+	(*TemplateSelection)(nil),        // 5: resources.documents.templates.TemplateSelection
 	(*TemplateApproval)(nil),         // 6: resources.documents.templates.TemplateApproval
 	(*TemplateApprovalPolicy)(nil),   // 7: resources.documents.templates.TemplateApprovalPolicy
 	(*TemplateApprovalTaskSeed)(nil), // 8: resources.documents.templates.TemplateApprovalTaskSeed
@@ -1856,12 +1819,8 @@ var file_resources_documents_templates_templates_proto_goTypes = []any{
 	(*access.JobAccess)(nil),         // 11: resources.access.JobAccess
 	(*access.Access)(nil),            // 12: resources.access.Access
 	(*workflow.Workflow)(nil),        // 13: resources.documents.workflow.Workflow
-	(*users.User)(nil),               // 14: resources.users.User
-	(*documents.DocumentShort)(nil),  // 15: resources.documents.DocumentShort
-	(*short.UserShort)(nil),          // 16: resources.users.short.UserShort
-	(*vehicles.Vehicle)(nil),         // 17: resources.vehicles.Vehicle
-	(approval.ApprovalRuleKind)(0),   // 18: resources.documents.approval.ApprovalRuleKind
-	(approval.OnEditBehavior)(0),     // 19: resources.documents.approval.OnEditBehavior
+	(approval.ApprovalRuleKind)(0),   // 14: resources.documents.approval.ApprovalRuleKind
+	(approval.OnEditBehavior)(0),     // 15: resources.documents.approval.OnEditBehavior
 }
 var file_resources_documents_templates_templates_proto_depIdxs = []int32{
 	9,  // 0: resources.documents.templates.Template.created_at:type_name -> resources.timestamp.Timestamp
@@ -1883,19 +1842,15 @@ var file_resources_documents_templates_templates_proto_depIdxs = []int32{
 	4,  // 16: resources.documents.templates.TemplateRequirements.documents:type_name -> resources.documents.templates.ObjectSpecs
 	4,  // 17: resources.documents.templates.TemplateRequirements.users:type_name -> resources.documents.templates.ObjectSpecs
 	4,  // 18: resources.documents.templates.TemplateRequirements.vehicles:type_name -> resources.documents.templates.ObjectSpecs
-	14, // 19: resources.documents.templates.TemplateData.active_char:type_name -> resources.users.User
-	15, // 20: resources.documents.templates.TemplateData.documents:type_name -> resources.documents.DocumentShort
-	16, // 21: resources.documents.templates.TemplateData.users:type_name -> resources.users.short.UserShort
-	17, // 22: resources.documents.templates.TemplateData.vehicles:type_name -> resources.vehicles.Vehicle
-	7,  // 23: resources.documents.templates.TemplateApproval.policy:type_name -> resources.documents.templates.TemplateApprovalPolicy
-	8,  // 24: resources.documents.templates.TemplateApproval.tasks:type_name -> resources.documents.templates.TemplateApprovalTaskSeed
-	18, // 25: resources.documents.templates.TemplateApprovalPolicy.rule_kind:type_name -> resources.documents.approval.ApprovalRuleKind
-	19, // 26: resources.documents.templates.TemplateApprovalPolicy.on_edit_behavior:type_name -> resources.documents.approval.OnEditBehavior
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	7,  // 19: resources.documents.templates.TemplateApproval.policy:type_name -> resources.documents.templates.TemplateApprovalPolicy
+	8,  // 20: resources.documents.templates.TemplateApproval.tasks:type_name -> resources.documents.templates.TemplateApprovalTaskSeed
+	14, // 21: resources.documents.templates.TemplateApprovalPolicy.rule_kind:type_name -> resources.documents.approval.ApprovalRuleKind
+	15, // 22: resources.documents.templates.TemplateApprovalPolicy.on_edit_behavior:type_name -> resources.documents.approval.OnEditBehavior
+	23, // [23:23] is the sub-list for method output_type
+	23, // [23:23] is the sub-list for method input_type
+	23, // [23:23] is the sub-list for extension type_name
+	23, // [23:23] is the sub-list for extension extendee
+	0,  // [0:23] is the sub-list for field type_name
 }
 
 func init() { file_resources_documents_templates_templates_proto_init() }

--- a/gen/go/proto/services/documents/documents.pb.go
+++ b/gen/go/proto/services/documents/documents.pb.go
@@ -1677,12 +1677,12 @@ func (b0 ChangeDocumentOwnerResponse_builder) Build() *ChangeDocumentOwnerRespon
 }
 
 type CreateDocumentRequest struct {
-	state         protoimpl.MessageState  `protogen:"hybrid.v1"`
-	ContentType   content.ContentType     `protobuf:"varint,1,opt,name=content_type,json=contentType,proto3,enum=resources.common.content.ContentType" json:"content_type,omitempty"`
-	TemplateId    *int64                  `protobuf:"varint,2,opt,name=template_id,json=templateId,proto3,oneof" json:"template_id,omitempty"`
-	TemplateData  *templates.TemplateData `protobuf:"bytes,3,opt,name=template_data,json=templateData,proto3,oneof" json:"template_data,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state             protoimpl.MessageState       `protogen:"hybrid.v1"`
+	ContentType       content.ContentType          `protobuf:"varint,1,opt,name=content_type,json=contentType,proto3,enum=resources.common.content.ContentType" json:"content_type,omitempty"`
+	TemplateId        *int64                       `protobuf:"varint,2,opt,name=template_id,json=templateId,proto3,oneof" json:"template_id,omitempty"`
+	TemplateSelection *templates.TemplateSelection `protobuf:"bytes,4,opt,name=template_selection,json=templateSelection,proto3,oneof" json:"template_selection,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
 }
 
 func (x *CreateDocumentRequest) Reset() {
@@ -1724,9 +1724,9 @@ func (x *CreateDocumentRequest) GetTemplateId() int64 {
 	return 0
 }
 
-func (x *CreateDocumentRequest) GetTemplateData() *templates.TemplateData {
+func (x *CreateDocumentRequest) GetTemplateSelection() *templates.TemplateSelection {
 	if x != nil {
-		return x.TemplateData
+		return x.TemplateSelection
 	}
 	return nil
 }
@@ -1739,8 +1739,8 @@ func (x *CreateDocumentRequest) SetTemplateId(v int64) {
 	x.TemplateId = &v
 }
 
-func (x *CreateDocumentRequest) SetTemplateData(v *templates.TemplateData) {
-	x.TemplateData = v
+func (x *CreateDocumentRequest) SetTemplateSelection(v *templates.TemplateSelection) {
+	x.TemplateSelection = v
 }
 
 func (x *CreateDocumentRequest) HasTemplateId() bool {
@@ -1750,27 +1750,27 @@ func (x *CreateDocumentRequest) HasTemplateId() bool {
 	return x.TemplateId != nil
 }
 
-func (x *CreateDocumentRequest) HasTemplateData() bool {
+func (x *CreateDocumentRequest) HasTemplateSelection() bool {
 	if x == nil {
 		return false
 	}
-	return x.TemplateData != nil
+	return x.TemplateSelection != nil
 }
 
 func (x *CreateDocumentRequest) ClearTemplateId() {
 	x.TemplateId = nil
 }
 
-func (x *CreateDocumentRequest) ClearTemplateData() {
-	x.TemplateData = nil
+func (x *CreateDocumentRequest) ClearTemplateSelection() {
+	x.TemplateSelection = nil
 }
 
 type CreateDocumentRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ContentType  content.ContentType
-	TemplateId   *int64
-	TemplateData *templates.TemplateData
+	ContentType       content.ContentType
+	TemplateId        *int64
+	TemplateSelection *templates.TemplateSelection
 }
 
 func (b0 CreateDocumentRequest_builder) Build() *CreateDocumentRequest {
@@ -1779,7 +1779,7 @@ func (b0 CreateDocumentRequest_builder) Build() *CreateDocumentRequest {
 	_, _ = b, x
 	x.ContentType = b.ContentType
 	x.TemplateId = b.TemplateId
-	x.TemplateData = b.TemplateData
+	x.TemplateSelection = b.TemplateSelection
 	return m0
 }
 
@@ -4000,14 +4000,14 @@ const file_services_documents_documents_proto_rawDesc = "" +
 	"documentId\x12#\n" +
 	"\vnew_user_id\x18\x02 \x01(\x05H\x00R\tnewUserId\x88\x01\x01B\x0e\n" +
 	"\f_new_user_id\"\x1d\n" +
-	"\x1bChangeDocumentOwnerResponse\"\x80\x02\n" +
+	"\x1bChangeDocumentOwnerResponse\"\x9a\x02\n" +
 	"\x15CreateDocumentRequest\x12H\n" +
 	"\fcontent_type\x18\x01 \x01(\x0e2%.resources.common.content.ContentTypeR\vcontentType\x12$\n" +
 	"\vtemplate_id\x18\x02 \x01(\x03H\x00R\n" +
-	"templateId\x88\x01\x01\x12U\n" +
-	"\rtemplate_data\x18\x03 \x01(\v2+.resources.documents.templates.TemplateDataH\x01R\ftemplateData\x88\x01\x01B\x0e\n" +
-	"\f_template_idB\x10\n" +
-	"\x0e_template_data\"(\n" +
+	"templateId\x88\x01\x01\x12d\n" +
+	"\x12template_selection\x18\x04 \x01(\v20.resources.documents.templates.TemplateSelectionH\x01R\x11templateSelection\x88\x01\x01B\x0e\n" +
+	"\f_template_idB\x15\n" +
+	"\x13_template_selectionJ\x04\b\x03\x10\x04\"(\n" +
 	"\x16CreateDocumentResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"\xbb\x04\n" +
 	"\x15UpdateDocumentRequest\x120\n" +
@@ -4230,7 +4230,7 @@ var file_services_documents_documents_proto_goTypes = []any{
 	(*references.DocumentReference)(nil),    // 55: resources.documents.references.DocumentReference
 	(*relations.DocumentRelation)(nil),      // 56: resources.documents.relations.DocumentRelation
 	(content.ContentType)(0),                // 57: resources.common.content.ContentType
-	(*templates.TemplateData)(nil),          // 58: resources.documents.templates.TemplateData
+	(*templates.TemplateSelection)(nil),     // 58: resources.documents.templates.TemplateSelection
 	(*content.Content)(nil),                 // 59: resources.common.content.Content
 	(*data.DocumentData)(nil),               // 60: resources.documents.data.DocumentData
 	(*documents.DocumentMeta)(nil),          // 61: resources.documents.DocumentMeta
@@ -4259,7 +4259,7 @@ var file_services_documents_documents_proto_depIdxs = []int32{
 	56, // 11: services.documents.AddDocumentRelationRequest.relation:type_name -> resources.documents.relations.DocumentRelation
 	53, // 12: services.documents.UpdateDocumentResponse.document:type_name -> resources.documents.Document
 	57, // 13: services.documents.CreateDocumentRequest.content_type:type_name -> resources.common.content.ContentType
-	58, // 14: services.documents.CreateDocumentRequest.template_data:type_name -> resources.documents.templates.TemplateData
+	58, // 14: services.documents.CreateDocumentRequest.template_selection:type_name -> resources.documents.templates.TemplateSelection
 	59, // 15: services.documents.UpdateDocumentRequest.content:type_name -> resources.common.content.Content
 	57, // 16: services.documents.UpdateDocumentRequest.content_type:type_name -> resources.common.content.ContentType
 	60, // 17: services.documents.UpdateDocumentRequest.data:type_name -> resources.documents.data.DocumentData

--- a/gen/go/proto/services/documents/documents.pb.sanitizer.go
+++ b/gen/go/proto/services/documents/documents.pb.sanitizer.go
@@ -95,9 +95,9 @@ func (m *CreateDocumentRequest) Sanitize() error {
 		return nil
 	}
 
-	// Field: TemplateData
-	if m.TemplateData != nil {
-		if v, ok := any(m.GetTemplateData()).(interface{ Sanitize() error }); ok {
+	// Field: TemplateSelection
+	if m.TemplateSelection != nil {
+		if v, ok := any(m.GetTemplateSelection()).(interface{ Sanitize() error }); ok {
 			if err := v.Sanitize(); err != nil {
 				return err
 			}

--- a/gen/go/proto/services/documents/documents_protoopaque.pb.go
+++ b/gen/go/proto/services/documents/documents_protoopaque.pb.go
@@ -1722,14 +1722,14 @@ func (b0 ChangeDocumentOwnerResponse_builder) Build() *ChangeDocumentOwnerRespon
 }
 
 type CreateDocumentRequest struct {
-	state                   protoimpl.MessageState  `protogen:"opaque.v1"`
-	xxx_hidden_ContentType  content.ContentType     `protobuf:"varint,1,opt,name=content_type,json=contentType,proto3,enum=resources.common.content.ContentType"`
-	xxx_hidden_TemplateId   int64                   `protobuf:"varint,2,opt,name=template_id,json=templateId,proto3,oneof"`
-	xxx_hidden_TemplateData *templates.TemplateData `protobuf:"bytes,3,opt,name=template_data,json=templateData,proto3,oneof"`
-	XXX_raceDetectHookData  protoimpl.RaceDetectHookData
-	XXX_presence            [1]uint32
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	state                        protoimpl.MessageState       `protogen:"opaque.v1"`
+	xxx_hidden_ContentType       content.ContentType          `protobuf:"varint,1,opt,name=content_type,json=contentType,proto3,enum=resources.common.content.ContentType"`
+	xxx_hidden_TemplateId        int64                        `protobuf:"varint,2,opt,name=template_id,json=templateId,proto3,oneof"`
+	xxx_hidden_TemplateSelection *templates.TemplateSelection `protobuf:"bytes,4,opt,name=template_selection,json=templateSelection,proto3,oneof"`
+	XXX_raceDetectHookData       protoimpl.RaceDetectHookData
+	XXX_presence                 [1]uint32
+	unknownFields                protoimpl.UnknownFields
+	sizeCache                    protoimpl.SizeCache
 }
 
 func (x *CreateDocumentRequest) Reset() {
@@ -1771,9 +1771,9 @@ func (x *CreateDocumentRequest) GetTemplateId() int64 {
 	return 0
 }
 
-func (x *CreateDocumentRequest) GetTemplateData() *templates.TemplateData {
+func (x *CreateDocumentRequest) GetTemplateSelection() *templates.TemplateSelection {
 	if x != nil {
-		return x.xxx_hidden_TemplateData
+		return x.xxx_hidden_TemplateSelection
 	}
 	return nil
 }
@@ -1787,8 +1787,8 @@ func (x *CreateDocumentRequest) SetTemplateId(v int64) {
 	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
 }
 
-func (x *CreateDocumentRequest) SetTemplateData(v *templates.TemplateData) {
-	x.xxx_hidden_TemplateData = v
+func (x *CreateDocumentRequest) SetTemplateSelection(v *templates.TemplateSelection) {
+	x.xxx_hidden_TemplateSelection = v
 }
 
 func (x *CreateDocumentRequest) HasTemplateId() bool {
@@ -1798,11 +1798,11 @@ func (x *CreateDocumentRequest) HasTemplateId() bool {
 	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
 }
 
-func (x *CreateDocumentRequest) HasTemplateData() bool {
+func (x *CreateDocumentRequest) HasTemplateSelection() bool {
 	if x == nil {
 		return false
 	}
-	return x.xxx_hidden_TemplateData != nil
+	return x.xxx_hidden_TemplateSelection != nil
 }
 
 func (x *CreateDocumentRequest) ClearTemplateId() {
@@ -1810,16 +1810,16 @@ func (x *CreateDocumentRequest) ClearTemplateId() {
 	x.xxx_hidden_TemplateId = 0
 }
 
-func (x *CreateDocumentRequest) ClearTemplateData() {
-	x.xxx_hidden_TemplateData = nil
+func (x *CreateDocumentRequest) ClearTemplateSelection() {
+	x.xxx_hidden_TemplateSelection = nil
 }
 
 type CreateDocumentRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
-	ContentType  content.ContentType
-	TemplateId   *int64
-	TemplateData *templates.TemplateData
+	ContentType       content.ContentType
+	TemplateId        *int64
+	TemplateSelection *templates.TemplateSelection
 }
 
 func (b0 CreateDocumentRequest_builder) Build() *CreateDocumentRequest {
@@ -1831,7 +1831,7 @@ func (b0 CreateDocumentRequest_builder) Build() *CreateDocumentRequest {
 		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
 		x.xxx_hidden_TemplateId = *b.TemplateId
 	}
-	x.xxx_hidden_TemplateData = b.TemplateData
+	x.xxx_hidden_TemplateSelection = b.TemplateSelection
 	return m0
 }
 
@@ -4120,14 +4120,14 @@ const file_services_documents_documents_proto_rawDesc = "" +
 	"documentId\x12#\n" +
 	"\vnew_user_id\x18\x02 \x01(\x05H\x00R\tnewUserId\x88\x01\x01B\x0e\n" +
 	"\f_new_user_id\"\x1d\n" +
-	"\x1bChangeDocumentOwnerResponse\"\x80\x02\n" +
+	"\x1bChangeDocumentOwnerResponse\"\x9a\x02\n" +
 	"\x15CreateDocumentRequest\x12H\n" +
 	"\fcontent_type\x18\x01 \x01(\x0e2%.resources.common.content.ContentTypeR\vcontentType\x12$\n" +
 	"\vtemplate_id\x18\x02 \x01(\x03H\x00R\n" +
-	"templateId\x88\x01\x01\x12U\n" +
-	"\rtemplate_data\x18\x03 \x01(\v2+.resources.documents.templates.TemplateDataH\x01R\ftemplateData\x88\x01\x01B\x0e\n" +
-	"\f_template_idB\x10\n" +
-	"\x0e_template_data\"(\n" +
+	"templateId\x88\x01\x01\x12d\n" +
+	"\x12template_selection\x18\x04 \x01(\v20.resources.documents.templates.TemplateSelectionH\x01R\x11templateSelection\x88\x01\x01B\x0e\n" +
+	"\f_template_idB\x15\n" +
+	"\x13_template_selectionJ\x04\b\x03\x10\x04\"(\n" +
 	"\x16CreateDocumentResponse\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\x03R\x02id\"\xbb\x04\n" +
 	"\x15UpdateDocumentRequest\x120\n" +
@@ -4350,7 +4350,7 @@ var file_services_documents_documents_proto_goTypes = []any{
 	(*references.DocumentReference)(nil),    // 55: resources.documents.references.DocumentReference
 	(*relations.DocumentRelation)(nil),      // 56: resources.documents.relations.DocumentRelation
 	(content.ContentType)(0),                // 57: resources.common.content.ContentType
-	(*templates.TemplateData)(nil),          // 58: resources.documents.templates.TemplateData
+	(*templates.TemplateSelection)(nil),     // 58: resources.documents.templates.TemplateSelection
 	(*content.Content)(nil),                 // 59: resources.common.content.Content
 	(*data.DocumentData)(nil),               // 60: resources.documents.data.DocumentData
 	(*documents.DocumentMeta)(nil),          // 61: resources.documents.DocumentMeta
@@ -4379,7 +4379,7 @@ var file_services_documents_documents_proto_depIdxs = []int32{
 	56, // 11: services.documents.AddDocumentRelationRequest.relation:type_name -> resources.documents.relations.DocumentRelation
 	53, // 12: services.documents.UpdateDocumentResponse.document:type_name -> resources.documents.Document
 	57, // 13: services.documents.CreateDocumentRequest.content_type:type_name -> resources.common.content.ContentType
-	58, // 14: services.documents.CreateDocumentRequest.template_data:type_name -> resources.documents.templates.TemplateData
+	58, // 14: services.documents.CreateDocumentRequest.template_selection:type_name -> resources.documents.templates.TemplateSelection
 	59, // 15: services.documents.UpdateDocumentRequest.content:type_name -> resources.common.content.Content
 	57, // 16: services.documents.UpdateDocumentRequest.content_type:type_name -> resources.common.content.ContentType
 	60, // 17: services.documents.UpdateDocumentRequest.data:type_name -> resources.documents.data.DocumentData

--- a/gen/go/proto/services/documents/templates.pb.go
+++ b/gen/go/proto/services/documents/templates.pb.go
@@ -126,10 +126,10 @@ func (b0 ListTemplatesResponse_builder) Build() *ListTemplatesResponse {
 }
 
 type GetTemplateRequest struct {
-	state         protoimpl.MessageState  `protogen:"hybrid.v1"`
-	TemplateId    int64                   `protobuf:"varint,1,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
-	Data          *templates.TemplateData `protobuf:"bytes,2,opt,name=data,proto3,oneof" json:"data,omitempty"`
-	Render        *bool                   `protobuf:"varint,3,opt,name=render,proto3,oneof" json:"render,omitempty"`
+	state         protoimpl.MessageState       `protogen:"hybrid.v1"`
+	TemplateId    int64                        `protobuf:"varint,1,opt,name=template_id,json=templateId,proto3" json:"template_id,omitempty"`
+	Render        *bool                        `protobuf:"varint,3,opt,name=render,proto3,oneof" json:"render,omitempty"`
+	Selection     *templates.TemplateSelection `protobuf:"bytes,4,opt,name=selection,proto3,oneof" json:"selection,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -166,13 +166,6 @@ func (x *GetTemplateRequest) GetTemplateId() int64 {
 	return 0
 }
 
-func (x *GetTemplateRequest) GetData() *templates.TemplateData {
-	if x != nil {
-		return x.Data
-	}
-	return nil
-}
-
 func (x *GetTemplateRequest) GetRender() bool {
 	if x != nil && x.Render != nil {
 		return *x.Render
@@ -180,23 +173,23 @@ func (x *GetTemplateRequest) GetRender() bool {
 	return false
 }
 
-func (x *GetTemplateRequest) SetTemplateId(v int64) {
-	x.TemplateId = v
+func (x *GetTemplateRequest) GetSelection() *templates.TemplateSelection {
+	if x != nil {
+		return x.Selection
+	}
+	return nil
 }
 
-func (x *GetTemplateRequest) SetData(v *templates.TemplateData) {
-	x.Data = v
+func (x *GetTemplateRequest) SetTemplateId(v int64) {
+	x.TemplateId = v
 }
 
 func (x *GetTemplateRequest) SetRender(v bool) {
 	x.Render = &v
 }
 
-func (x *GetTemplateRequest) HasData() bool {
-	if x == nil {
-		return false
-	}
-	return x.Data != nil
+func (x *GetTemplateRequest) SetSelection(v *templates.TemplateSelection) {
+	x.Selection = v
 }
 
 func (x *GetTemplateRequest) HasRender() bool {
@@ -206,20 +199,27 @@ func (x *GetTemplateRequest) HasRender() bool {
 	return x.Render != nil
 }
 
-func (x *GetTemplateRequest) ClearData() {
-	x.Data = nil
+func (x *GetTemplateRequest) HasSelection() bool {
+	if x == nil {
+		return false
+	}
+	return x.Selection != nil
 }
 
 func (x *GetTemplateRequest) ClearRender() {
 	x.Render = nil
 }
 
+func (x *GetTemplateRequest) ClearSelection() {
+	x.Selection = nil
+}
+
 type GetTemplateRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	TemplateId int64
-	Data       *templates.TemplateData
 	Render     *bool
+	Selection  *templates.TemplateSelection
 }
 
 func (b0 GetTemplateRequest_builder) Build() *GetTemplateRequest {
@@ -227,8 +227,8 @@ func (b0 GetTemplateRequest_builder) Build() *GetTemplateRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.TemplateId = b.TemplateId
-	x.Data = b.Data
 	x.Render = b.Render
+	x.Selection = b.Selection
 	return m0
 }
 
@@ -832,14 +832,15 @@ const file_services_documents_templates_proto_rawDesc = "" +
 	"\"services/documents/templates.proto\x12\x12services.documents\x1a\x1fcodegen/itemslen/itemslen.proto\x1a\x19codegen/perms/perms.proto\x1a-resources/documents/templates/templates.proto\"\x16\n" +
 	"\x14ListTemplatesRequest\"i\n" +
 	"\x15ListTemplatesResponse\x12P\n" +
-	"\ttemplates\x18\x01 \x03(\v2,.resources.documents.templates.TemplateShortB\x04\xc8\xf3\x18\x01R\ttemplates\"\xac\x01\n" +
+	"\ttemplates\x18\x01 \x03(\v2,.resources.documents.templates.TemplateShortB\x04\xc8\xf3\x18\x01R\ttemplates\"\xc6\x01\n" +
 	"\x12GetTemplateRequest\x12\x1f\n" +
 	"\vtemplate_id\x18\x01 \x01(\x03R\n" +
-	"templateId\x12D\n" +
-	"\x04data\x18\x02 \x01(\v2+.resources.documents.templates.TemplateDataH\x00R\x04data\x88\x01\x01\x12\x1b\n" +
-	"\x06render\x18\x03 \x01(\bH\x01R\x06render\x88\x01\x01B\a\n" +
-	"\x05_dataB\t\n" +
-	"\a_render\"v\n" +
+	"templateId\x12\x1b\n" +
+	"\x06render\x18\x03 \x01(\bH\x00R\x06render\x88\x01\x01\x12S\n" +
+	"\tselection\x18\x04 \x01(\v20.resources.documents.templates.TemplateSelectionH\x01R\tselection\x88\x01\x01B\t\n" +
+	"\a_renderB\f\n" +
+	"\n" +
+	"_selectionJ\x04\b\x02\x10\x03\"v\n" +
 	"\x13GetTemplateResponse\x12C\n" +
 	"\btemplate\x18\x01 \x01(\v2'.resources.documents.templates.TemplateR\btemplate\x12\x1a\n" +
 	"\brendered\x18\x02 \x01(\bR\brendered\"\\\n" +
@@ -873,25 +874,25 @@ const file_services_documents_templates_proto_rawDesc = "" +
 
 var file_services_documents_templates_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_services_documents_templates_proto_goTypes = []any{
-	(*ListTemplatesRequest)(nil),    // 0: services.documents.ListTemplatesRequest
-	(*ListTemplatesResponse)(nil),   // 1: services.documents.ListTemplatesResponse
-	(*GetTemplateRequest)(nil),      // 2: services.documents.GetTemplateRequest
-	(*GetTemplateResponse)(nil),     // 3: services.documents.GetTemplateResponse
-	(*CreateTemplateRequest)(nil),   // 4: services.documents.CreateTemplateRequest
-	(*CreateTemplateResponse)(nil),  // 5: services.documents.CreateTemplateResponse
-	(*UpdateTemplateRequest)(nil),   // 6: services.documents.UpdateTemplateRequest
-	(*UpdateTemplateResponse)(nil),  // 7: services.documents.UpdateTemplateResponse
-	(*DeleteTemplateRequest)(nil),   // 8: services.documents.DeleteTemplateRequest
-	(*DeleteTemplateResponse)(nil),  // 9: services.documents.DeleteTemplateResponse
-	(*MoveTemplateRequest)(nil),     // 10: services.documents.MoveTemplateRequest
-	(*MoveTemplateResponse)(nil),    // 11: services.documents.MoveTemplateResponse
-	(*templates.TemplateShort)(nil), // 12: resources.documents.templates.TemplateShort
-	(*templates.TemplateData)(nil),  // 13: resources.documents.templates.TemplateData
-	(*templates.Template)(nil),      // 14: resources.documents.templates.Template
+	(*ListTemplatesRequest)(nil),        // 0: services.documents.ListTemplatesRequest
+	(*ListTemplatesResponse)(nil),       // 1: services.documents.ListTemplatesResponse
+	(*GetTemplateRequest)(nil),          // 2: services.documents.GetTemplateRequest
+	(*GetTemplateResponse)(nil),         // 3: services.documents.GetTemplateResponse
+	(*CreateTemplateRequest)(nil),       // 4: services.documents.CreateTemplateRequest
+	(*CreateTemplateResponse)(nil),      // 5: services.documents.CreateTemplateResponse
+	(*UpdateTemplateRequest)(nil),       // 6: services.documents.UpdateTemplateRequest
+	(*UpdateTemplateResponse)(nil),      // 7: services.documents.UpdateTemplateResponse
+	(*DeleteTemplateRequest)(nil),       // 8: services.documents.DeleteTemplateRequest
+	(*DeleteTemplateResponse)(nil),      // 9: services.documents.DeleteTemplateResponse
+	(*MoveTemplateRequest)(nil),         // 10: services.documents.MoveTemplateRequest
+	(*MoveTemplateResponse)(nil),        // 11: services.documents.MoveTemplateResponse
+	(*templates.TemplateShort)(nil),     // 12: resources.documents.templates.TemplateShort
+	(*templates.TemplateSelection)(nil), // 13: resources.documents.templates.TemplateSelection
+	(*templates.Template)(nil),          // 14: resources.documents.templates.Template
 }
 var file_services_documents_templates_proto_depIdxs = []int32{
 	12, // 0: services.documents.ListTemplatesResponse.templates:type_name -> resources.documents.templates.TemplateShort
-	13, // 1: services.documents.GetTemplateRequest.data:type_name -> resources.documents.templates.TemplateData
+	13, // 1: services.documents.GetTemplateRequest.selection:type_name -> resources.documents.templates.TemplateSelection
 	14, // 2: services.documents.GetTemplateResponse.template:type_name -> resources.documents.templates.Template
 	14, // 3: services.documents.CreateTemplateRequest.template:type_name -> resources.documents.templates.Template
 	14, // 4: services.documents.UpdateTemplateRequest.template:type_name -> resources.documents.templates.Template

--- a/gen/go/proto/services/documents/templates.pb.sanitizer.go
+++ b/gen/go/proto/services/documents/templates.pb.sanitizer.go
@@ -29,9 +29,9 @@ func (m *GetTemplateRequest) Sanitize() error {
 		return nil
 	}
 
-	// Field: Data
-	if m.Data != nil {
-		if v, ok := any(m.GetData()).(interface{ Sanitize() error }); ok {
+	// Field: Selection
+	if m.Selection != nil {
+		if v, ok := any(m.GetSelection()).(interface{ Sanitize() error }); ok {
 			if err := v.Sanitize(); err != nil {
 				return err
 			}

--- a/gen/go/proto/services/documents/templates_protoopaque.pb.go
+++ b/gen/go/proto/services/documents/templates_protoopaque.pb.go
@@ -128,10 +128,10 @@ func (b0 ListTemplatesResponse_builder) Build() *ListTemplatesResponse {
 }
 
 type GetTemplateRequest struct {
-	state                  protoimpl.MessageState  `protogen:"opaque.v1"`
-	xxx_hidden_TemplateId  int64                   `protobuf:"varint,1,opt,name=template_id,json=templateId,proto3"`
-	xxx_hidden_Data        *templates.TemplateData `protobuf:"bytes,2,opt,name=data,proto3,oneof"`
-	xxx_hidden_Render      bool                    `protobuf:"varint,3,opt,name=render,proto3,oneof"`
+	state                  protoimpl.MessageState       `protogen:"opaque.v1"`
+	xxx_hidden_TemplateId  int64                        `protobuf:"varint,1,opt,name=template_id,json=templateId,proto3"`
+	xxx_hidden_Render      bool                         `protobuf:"varint,3,opt,name=render,proto3,oneof"`
+	xxx_hidden_Selection   *templates.TemplateSelection `protobuf:"bytes,4,opt,name=selection,proto3,oneof"`
 	XXX_raceDetectHookData protoimpl.RaceDetectHookData
 	XXX_presence           [1]uint32
 	unknownFields          protoimpl.UnknownFields
@@ -170,13 +170,6 @@ func (x *GetTemplateRequest) GetTemplateId() int64 {
 	return 0
 }
 
-func (x *GetTemplateRequest) GetData() *templates.TemplateData {
-	if x != nil {
-		return x.xxx_hidden_Data
-	}
-	return nil
-}
-
 func (x *GetTemplateRequest) GetRender() bool {
 	if x != nil {
 		return x.xxx_hidden_Render
@@ -184,48 +177,55 @@ func (x *GetTemplateRequest) GetRender() bool {
 	return false
 }
 
+func (x *GetTemplateRequest) GetSelection() *templates.TemplateSelection {
+	if x != nil {
+		return x.xxx_hidden_Selection
+	}
+	return nil
+}
+
 func (x *GetTemplateRequest) SetTemplateId(v int64) {
 	x.xxx_hidden_TemplateId = v
 }
 
-func (x *GetTemplateRequest) SetData(v *templates.TemplateData) {
-	x.xxx_hidden_Data = v
-}
-
 func (x *GetTemplateRequest) SetRender(v bool) {
 	x.xxx_hidden_Render = v
-	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 2, 3)
+	protoimpl.X.SetPresent(&(x.XXX_presence[0]), 1, 3)
 }
 
-func (x *GetTemplateRequest) HasData() bool {
-	if x == nil {
-		return false
-	}
-	return x.xxx_hidden_Data != nil
+func (x *GetTemplateRequest) SetSelection(v *templates.TemplateSelection) {
+	x.xxx_hidden_Selection = v
 }
 
 func (x *GetTemplateRequest) HasRender() bool {
 	if x == nil {
 		return false
 	}
-	return protoimpl.X.Present(&(x.XXX_presence[0]), 2)
+	return protoimpl.X.Present(&(x.XXX_presence[0]), 1)
 }
 
-func (x *GetTemplateRequest) ClearData() {
-	x.xxx_hidden_Data = nil
+func (x *GetTemplateRequest) HasSelection() bool {
+	if x == nil {
+		return false
+	}
+	return x.xxx_hidden_Selection != nil
 }
 
 func (x *GetTemplateRequest) ClearRender() {
-	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 2)
+	protoimpl.X.ClearPresent(&(x.XXX_presence[0]), 1)
 	x.xxx_hidden_Render = false
+}
+
+func (x *GetTemplateRequest) ClearSelection() {
+	x.xxx_hidden_Selection = nil
 }
 
 type GetTemplateRequest_builder struct {
 	_ [0]func() // Prevents comparability and use of unkeyed literals for the builder.
 
 	TemplateId int64
-	Data       *templates.TemplateData
 	Render     *bool
+	Selection  *templates.TemplateSelection
 }
 
 func (b0 GetTemplateRequest_builder) Build() *GetTemplateRequest {
@@ -233,11 +233,11 @@ func (b0 GetTemplateRequest_builder) Build() *GetTemplateRequest {
 	b, x := &b0, m0
 	_, _ = b, x
 	x.xxx_hidden_TemplateId = b.TemplateId
-	x.xxx_hidden_Data = b.Data
 	if b.Render != nil {
-		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 2, 3)
+		protoimpl.X.SetPresentNonAtomic(&(x.XXX_presence[0]), 1, 3)
 		x.xxx_hidden_Render = *b.Render
 	}
+	x.xxx_hidden_Selection = b.Selection
 	return m0
 }
 
@@ -853,14 +853,15 @@ const file_services_documents_templates_proto_rawDesc = "" +
 	"\"services/documents/templates.proto\x12\x12services.documents\x1a\x1fcodegen/itemslen/itemslen.proto\x1a\x19codegen/perms/perms.proto\x1a-resources/documents/templates/templates.proto\"\x16\n" +
 	"\x14ListTemplatesRequest\"i\n" +
 	"\x15ListTemplatesResponse\x12P\n" +
-	"\ttemplates\x18\x01 \x03(\v2,.resources.documents.templates.TemplateShortB\x04\xc8\xf3\x18\x01R\ttemplates\"\xac\x01\n" +
+	"\ttemplates\x18\x01 \x03(\v2,.resources.documents.templates.TemplateShortB\x04\xc8\xf3\x18\x01R\ttemplates\"\xc6\x01\n" +
 	"\x12GetTemplateRequest\x12\x1f\n" +
 	"\vtemplate_id\x18\x01 \x01(\x03R\n" +
-	"templateId\x12D\n" +
-	"\x04data\x18\x02 \x01(\v2+.resources.documents.templates.TemplateDataH\x00R\x04data\x88\x01\x01\x12\x1b\n" +
-	"\x06render\x18\x03 \x01(\bH\x01R\x06render\x88\x01\x01B\a\n" +
-	"\x05_dataB\t\n" +
-	"\a_render\"v\n" +
+	"templateId\x12\x1b\n" +
+	"\x06render\x18\x03 \x01(\bH\x00R\x06render\x88\x01\x01\x12S\n" +
+	"\tselection\x18\x04 \x01(\v20.resources.documents.templates.TemplateSelectionH\x01R\tselection\x88\x01\x01B\t\n" +
+	"\a_renderB\f\n" +
+	"\n" +
+	"_selectionJ\x04\b\x02\x10\x03\"v\n" +
 	"\x13GetTemplateResponse\x12C\n" +
 	"\btemplate\x18\x01 \x01(\v2'.resources.documents.templates.TemplateR\btemplate\x12\x1a\n" +
 	"\brendered\x18\x02 \x01(\bR\brendered\"\\\n" +
@@ -894,25 +895,25 @@ const file_services_documents_templates_proto_rawDesc = "" +
 
 var file_services_documents_templates_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
 var file_services_documents_templates_proto_goTypes = []any{
-	(*ListTemplatesRequest)(nil),    // 0: services.documents.ListTemplatesRequest
-	(*ListTemplatesResponse)(nil),   // 1: services.documents.ListTemplatesResponse
-	(*GetTemplateRequest)(nil),      // 2: services.documents.GetTemplateRequest
-	(*GetTemplateResponse)(nil),     // 3: services.documents.GetTemplateResponse
-	(*CreateTemplateRequest)(nil),   // 4: services.documents.CreateTemplateRequest
-	(*CreateTemplateResponse)(nil),  // 5: services.documents.CreateTemplateResponse
-	(*UpdateTemplateRequest)(nil),   // 6: services.documents.UpdateTemplateRequest
-	(*UpdateTemplateResponse)(nil),  // 7: services.documents.UpdateTemplateResponse
-	(*DeleteTemplateRequest)(nil),   // 8: services.documents.DeleteTemplateRequest
-	(*DeleteTemplateResponse)(nil),  // 9: services.documents.DeleteTemplateResponse
-	(*MoveTemplateRequest)(nil),     // 10: services.documents.MoveTemplateRequest
-	(*MoveTemplateResponse)(nil),    // 11: services.documents.MoveTemplateResponse
-	(*templates.TemplateShort)(nil), // 12: resources.documents.templates.TemplateShort
-	(*templates.TemplateData)(nil),  // 13: resources.documents.templates.TemplateData
-	(*templates.Template)(nil),      // 14: resources.documents.templates.Template
+	(*ListTemplatesRequest)(nil),        // 0: services.documents.ListTemplatesRequest
+	(*ListTemplatesResponse)(nil),       // 1: services.documents.ListTemplatesResponse
+	(*GetTemplateRequest)(nil),          // 2: services.documents.GetTemplateRequest
+	(*GetTemplateResponse)(nil),         // 3: services.documents.GetTemplateResponse
+	(*CreateTemplateRequest)(nil),       // 4: services.documents.CreateTemplateRequest
+	(*CreateTemplateResponse)(nil),      // 5: services.documents.CreateTemplateResponse
+	(*UpdateTemplateRequest)(nil),       // 6: services.documents.UpdateTemplateRequest
+	(*UpdateTemplateResponse)(nil),      // 7: services.documents.UpdateTemplateResponse
+	(*DeleteTemplateRequest)(nil),       // 8: services.documents.DeleteTemplateRequest
+	(*DeleteTemplateResponse)(nil),      // 9: services.documents.DeleteTemplateResponse
+	(*MoveTemplateRequest)(nil),         // 10: services.documents.MoveTemplateRequest
+	(*MoveTemplateResponse)(nil),        // 11: services.documents.MoveTemplateResponse
+	(*templates.TemplateShort)(nil),     // 12: resources.documents.templates.TemplateShort
+	(*templates.TemplateSelection)(nil), // 13: resources.documents.templates.TemplateSelection
+	(*templates.Template)(nil),          // 14: resources.documents.templates.Template
 }
 var file_services_documents_templates_proto_depIdxs = []int32{
 	12, // 0: services.documents.ListTemplatesResponse.templates:type_name -> resources.documents.templates.TemplateShort
-	13, // 1: services.documents.GetTemplateRequest.data:type_name -> resources.documents.templates.TemplateData
+	13, // 1: services.documents.GetTemplateRequest.selection:type_name -> resources.documents.templates.TemplateSelection
 	14, // 2: services.documents.GetTemplateResponse.template:type_name -> resources.documents.templates.Template
 	14, // 3: services.documents.CreateTemplateRequest.template:type_name -> resources.documents.templates.Template
 	14, // 4: services.documents.UpdateTemplateRequest.template:type_name -> resources.documents.templates.Template

--- a/gen/grpc-api.md
+++ b/gen/grpc-api.md
@@ -4175,20 +4175,6 @@ Policy snapshot applied to a specific version
 
 
 
-### resources.documents.templates.TemplateData
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| `active_char` | [resources.users.User](#resourcesusersUser) |  |  |
-| `documents` | [resources.documents.DocumentShort](#resourcesdocumentsDocumentShort) | repeated |  |
-| `users` | [resources.users.short.UserShort](#resourcesusersshortUserShort) | repeated |  |
-| `vehicles` | [resources.vehicles.Vehicle](#resourcesvehiclesVehicle) | repeated |  |
-
-
-
-
-
 ### resources.documents.templates.TemplateRequirements
 
 
@@ -4208,6 +4194,19 @@ Policy snapshot applied to a specific version
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | `requirements` | [TemplateRequirements](#resourcesdocumentstemplatesTemplateRequirements) |  |  |
+
+
+
+
+
+### resources.documents.templates.TemplateSelection
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| `user_ids` | [int32](#int32) | repeated |  |
+| `document_ids` | [int64](#int64) | repeated |  |
+| `plates` | [string](#string) | repeated |  |
 
 
 
@@ -10139,7 +10138,7 @@ Upsert = insert missing PENDING tasks/slots; will NOT delete existing tasks. Ide
 | ----- | ---- | ----- | ----------- |
 | `content_type` | [resources.common.content.ContentType](#resourcescommoncontentContentType) |  |  |
 | `template_id` | [int64](#int64) | optional |  |
-| `template_data` | [resources.documents.templates.TemplateData](#resourcesdocumentstemplatesTemplateData) | optional |  |
+| `template_selection` | [resources.documents.templates.TemplateSelection](#resourcesdocumentstemplatesTemplateSelection) | optional |  |
 
 
 
@@ -10889,8 +10888,8 @@ Upsert = insert missing PENDING tasks/slots; will NOT delete existing tasks. Ide
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | `template_id` | [int64](#int64) |  |  |
-| `data` | [resources.documents.templates.TemplateData](#resourcesdocumentstemplatesTemplateData) | optional |  |
 | `render` | [bool](#bool) | optional |  |
+| `selection` | [resources.documents.templates.TemplateSelection](#resourcesdocumentstemplatesTemplateSelection) | optional |  |
 
 
 

--- a/gen/ts/resources/documents/templates/templates.ts
+++ b/gen/ts/resources/documents/templates/templates.ts
@@ -13,10 +13,6 @@ import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
 import { OnEditBehavior } from "../approval/approval";
 import { ApprovalRuleKind } from "../approval/approval";
-import { Vehicle } from "../../vehicles/vehicles";
-import { UserShort } from "../../users/short/user";
-import { DocumentShort } from "../documents";
-import { User } from "../../users/user";
 import { Workflow } from "../workflow/workflow";
 import { Access } from "../../access/access";
 import { JobAccess } from "../../access/access";
@@ -204,25 +200,21 @@ export interface ObjectSpecs {
     max?: number;
 }
 /**
- * @generated from protobuf message resources.documents.templates.TemplateData
+ * @generated from protobuf message resources.documents.templates.TemplateSelection
  */
-export interface TemplateData {
+export interface TemplateSelection {
     /**
-     * @generated from protobuf field: resources.users.User active_char = 1
+     * @generated from protobuf field: repeated int32 user_ids = 1
      */
-    activeChar?: User;
+    userIds: number[];
     /**
-     * @generated from protobuf field: repeated resources.documents.DocumentShort documents = 2
+     * @generated from protobuf field: repeated int64 document_ids = 2
      */
-    documents: DocumentShort[];
+    documentIds: number[];
     /**
-     * @generated from protobuf field: repeated resources.users.short.UserShort users = 3
+     * @generated from protobuf field: repeated string plates = 3
      */
-    users: UserShort[];
-    /**
-     * @generated from protobuf field: repeated resources.vehicles.Vehicle vehicles = 4
-     */
-    vehicles: Vehicle[];
+    plates: string[];
 }
 /**
  * @generated from protobuf message resources.documents.templates.TemplateApproval
@@ -794,40 +786,44 @@ class ObjectSpecs$Type extends MessageType<ObjectSpecs> {
  */
 export const ObjectSpecs = new ObjectSpecs$Type();
 // @generated message type with reflection information, may provide speed optimized methods
-class TemplateData$Type extends MessageType<TemplateData> {
+class TemplateSelection$Type extends MessageType<TemplateSelection> {
     constructor() {
-        super("resources.documents.templates.TemplateData", [
-            { no: 1, name: "active_char", kind: "message", T: () => User, options: { "buf.validate.field": { required: true } } },
-            { no: 2, name: "documents", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => DocumentShort, options: { "buf.validate.field": { repeated: { maxItems: "12" } } } },
-            { no: 3, name: "users", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => UserShort, options: { "buf.validate.field": { repeated: { maxItems: "12" } } } },
-            { no: 4, name: "vehicles", kind: "message", repeat: 2 /*RepeatType.UNPACKED*/, T: () => Vehicle, options: { "buf.validate.field": { repeated: { maxItems: "12" } } } }
+        super("resources.documents.templates.TemplateSelection", [
+            { no: 1, name: "user_ids", kind: "scalar", repeat: 1 /*RepeatType.PACKED*/, T: 5 /*ScalarType.INT32*/, options: { "buf.validate.field": { repeated: { maxItems: "12", items: { int32: { gt: 0 } } } } } },
+            { no: 2, name: "document_ids", kind: "scalar", repeat: 1 /*RepeatType.PACKED*/, T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/, options: { "buf.validate.field": { repeated: { maxItems: "12", items: { int64: { gt: "0" } } } } } },
+            { no: 3, name: "plates", kind: "scalar", repeat: 2 /*RepeatType.UNPACKED*/, T: 9 /*ScalarType.STRING*/, options: { "buf.validate.field": { repeated: { maxItems: "12", items: { string: { minLen: "1", maxLen: "32" } } } } } }
         ]);
     }
-    create(value?: PartialMessage<TemplateData>): TemplateData {
+    create(value?: PartialMessage<TemplateSelection>): TemplateSelection {
         const message = globalThis.Object.create((this.messagePrototype!));
-        message.documents = [];
-        message.users = [];
-        message.vehicles = [];
+        message.userIds = [];
+        message.documentIds = [];
+        message.plates = [];
         if (value !== undefined)
-            reflectionMergePartial<TemplateData>(this, message, value);
+            reflectionMergePartial<TemplateSelection>(this, message, value);
         return message;
     }
-    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TemplateData): TemplateData {
+    internalBinaryRead(reader: IBinaryReader, length: number, options: BinaryReadOptions, target?: TemplateSelection): TemplateSelection {
         let message = target ?? this.create(), end = reader.pos + length;
         while (reader.pos < end) {
             let [fieldNo, wireType] = reader.tag();
             switch (fieldNo) {
-                case /* resources.users.User active_char */ 1:
-                    message.activeChar = User.internalBinaryRead(reader, reader.uint32(), options, message.activeChar);
+                case /* repeated int32 user_ids */ 1:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.userIds.push(reader.int32());
+                    else
+                        message.userIds.push(reader.int32());
                     break;
-                case /* repeated resources.documents.DocumentShort documents */ 2:
-                    message.documents.push(DocumentShort.internalBinaryRead(reader, reader.uint32(), options));
+                case /* repeated int64 document_ids */ 2:
+                    if (wireType === WireType.LengthDelimited)
+                        for (let e = reader.int32() + reader.pos; reader.pos < e;)
+                            message.documentIds.push(reader.int64().toNumber());
+                    else
+                        message.documentIds.push(reader.int64().toNumber());
                     break;
-                case /* repeated resources.users.short.UserShort users */ 3:
-                    message.users.push(UserShort.internalBinaryRead(reader, reader.uint32(), options));
-                    break;
-                case /* repeated resources.vehicles.Vehicle vehicles */ 4:
-                    message.vehicles.push(Vehicle.internalBinaryRead(reader, reader.uint32(), options));
+                case /* repeated string plates */ 3:
+                    message.plates.push(reader.string());
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -840,19 +836,24 @@ class TemplateData$Type extends MessageType<TemplateData> {
         }
         return message;
     }
-    internalBinaryWrite(message: TemplateData, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
-        /* resources.users.User active_char = 1; */
-        if (message.activeChar)
-            User.internalBinaryWrite(message.activeChar, writer.tag(1, WireType.LengthDelimited).fork(), options).join();
-        /* repeated resources.documents.DocumentShort documents = 2; */
-        for (let i = 0; i < message.documents.length; i++)
-            DocumentShort.internalBinaryWrite(message.documents[i], writer.tag(2, WireType.LengthDelimited).fork(), options).join();
-        /* repeated resources.users.short.UserShort users = 3; */
-        for (let i = 0; i < message.users.length; i++)
-            UserShort.internalBinaryWrite(message.users[i], writer.tag(3, WireType.LengthDelimited).fork(), options).join();
-        /* repeated resources.vehicles.Vehicle vehicles = 4; */
-        for (let i = 0; i < message.vehicles.length; i++)
-            Vehicle.internalBinaryWrite(message.vehicles[i], writer.tag(4, WireType.LengthDelimited).fork(), options).join();
+    internalBinaryWrite(message: TemplateSelection, writer: IBinaryWriter, options: BinaryWriteOptions): IBinaryWriter {
+        /* repeated int32 user_ids = 1; */
+        if (message.userIds.length) {
+            writer.tag(1, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.userIds.length; i++)
+                writer.int32(message.userIds[i]);
+            writer.join();
+        }
+        /* repeated int64 document_ids = 2; */
+        if (message.documentIds.length) {
+            writer.tag(2, WireType.LengthDelimited).fork();
+            for (let i = 0; i < message.documentIds.length; i++)
+                writer.int64(message.documentIds[i]);
+            writer.join();
+        }
+        /* repeated string plates = 3; */
+        for (let i = 0; i < message.plates.length; i++)
+            writer.tag(3, WireType.LengthDelimited).string(message.plates[i]);
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);
@@ -860,9 +861,9 @@ class TemplateData$Type extends MessageType<TemplateData> {
     }
 }
 /**
- * @generated MessageType for protobuf message resources.documents.templates.TemplateData
+ * @generated MessageType for protobuf message resources.documents.templates.TemplateSelection
  */
-export const TemplateData = new TemplateData$Type();
+export const TemplateSelection = new TemplateSelection$Type();
 // @generated message type with reflection information, may provide speed optimized methods
 class TemplateApproval$Type extends MessageType<TemplateApproval> {
     constructor() {

--- a/gen/ts/services/documents/documents.ts
+++ b/gen/ts/services/documents/documents.ts
@@ -24,7 +24,7 @@ import { File } from "../../resources/file/file";
 import { DocumentMeta } from "../../resources/documents/documents";
 import { DocumentData } from "../../resources/documents/data/data";
 import { Content } from "../../resources/common/content/content";
-import { TemplateData } from "../../resources/documents/templates/templates";
+import { TemplateSelection } from "../../resources/documents/templates/templates";
 import { ContentType } from "../../resources/common/content/content";
 import { DocumentRelation } from "../../resources/documents/relations/relations";
 import { DocumentReference } from "../../resources/documents/references/references";
@@ -304,9 +304,9 @@ export interface CreateDocumentRequest {
      */
     templateId?: number;
     /**
-     * @generated from protobuf field: optional resources.documents.templates.TemplateData template_data = 3
+     * @generated from protobuf field: optional resources.documents.templates.TemplateSelection template_selection = 4
      */
-    templateData?: TemplateData;
+    templateSelection?: TemplateSelection;
 }
 /**
  * @generated from protobuf message services.documents.CreateDocumentResponse
@@ -1835,7 +1835,7 @@ class CreateDocumentRequest$Type extends MessageType<CreateDocumentRequest> {
         super("services.documents.CreateDocumentRequest", [
             { no: 1, name: "content_type", kind: "enum", T: () => ["resources.common.content.ContentType", ContentType, "CONTENT_TYPE_"], options: { "buf.validate.field": { enum: { definedOnly: true } } } },
             { no: 2, name: "template_id", kind: "scalar", opt: true, T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
-            { no: 3, name: "template_data", kind: "message", T: () => TemplateData }
+            { no: 4, name: "template_selection", kind: "message", T: () => TemplateSelection }
         ]);
     }
     create(value?: PartialMessage<CreateDocumentRequest>): CreateDocumentRequest {
@@ -1856,8 +1856,8 @@ class CreateDocumentRequest$Type extends MessageType<CreateDocumentRequest> {
                 case /* optional int64 template_id */ 2:
                     message.templateId = reader.int64().toNumber();
                     break;
-                case /* optional resources.documents.templates.TemplateData template_data */ 3:
-                    message.templateData = TemplateData.internalBinaryRead(reader, reader.uint32(), options, message.templateData);
+                case /* optional resources.documents.templates.TemplateSelection template_selection */ 4:
+                    message.templateSelection = TemplateSelection.internalBinaryRead(reader, reader.uint32(), options, message.templateSelection);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -1877,9 +1877,9 @@ class CreateDocumentRequest$Type extends MessageType<CreateDocumentRequest> {
         /* optional int64 template_id = 2; */
         if (message.templateId !== undefined)
             writer.tag(2, WireType.Varint).int64(message.templateId);
-        /* optional resources.documents.templates.TemplateData template_data = 3; */
-        if (message.templateData)
-            TemplateData.internalBinaryWrite(message.templateData, writer.tag(3, WireType.LengthDelimited).fork(), options).join();
+        /* optional resources.documents.templates.TemplateSelection template_selection = 4; */
+        if (message.templateSelection)
+            TemplateSelection.internalBinaryWrite(message.templateSelection, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/gen/ts/services/documents/templates.ts
+++ b/gen/ts/services/documents/templates.ts
@@ -13,7 +13,7 @@ import type { PartialMessage } from "@protobuf-ts/runtime";
 import { reflectionMergePartial } from "@protobuf-ts/runtime";
 import { MessageType } from "@protobuf-ts/runtime";
 import { Template } from "../../resources/documents/templates/templates";
-import { TemplateData } from "../../resources/documents/templates/templates";
+import { TemplateSelection } from "../../resources/documents/templates/templates";
 import { TemplateShort } from "../../resources/documents/templates/templates";
 /**
  * @generated from protobuf message services.documents.ListTemplatesRequest
@@ -38,13 +38,13 @@ export interface GetTemplateRequest {
      */
     templateId: number;
     /**
-     * @generated from protobuf field: optional resources.documents.templates.TemplateData data = 2
-     */
-    data?: TemplateData;
-    /**
      * @generated from protobuf field: optional bool render = 3
      */
     render?: boolean;
+    /**
+     * @generated from protobuf field: optional resources.documents.templates.TemplateSelection selection = 4
+     */
+    selection?: TemplateSelection;
 }
 /**
  * @generated from protobuf message services.documents.GetTemplateResponse
@@ -221,8 +221,8 @@ class GetTemplateRequest$Type extends MessageType<GetTemplateRequest> {
     constructor() {
         super("services.documents.GetTemplateRequest", [
             { no: 1, name: "template_id", kind: "scalar", T: 3 /*ScalarType.INT64*/, L: 2 /*LongType.NUMBER*/ },
-            { no: 2, name: "data", kind: "message", T: () => TemplateData },
-            { no: 3, name: "render", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ }
+            { no: 3, name: "render", kind: "scalar", opt: true, T: 8 /*ScalarType.BOOL*/ },
+            { no: 4, name: "selection", kind: "message", T: () => TemplateSelection }
         ]);
     }
     create(value?: PartialMessage<GetTemplateRequest>): GetTemplateRequest {
@@ -240,11 +240,11 @@ class GetTemplateRequest$Type extends MessageType<GetTemplateRequest> {
                 case /* int64 template_id */ 1:
                     message.templateId = reader.int64().toNumber();
                     break;
-                case /* optional resources.documents.templates.TemplateData data */ 2:
-                    message.data = TemplateData.internalBinaryRead(reader, reader.uint32(), options, message.data);
-                    break;
                 case /* optional bool render */ 3:
                     message.render = reader.bool();
+                    break;
+                case /* optional resources.documents.templates.TemplateSelection selection */ 4:
+                    message.selection = TemplateSelection.internalBinaryRead(reader, reader.uint32(), options, message.selection);
                     break;
                 default:
                     let u = options.readUnknownField;
@@ -261,12 +261,12 @@ class GetTemplateRequest$Type extends MessageType<GetTemplateRequest> {
         /* int64 template_id = 1; */
         if (message.templateId !== 0)
             writer.tag(1, WireType.Varint).int64(message.templateId);
-        /* optional resources.documents.templates.TemplateData data = 2; */
-        if (message.data)
-            TemplateData.internalBinaryWrite(message.data, writer.tag(2, WireType.LengthDelimited).fork(), options).join();
         /* optional bool render = 3; */
         if (message.render !== undefined)
             writer.tag(3, WireType.Varint).bool(message.render);
+        /* optional resources.documents.templates.TemplateSelection selection = 4; */
+        if (message.selection)
+            TemplateSelection.internalBinaryWrite(message.selection, writer.tag(4, WireType.LengthDelimited).fork(), options).join();
         let u = options.writeUnknownFields;
         if (u !== false)
             (u == true ? UnknownFieldHandler.onWrite : u)(this.typeName, message, writer);

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -3172,9 +3172,30 @@
                     "title": "Ansichtszugriff verweigert",
                     "content": "Sie haben keine Rechte die Zugangsinfo des Dokumentes zu sehen!"
                 },
-                "ErrTemplateFailed": {
+                "ErrTemplateRequirementsNotMet": {
+                    "title": "Vorlagenanforderungen nicht erfüllt",
+                    "content": "Diese Vorlage benötigt mindestens {required} {kind}, aber {available} wurden ausgewählt. Bitte wähle weitere aus und versuche es erneut."
+                },
+                "ErrTemplateRequirementsExceeded": {
+                    "title": "Zu viele Daten ausgewählt",
+                    "content": "Diese Vorlage erlaubt höchstens {required} {kind}, aber {available} wurden ausgewählt. Bitte entferne einige und versuche es erneut."
+                },
+                "ErrTemplateRenderFailed": {
                     "title": "Vorlage konnte nicht gerendert werden",
-                    "content": "Fehler beim Laden der Dokumenten Vorlage! Bitte spreche deine Fraktionsführung darauf an."
+                    "content": "Die Dokumentvorlage konnte nicht gerendert werden. Bitte versuche es erneut oder wende dich an den Ersteller der Vorlage."
+                },
+                "ErrTemplateInvalid": {
+                    "title": "Ungültige Dokumentvorlage",
+                    "content": "Diese Dokumentvorlage enthält ein ungültiges Feld oder einen ungültigen Formatierungsausdruck. Bitte wende dich an den Ersteller der Vorlage."
+                },
+                "ErrTemplateOutputInvalid": {
+                    "title": "Ungültige Vorlagenausgabe",
+                    "content": "Diese Vorlage hat Inhalte erzeugt, die nicht in ein Dokument umgewandelt werden konnten. Bitte wende dich an den Ersteller der Vorlage."
+                },
+                "TemplateKinds": {
+                    "users": "Bürger",
+                    "documents": "Dokumente",
+                    "vehicles": "Fahrzeuge"
                 },
                 "ErrDocViewDenied": "Sie haben keinen Zugriff auf das Dokument!",
                 "ErrDocUpdateDenied": "Sie dürfen das Dokument nicht bearbeiten!",

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -2307,6 +2307,10 @@
             "email_address_copied": {
                 "title": "E-Mail Adresse kopiert",
                 "content": "E-Mail Adresse wurde in die Zwischenablage kopiert."
+            },
+            "limit_reached": {
+                "title": "Zwischenablagenlimit erreicht",
+                "content": "Du kannst höchstens 12 Einträge jedes Typs in deiner Zwischenablage haben."
             }
         },
         "category_deleted": {

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1014,6 +1014,9 @@
                     "template_block": {
                         "title": "Vorlage-Logik-Block",
                         "insert_block": "Block einfügen",
+                        "insert_end": "{end} Block einfügen",
+                        "close_info": "Bedingungen, Schleifen und andere Vorlagenlogik müssen ebenfalls mit einem {end}-Block geschlossen werden.",
+                        "invalid": "Dieser Logik-Block hat eine ungültige Form. Verwende einen Ausdruck mit range, if oder with; else allein oder else if mit einem Ausdruck; oder break, continue bzw. end allein.",
                         "block_placeholder": {
                             "empty": "Zuerst einen Block auswählen",
                             "select": "E.g., .Vehicles"

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -3172,9 +3172,30 @@
                     "title": "View access denied",
                     "content": "You don't have permission to view this document's access!"
                 },
-                "ErrTemplateFailed": {
-                    "title": "Template render failed",
-                    "content": "Failed to render document template! Please talk with your faction leader."
+                "ErrTemplateRequirementsNotMet": {
+                    "title": "Template requirements not met",
+                    "content": "This template requires at least {required} {kind}, but {available} were selected. Please select more and try again."
+                },
+                "ErrTemplateRequirementsExceeded": {
+                    "title": "Too much data selected",
+                    "content": "This template allows at most {required} {kind}, but {available} were selected. Please remove some and try again."
+                },
+                "ErrTemplateRenderFailed": {
+                    "title": "Template rendering failed",
+                    "content": "The document template could not be rendered. Please try again or contact the template owner."
+                },
+                "ErrTemplateInvalid": {
+                    "title": "Invalid document template",
+                    "content": "This document template contains an invalid field or formatting expression. Please contact the template owner."
+                },
+                "ErrTemplateOutputInvalid": {
+                    "title": "Invalid template output",
+                    "content": "This template produced content that could not be turned into a document. Please contact the template owner."
+                },
+                "TemplateKinds": {
+                    "users": "citizens",
+                    "documents": "documents",
+                    "vehicles": "vehicles"
                 },
                 "ErrDocViewDenied": "You don't have permission to view this document!",
                 "ErrDocUpdateDenied": "You don't have permission to edit this document!",

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -2307,6 +2307,10 @@
             "email_address_copied": {
                 "title": "E-Mail address copied",
                 "content": "E-Mail address has been copied to your clipboard."
+            },
+            "limit_reached": {
+                "title": "Clipboard limit reached",
+                "content": "You can only have up to 12 items of each type in your clipboard."
             }
         },
         "category_deleted": {

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1014,6 +1014,9 @@
                     "template_block": {
                         "title": "Template Logic Block",
                         "insert_block": "Insert Block",
+                        "insert_end": "Insert {end} block",
+                        "close_info": "Conditions, loops, and other template logic must also be closed again with a {end} block.",
+                        "invalid": "This block action has an invalid shape. Use an expression with range, if, or with; else alone or else if with an expression; or break, continue, or end alone.",
                         "block_placeholder": {
                             "empty": "Pick a block first...",
                             "select": "e.g. .Items"

--- a/pkg/dbsync/syncers/users.go
+++ b/pkg/dbsync/syncers/users.go
@@ -409,7 +409,8 @@ func (s *UsersSync) applyFiltersAndTransformations(
 			us = slices.Delete(us, idx, idx+1)
 			continue
 		}
-		if s.cfg.Tables.Users.IgnoreEmptyName && user.GetFirstname() == "" && user.GetLastname() == "" {
+		if s.cfg.Tables.Users.IgnoreEmptyName && user.GetFirstname() == "" &&
+			user.GetLastname() == "" {
 			us = slices.Delete(us, idx, idx+1)
 			continue
 		}

--- a/pkg/demo/seed_catalog.go
+++ b/pkg/demo/seed_catalog.go
@@ -297,13 +297,15 @@ func (d *Demo) upsertDemoLawbooks(ctx context.Context) error {
 			if _, err := tLawbooks.UPDATE(
 				tLawbooks.Name, tLawbooks.Description, tLawbooks.DeletedAt,
 			).SET(lawbook.Name, lawbook.Description, mysql.NULL).
-				WHERE(tLawbooks.ID.EQ(mysql.Int64(existing.ID))).LIMIT(1).ExecContext(ctx, d.db); err != nil {
+				WHERE(tLawbooks.ID.EQ(mysql.Int64(existing.ID))).
+				LIMIT(1).ExecContext(ctx, d.db); err != nil {
 				return fmt.Errorf("failed to update demo lawbook. %w", err)
 			}
 			continue
 		}
 		if _, err := tLawbooks.INSERT(tLawbooks.ID, tLawbooks.Name, tLawbooks.Description).
-			VALUES(lawbook.ID, lawbook.Name, lawbook.Description).ExecContext(ctx, d.db); err != nil {
+			VALUES(lawbook.ID, lawbook.Name, lawbook.Description).
+			ExecContext(ctx, d.db); err != nil {
 			return fmt.Errorf("failed to insert demo lawbook. %w", err)
 		}
 	}
@@ -346,8 +348,14 @@ func (d *Demo) upsertDemoLaws(ctx context.Context) error {
 			continue
 		}
 		if _, err := tLawbooksLaws.INSERT(
-			tLawbooksLaws.ID, tLawbooksLaws.LawbookID, tLawbooksLaws.Name, tLawbooksLaws.Description,
-			tLawbooksLaws.Hint, tLawbooksLaws.Fine, tLawbooksLaws.DetentionTime, tLawbooksLaws.StvoPoints,
+			tLawbooksLaws.ID,
+			tLawbooksLaws.LawbookID,
+			tLawbooksLaws.Name,
+			tLawbooksLaws.Description,
+			tLawbooksLaws.Hint,
+			tLawbooksLaws.Fine,
+			tLawbooksLaws.DetentionTime,
+			tLawbooksLaws.StvoPoints,
 		).VALUES(
 			law.ID, law.LawbookID, law.Name, law.Description, law.Hint, law.Fine,
 			law.DetentionTime, law.StvoPoints,

--- a/proto/resources/documents/templates/templates.proto
+++ b/proto/resources/documents/templates/templates.proto
@@ -6,15 +6,10 @@ import "buf/validate/validate.proto";
 import "codegen/dbscanner/dbscanner.proto";
 import "codegen/sanitizer/sanitizer.proto";
 import "resources/access/access.proto";
-import "resources/documents/access/access.proto";
 import "resources/documents/approval/approval.proto";
 import "resources/documents/category/category.proto";
-import "resources/documents/documents.proto";
 import "resources/documents/workflow/workflow.proto";
 import "resources/timestamp/timestamp.proto";
-import "resources/users/short/user.proto";
-import "resources/users/user.proto";
-import "resources/vehicles/vehicles.proto";
 import "tagger/tagger.proto";
 
 option go_package = "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/templates;documentstemplates";
@@ -141,15 +136,24 @@ message ObjectSpecs {
 message TemplateSelection {
   repeated int32 user_ids = 1 [(buf.validate.field).repeated = {
     max_items: 12
-    items: {int32: {gt: 0}}
+    items: {
+      int32: {gt: 0}
+    }
   }];
   repeated int64 document_ids = 2 [(buf.validate.field).repeated = {
     max_items: 12
-    items: {int64: {gt: 0}}
+    items: {
+      int64: {gt: 0}
+    }
   }];
   repeated string plates = 3 [(buf.validate.field).repeated = {
     max_items: 12
-    items: {string: {min_len: 1, max_len: 32}}
+    items: {
+      string: {
+        min_len: 1
+        max_len: 32
+      }
+    }
   }];
 }
 

--- a/proto/resources/documents/templates/templates.proto
+++ b/proto/resources/documents/templates/templates.proto
@@ -138,11 +138,19 @@ message ObjectSpecs {
   optional int32 max = 3;
 }
 
-message TemplateData {
-  resources.users.User active_char = 1 [(buf.validate.field).required = true];
-  repeated resources.documents.DocumentShort documents = 2 [(buf.validate.field).repeated.max_items = 12];
-  repeated resources.users.short.UserShort users = 3 [(buf.validate.field).repeated.max_items = 12];
-  repeated resources.vehicles.Vehicle vehicles = 4 [(buf.validate.field).repeated.max_items = 12];
+message TemplateSelection {
+  repeated int32 user_ids = 1 [(buf.validate.field).repeated = {
+    max_items: 12
+    items: {int32: {gt: 0}}
+  }];
+  repeated int64 document_ids = 2 [(buf.validate.field).repeated = {
+    max_items: 12
+    items: {int64: {gt: 0}}
+  }];
+  repeated string plates = 3 [(buf.validate.field).repeated = {
+    max_items: 12
+    items: {string: {min_len: 1, max_len: 32}}
+  }];
 }
 
 message TemplateApproval {

--- a/proto/services/documents/documents.proto
+++ b/proto/services/documents/documents.proto
@@ -140,7 +140,8 @@ message ChangeDocumentOwnerResponse {}
 message CreateDocumentRequest {
   resources.common.content.ContentType content_type = 1 [(buf.validate.field).enum.defined_only = true];
   optional int64 template_id = 2;
-  optional resources.documents.templates.TemplateData template_data = 3;
+  reserved 3;
+  optional resources.documents.templates.TemplateSelection template_selection = 4;
 }
 
 message CreateDocumentResponse {

--- a/proto/services/documents/templates.proto
+++ b/proto/services/documents/templates.proto
@@ -17,8 +17,9 @@ message ListTemplatesResponse {
 
 message GetTemplateRequest {
   int64 template_id = 1;
-  optional resources.documents.templates.TemplateData data = 2;
   optional bool render = 3;
+  reserved 2;
+  optional resources.documents.templates.TemplateSelection selection = 4;
 }
 
 message GetTemplateResponse {

--- a/services/documents/documents.go
+++ b/services/documents/documents.go
@@ -310,6 +310,7 @@ func (s *Server) CreateDocument(
 	docRelations := []*documentsrelations.DocumentRelation{}
 
 	var tmpl *documentstemplates.Template
+	var resolvedData *resolvedTemplateData
 	if req.GetTemplateId() > 0 {
 		var err error
 		tmpl, err = s.store.GetTemplate(ctx, req.GetTemplateId(), false)
@@ -318,15 +319,19 @@ func (s *Server) CreateDocument(
 		}
 
 		var tplContent string
-		docTitle, docState, tplContent, err = s.renderTemplate(tmpl, req.GetTemplateData())
+		resolvedData, err = s.resolveTemplateData(ctx, tmpl, req.GetTemplateSelection(), userInfo)
 		if err != nil {
-			return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
+			return nil, templateResolutionError(err)
+		}
+		docTitle, docState, tplContent, err = s.renderTemplate(tmpl, resolvedData)
+		if err != nil {
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateInvalid)
 		}
 
 		// Build Content object
 		htmlNode, err := content.FromHTML(tplContent)
 		if err != nil {
-			return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateOutputInvalid)
 		}
 		docContent = &content.Content{
 			Version:     content.ContentVersionLegacyJSONV1,
@@ -347,9 +352,9 @@ func (s *Server) CreateDocument(
 		}
 
 		// Add references from template data documents if not already present
-		if tmpl != nil && req.GetTemplateData() != nil {
-			if len(req.GetTemplateData().GetDocuments()) > 0 {
-				for _, doc := range req.GetTemplateData().GetDocuments() {
+		if tmpl != nil && resolvedData != nil {
+			if len(resolvedData.Documents) > 0 {
+				for _, doc := range resolvedData.Documents {
 					if doc == nil {
 						continue
 					}
@@ -380,8 +385,8 @@ func (s *Server) CreateDocument(
 			}
 
 			// Add relations from template data users if not already present
-			if len(req.GetTemplateData().GetUsers()) > 0 {
-				for _, user := range req.GetTemplateData().GetUsers() {
+			if len(resolvedData.Users) > 0 {
+				for _, user := range resolvedData.Users {
 					exists := false
 					for _, relation := range docRelations {
 						if relation.GetTargetUserId() == user.GetUserId() {

--- a/services/documents/documents.go
+++ b/services/documents/documents.go
@@ -321,7 +321,7 @@ func (s *Server) CreateDocument(
 		var tplContent string
 		resolvedData, err = s.resolveTemplateData(ctx, tmpl, req.GetTemplateSelection(), userInfo)
 		if err != nil {
-			return nil, templateResolutionError(err)
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateRenderFailed)
 		}
 		docTitle, docState, tplContent, err = s.renderTemplate(tmpl, resolvedData)
 		if err != nil {

--- a/services/documents/errors/errors.go
+++ b/services/documents/errors/errors.go
@@ -87,10 +87,38 @@ var (
 		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrDocAccessInvalid.title"},
 	)
 
-	ErrTemplateFailed = common.NewI18nErr(
+	ErrTemplateRequirementsNotMet = common.NewI18nErrFunc(
 		codes.InvalidArgument,
-		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateFailed.content"},
-		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateFailed.title"},
+		&common.I18NItem{
+			Key: "errors.documents.DocumentsService.ErrTemplateRequirementsNotMet.content",
+		},
+		&common.I18NItem{
+			Key: "errors.documents.DocumentsService.ErrTemplateRequirementsNotMet.title",
+		},
+	)
+	ErrTemplateRequirementsExceeded = common.NewI18nErrFunc(
+		codes.InvalidArgument,
+		&common.I18NItem{
+			Key: "errors.documents.DocumentsService.ErrTemplateRequirementsExceeded.content",
+		},
+		&common.I18NItem{
+			Key: "errors.documents.DocumentsService.ErrTemplateRequirementsExceeded.title",
+		},
+	)
+	ErrTemplateRenderFailed = common.NewI18nErr(
+		codes.InvalidArgument,
+		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateRenderFailed.content"},
+		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateRenderFailed.title"},
+	)
+	ErrTemplateInvalid = common.NewI18nErr(
+		codes.InvalidArgument,
+		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateInvalid.content"},
+		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateInvalid.title"},
+	)
+	ErrTemplateOutputInvalid = common.NewI18nErr(
+		codes.InvalidArgument,
+		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateOutputInvalid.content"},
+		&common.I18NItem{Key: "errors.documents.DocumentsService.ErrTemplateOutputInvalid.title"},
 	)
 	ErrDocRequiredAccessTemplate = common.NewI18nErr(
 		codes.InvalidArgument,

--- a/services/documents/server.go
+++ b/services/documents/server.go
@@ -23,7 +23,9 @@ import (
 	"github.com/fivenet-app/fivenet/v2026/pkg/storage"
 	"github.com/fivenet-app/fivenet/v2026/pkg/userinfo"
 	"github.com/fivenet-app/fivenet/v2026/query/fivenet/table"
+	citizensstore "github.com/fivenet-app/fivenet/v2026/stores/citizens"
 	documentsstore "github.com/fivenet-app/fivenet/v2026/stores/documents"
+	vehiclesstore "github.com/fivenet-app/fivenet/v2026/stores/vehicles"
 	"github.com/go-jet/jet/v2/mysql"
 	tracesdk "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
@@ -134,6 +136,8 @@ type Server struct {
 	ui            userinfo.UserInfoRetriever
 	notifi        notifi.INotifi
 	store         documentsstore.IStore
+	citizensStore citizensstore.IStore
+	vehiclesStore vehiclesstore.IStore
 
 	subjectAccess   *access.DocumentsObjectAccess
 	subjectResolver *access.SubjectResolver
@@ -164,6 +168,8 @@ type Params struct {
 	JS                 *events.JSWrapper
 	Stats              *docstats.Service
 	Store              documentsstore.IStore
+	CitizensStore      citizensstore.IStore
+	VehiclesStore      vehiclesstore.IStore
 	SubjectAccess      *access.DocumentsObjectAccess
 	TemplateAccess     *access.DocumentTemplatesObjectAccess
 	SigningStampAccess *access.DocumentStampsObjectAccess
@@ -216,6 +222,8 @@ func NewServer(p Params) Result {
 		ui:            p.Ui,
 		notifi:        p.Notif,
 		store:         p.Store,
+		citizensStore: p.CitizensStore,
+		vehiclesStore: p.VehiclesStore,
 
 		subjectAccess:   p.SubjectAccess,
 		subjectResolver: docSubjectResolver,

--- a/services/documents/templates.go
+++ b/services/documents/templates.go
@@ -9,20 +9,34 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	resourcesaccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/access"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/audit"
+	database "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/common/database"
+	resourcesdocuments "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents"
 	documentsaccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/access"
 	documentstemplates "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/templates"
+	jobscolleagues "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/jobs/colleagues"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/timestamp"
 	"github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/userinfo"
+	users "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
+	resourcesvehicles "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/vehicles"
+	pbcitizens "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/citizens"
+	permscitizens "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/citizens/perms"
 	pbdocuments "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/documents"
-	permsdocuments "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/documents/perms"
+	permsvehicles "github.com/fivenet-app/fivenet/v2026/gen/go/proto/services/vehicles/perms"
 	"github.com/fivenet-app/fivenet/v2026/pkg/access"
 	"github.com/fivenet-app/fivenet/v2026/pkg/dbutils"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/auth"
 	"github.com/fivenet-app/fivenet/v2026/pkg/grpc/errswrap"
 	grpc_audit "github.com/fivenet-app/fivenet/v2026/pkg/grpc/interceptors/audit"
+	"github.com/fivenet-app/fivenet/v2026/pkg/perms"
 	errorsdocuments "github.com/fivenet-app/fivenet/v2026/services/documents/errors"
+	citizensstore "github.com/fivenet-app/fivenet/v2026/stores/citizens"
+	documentsstore "github.com/fivenet-app/fivenet/v2026/stores/documents"
+	usersstore "github.com/fivenet-app/fivenet/v2026/stores/users"
+	vehiclesstore "github.com/fivenet-app/fivenet/v2026/stores/vehicles"
 	"github.com/go-jet/jet/v2/qrm"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var templateSubjectAccessOptions = access.SubjectAccessOptions{
@@ -156,20 +170,17 @@ func (s *Server) GetTemplate(
 		if err := s.sanitizeTemplateAccess(resp.GetTemplate(), true, true); err != nil {
 			return nil, errswrap.NewError(err, errorsdocuments.ErrFailedQuery)
 		}
-	} else if req.Render != nil && req.GetRender() && req.GetData() != nil {
+	} else if req.Render != nil && req.GetRender() && req.GetSelection() != nil {
+		data, err := s.resolveTemplateData(ctx, resp.GetTemplate(), req.GetSelection(), userInfo)
+		if err != nil {
+			return nil, templateResolutionError(err)
+		}
 		resp.Template.ContentTitle, resp.Template.State, resp.Template.Content, err = s.renderTemplate(
 			resp.GetTemplate(),
-			req.GetData(),
+			data,
 		)
 		if err != nil {
-			if s.ps.Can(
-				userInfo,
-				permsdocuments.TemplatesService.CreateTemplate.Perm,
-			) {
-				return nil, err
-			} else {
-				return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateFailed)
-			}
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateInvalid)
 		}
 
 		resp.Rendered = true
@@ -180,9 +191,225 @@ func (s *Server) GetTemplate(
 	return resp, nil
 }
 
+type resolvedTemplateData struct {
+	ActiveChar *jobscolleagues.Colleague
+	Documents  []*resourcesdocuments.DocumentShort
+	Users      []*users.User
+	Vehicles   []*resourcesvehicles.Vehicle
+}
+
+func (s *Server) resolveTemplateData(
+	ctx context.Context,
+	tmpl *documentstemplates.Template,
+	selection *documentstemplates.TemplateSelection,
+	userInfo *userinfo.UserInfo,
+) (*resolvedTemplateData, error) {
+	activeChar, err := usersstore.RetrieveColleagueById(ctx, s.db, s.enricher, userInfo.GetUserId())
+	if err != nil {
+		return nil, err
+	}
+	if len(activeChar) == 0 || activeChar[0] == nil {
+		return nil, errors.New("active character could not be resolved")
+	}
+
+	fields, err := permscitizens.CitizensService.ListCitizens.FieldsTyped.Get(s.ps, userInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	data := &resolvedTemplateData{
+		ActiveChar: activeChar[0],
+	}
+	if selection == nil {
+		return data, validateTemplateRequirements(tmpl, data)
+	}
+
+	if len(selection.GetUserIds()) > 0 {
+		pageSize := int64(len(selection.GetUserIds()))
+		citizensReq := &pbcitizens.ListCitizensRequest{Pagination: &database.PaginationRequest{}}
+		citizensReq.GetPagination().SetPageSize(pageSize)
+
+		listOptions := citizensListOptions(fields)
+		listOptions.UserIDs = selection.GetUserIds()
+
+		usersResp, err := s.citizensStore.ListCitizens(ctx, citizensReq, listOptions)
+		if err != nil {
+			return nil, err
+		}
+
+		byID := make(map[int32]*users.User, len(usersResp.GetUsers()))
+		for _, user := range usersResp.GetUsers() {
+			s.enricher.EnrichJobInfoSafe(userInfo, user)
+			byID[user.GetUserId()] = user
+		}
+		seen := make(map[int32]struct{}, len(selection.GetUserIds()))
+		for _, id := range selection.GetUserIds() {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			if user := byID[id]; user != nil {
+				data.Users = append(data.Users, user)
+			}
+		}
+	}
+
+	if len(selection.GetDocumentIds()) > 0 {
+		docs, err := s.store.List(ctx, documentsstore.ListQuery{
+			DocumentIDs: selection.GetDocumentIds(),
+			Limit:       int64(len(selection.GetDocumentIds())),
+			IncludePhoneNumber: fields.Contains(
+				permscitizens.CitizensServiceListCitizensFieldsPermValuePhoneNumber,
+			),
+			UserInfo: userInfo,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		byID := make(map[int64]*resourcesdocuments.DocumentShort, len(docs))
+		for _, doc := range docs {
+			byID[doc.GetId()] = doc
+		}
+		seen := make(map[int64]struct{}, len(selection.GetDocumentIds()))
+		for _, id := range selection.GetDocumentIds() {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			if doc := byID[id]; doc != nil {
+				data.Documents = append(data.Documents, doc)
+			}
+		}
+	}
+
+	vehicleFields, err := permsvehicles.VehiclesService.ListVehicles.FieldsTyped.Get(s.ps, userInfo)
+	if err != nil {
+		return nil, err
+	}
+	if len(selection.GetPlates()) > 0 {
+		vehicles, err := s.vehiclesStore.List(ctx, vehiclesstore.ListQuery{
+			Plates: selection.GetPlates(),
+			Limit:  int64(len(selection.GetPlates())),
+			IncludePhoneNumber: fields.Contains(
+				permscitizens.CitizensServiceListCitizensFieldsPermValuePhoneNumber,
+			),
+			IncludePropsUpdated: vehicleFields.Len() > 0,
+			IncludeWantedFields: vehicleFields.Contains(
+				permsvehicles.VehiclesServiceListVehiclesFieldsPermValueWanted,
+			) ||
+				userInfo.GetJobAdmin(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		byPlate := make(map[string]*resourcesvehicles.Vehicle, len(vehicles))
+		for _, vehicle := range vehicles {
+			byPlate[vehicle.GetPlate()] = vehicle
+		}
+		seen := make(map[string]struct{}, len(selection.GetPlates()))
+		for _, plate := range selection.GetPlates() {
+			if _, ok := seen[plate]; ok {
+				continue
+			}
+			seen[plate] = struct{}{}
+			if vehicle := byPlate[plate]; vehicle != nil {
+				data.Vehicles = append(data.Vehicles, vehicle)
+			}
+		}
+	}
+
+	return data, validateTemplateRequirements(tmpl, data)
+}
+
+func citizensListOptions(
+	fields *perms.TypedStringList[permscitizens.CitizensServiceListCitizensFieldsPermValue],
+) citizensstore.ListCitizensOptions {
+	return citizensstore.ListCitizensOptions{
+		IncludePhoneNumber: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValuePhoneNumber,
+		),
+		IncludeWanted: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsWanted,
+		),
+		IncludeJob: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsJob,
+		),
+		IncludeTrafficInfractionPoints: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsTrafficInfractionPoints,
+		),
+		IncludeOpenFines: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsOpenFines,
+		),
+		IncludeBloodType: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsBloodType,
+		),
+		IncludeMugshot: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsMugshot,
+		),
+		IncludeEmail: fields.Contains(
+			permscitizens.CitizensServiceListCitizensFieldsPermValueUserPropsEmail,
+		),
+	}
+}
+
+func validateTemplateRequirements(
+	tmpl *documentstemplates.Template,
+	data *resolvedTemplateData,
+) error {
+	reqs := tmpl.GetSchema().GetRequirements()
+	checks := []struct {
+		spec  *documentstemplates.ObjectSpecs
+		kind  string
+		count int
+	}{
+		{reqs.GetUsers(), "users", len(data.Users)},
+		{reqs.GetDocuments(), "documents", len(data.Documents)},
+		{reqs.GetVehicles(), "vehicles", len(data.Vehicles)},
+	}
+	for _, check := range checks {
+		if check.spec == nil {
+			continue
+		}
+		if check.spec.GetRequired() && check.count == 0 {
+			return errorsdocuments.ErrTemplateRequirementsNotMet(map[string]any{
+				"kind":      check.kind,
+				"required":  1,
+				"available": check.count,
+			})
+		}
+		if check.spec.GetMin() > 0 && int64(check.count) < int64(check.spec.GetMin()) {
+			return errorsdocuments.ErrTemplateRequirementsNotMet(map[string]any{
+				"kind":      check.kind,
+				"required":  check.spec.GetMin(),
+				"available": check.count,
+			})
+		}
+		if check.spec.GetMax() > 0 && int64(check.count) > int64(check.spec.GetMax()) {
+			return errorsdocuments.ErrTemplateRequirementsExceeded(map[string]any{
+				"kind":      check.kind,
+				"required":  check.spec.GetMax(),
+				"available": check.count,
+			})
+		}
+	}
+	return nil
+}
+
+func templateResolutionError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if status.Code(err) == codes.InvalidArgument {
+		return err
+	}
+	return errswrap.NewError(err, errorsdocuments.ErrTemplateDataUnavailable)
+}
+
 func (s *Server) renderTemplate(
 	docTmpl *documentstemplates.Template,
-	data *documentstemplates.TemplateData,
+	data *resolvedTemplateData,
 ) (string, string, string, error) {
 	// Render Title template
 	titleTpl, err := template.

--- a/services/documents/templates.go
+++ b/services/documents/templates.go
@@ -35,9 +35,15 @@ import (
 	vehiclesstore "github.com/fivenet-app/fivenet/v2026/stores/vehicles"
 	"github.com/go-jet/jet/v2/qrm"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
+
+const (
+	kindKey      = "kind"
+	requiredKey  = "required"
+	availableKey = "available"
+)
+
+var ErrTemplateActiveChar = errors.New("failed to resolve active character/user")
 
 var templateSubjectAccessOptions = access.SubjectAccessOptions{
 	BlockedAccess: int32(documentsaccess.AccessLevel_ACCESS_LEVEL_BLOCKED),
@@ -173,7 +179,7 @@ func (s *Server) GetTemplate(
 	} else if req.Render != nil && req.GetRender() && req.GetSelection() != nil {
 		data, err := s.resolveTemplateData(ctx, resp.GetTemplate(), req.GetSelection(), userInfo)
 		if err != nil {
-			return nil, templateResolutionError(err)
+			return nil, err
 		}
 		resp.Template.ContentTitle, resp.Template.State, resp.Template.Content, err = s.renderTemplate(
 			resp.GetTemplate(),
@@ -209,12 +215,15 @@ func (s *Server) resolveTemplateData(
 		return nil, err
 	}
 	if len(activeChar) == 0 || activeChar[0] == nil {
-		return nil, errors.New("active character could not be resolved")
+		return nil, errswrap.NewError(
+			ErrTemplateActiveChar,
+			errorsdocuments.ErrTemplateRenderFailed,
+		)
 	}
 
 	fields, err := permscitizens.CitizensService.ListCitizens.FieldsTyped.Get(s.ps, userInfo)
 	if err != nil {
-		return nil, err
+		return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateRenderFailed)
 	}
 
 	data := &resolvedTemplateData{
@@ -234,7 +243,7 @@ func (s *Server) resolveTemplateData(
 
 		usersResp, err := s.citizensStore.ListCitizens(ctx, citizensReq, listOptions)
 		if err != nil {
-			return nil, err
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateRenderFailed)
 		}
 
 		byID := make(map[int32]*users.User, len(usersResp.GetUsers()))
@@ -264,7 +273,7 @@ func (s *Server) resolveTemplateData(
 			UserInfo: userInfo,
 		})
 		if err != nil {
-			return nil, err
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateRenderFailed)
 		}
 
 		byID := make(map[int64]*resourcesdocuments.DocumentShort, len(docs))
@@ -285,7 +294,7 @@ func (s *Server) resolveTemplateData(
 
 	vehicleFields, err := permsvehicles.VehiclesService.ListVehicles.FieldsTyped.Get(s.ps, userInfo)
 	if err != nil {
-		return nil, err
+		return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateRenderFailed)
 	}
 	if len(selection.GetPlates()) > 0 {
 		vehicles, err := s.vehiclesStore.List(ctx, vehiclesstore.ListQuery{
@@ -301,7 +310,7 @@ func (s *Server) resolveTemplateData(
 				userInfo.GetJobAdmin(),
 		})
 		if err != nil {
-			return nil, err
+			return nil, errswrap.NewError(err, errorsdocuments.ErrTemplateRenderFailed)
 		}
 
 		byPlate := make(map[string]*resourcesvehicles.Vehicle, len(vehicles))
@@ -374,37 +383,28 @@ func validateTemplateRequirements(
 		}
 		if check.spec.GetRequired() && check.count == 0 {
 			return errorsdocuments.ErrTemplateRequirementsNotMet(map[string]any{
-				"kind":      check.kind,
-				"required":  1,
-				"available": check.count,
+				kindKey:      check.kind,
+				requiredKey:  1,
+				availableKey: check.count,
 			})
 		}
 		if check.spec.GetMin() > 0 && int64(check.count) < int64(check.spec.GetMin()) {
 			return errorsdocuments.ErrTemplateRequirementsNotMet(map[string]any{
-				"kind":      check.kind,
-				"required":  check.spec.GetMin(),
-				"available": check.count,
+				kindKey:      check.kind,
+				requiredKey:  check.spec.GetMin(),
+				availableKey: check.count,
 			})
 		}
 		if check.spec.GetMax() > 0 && int64(check.count) > int64(check.spec.GetMax()) {
 			return errorsdocuments.ErrTemplateRequirementsExceeded(map[string]any{
-				"kind":      check.kind,
-				"required":  check.spec.GetMax(),
-				"available": check.count,
+				kindKey:      check.kind,
+				requiredKey:  check.spec.GetMax(),
+				availableKey: check.count,
 			})
 		}
 	}
-	return nil
-}
 
-func templateResolutionError(err error) error {
-	if err == nil {
-		return nil
-	}
-	if status.Code(err) == codes.InvalidArgument {
-		return err
-	}
-	return errswrap.NewError(err, errorsdocuments.ErrTemplateDataUnavailable)
+	return nil
 }
 
 func (s *Server) renderTemplate(

--- a/services/documents/templates.go
+++ b/services/documents/templates.go
@@ -5,6 +5,7 @@ import (
 	context "context"
 	"errors"
 	"html/template"
+	"regexp"
 
 	"github.com/Masterminds/sprig/v3"
 	resourcesaccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/access"
@@ -44,6 +45,15 @@ const (
 )
 
 var ErrTemplateActiveChar = errors.New("failed to resolve active character/user")
+
+// FIXME parse html via go and then remove/unwrap the template var spans, instead of using regex.
+var templateVarSpan = regexp.MustCompile(
+	`(?is)<span\b[^>]*\bdata-template-var\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>(.*?)</span>`,
+)
+
+func stripTemplateVarSpans(content string) string {
+	return templateVarSpan.ReplaceAllString(content, "$1")
+}
 
 var templateSubjectAccessOptions = access.SubjectAccessOptions{
 	BlockedAccess: int32(documentsaccess.AccessLevel_ACCESS_LEVEL_BLOCKED),
@@ -443,10 +453,12 @@ func (s *Server) renderTemplate(
 	outState := buf.String()
 
 	// Render Content template
+	content := stripTemplateVarSpans(docTmpl.GetContent())
+
 	contentTpl, err := template.
 		New("content").
 		Funcs(sprig.FuncMap()).
-		Parse(docTmpl.GetContent())
+		Parse(content)
 	if err != nil {
 		return "", "", "", err
 	}

--- a/services/documents/templates.go
+++ b/services/documents/templates.go
@@ -5,7 +5,7 @@ import (
 	context "context"
 	"errors"
 	"html/template"
-	"regexp"
+	"strings"
 
 	"github.com/Masterminds/sprig/v3"
 	resourcesaccess "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/access"
@@ -36,6 +36,8 @@ import (
 	vehiclesstore "github.com/fivenet-app/fivenet/v2026/stores/vehicles"
 	"github.com/go-jet/jet/v2/qrm"
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
+	htmlnode "golang.org/x/net/html"
+	"golang.org/x/net/html/atom"
 )
 
 const (
@@ -46,13 +48,68 @@ const (
 
 var ErrTemplateActiveChar = errors.New("failed to resolve active character/user")
 
-// FIXME parse html via go and then remove/unwrap the template var spans, instead of using regex.
-var templateVarSpan = regexp.MustCompile(
-	`(?is)<span\b[^>]*\bdata-template-var\s*=\s*(?:"[^"]*"|'[^']*')[^>]*>(.*?)</span>`,
-)
+func isTemplateActionSpan(node *htmlnode.Node) bool {
+	if node.Type != htmlnode.ElementNode || node.Data != "span" {
+		return false
+	}
 
-func stripTemplateVarSpans(content string) string {
-	return templateVarSpan.ReplaceAllString(content, "$1")
+	for _, attr := range node.Attr {
+		switch attr.Key {
+		case "data-template-var", "data-template-block", "data-template-block-end":
+			return true
+		}
+	}
+
+	return false
+}
+
+func unwrapTemplateActionSpans(node *htmlnode.Node) {
+	for child := node.FirstChild; child != nil; {
+		next := child.NextSibling
+		unwrapTemplateActionSpans(child)
+
+		if isTemplateActionSpan(child) {
+			for content := child.FirstChild; content != nil; {
+				nextContent := content.NextSibling
+				child.RemoveChild(content)
+				node.InsertBefore(content, child)
+				content = nextContent
+			}
+			node.RemoveChild(child)
+		}
+
+		child = next
+	}
+}
+
+func stripTemplateActionSpans(content string) (string, error) {
+	// Parse the editor HTML as a fragment so action spans can be identified by
+	// their element and exact data-* attributes instead of matching HTML with a
+	// regular expression. Rendering the cleaned tree may normalize markup such
+	// as attribute quoting or equivalent whitespace, which is intentional.
+	fragment, err := htmlnode.ParseFragment(strings.NewReader(content), &htmlnode.Node{
+		Type:     htmlnode.ElementNode,
+		DataAtom: atom.Div,
+		Data:     "div",
+	})
+	if err != nil {
+		return "", err
+	}
+
+	root := &htmlnode.Node{Type: htmlnode.DocumentNode}
+	for _, node := range fragment {
+		root.AppendChild(node)
+	}
+	unwrapTemplateActionSpans(root)
+
+	var output bytes.Buffer
+	for node := root.FirstChild; node != nil; node = node.NextSibling {
+		if err := htmlnode.Render(&output, node); err != nil {
+			return "", err
+		}
+	}
+
+	return output.String(), nil
 }
 
 var templateSubjectAccessOptions = access.SubjectAccessOptions{
@@ -453,7 +510,10 @@ func (s *Server) renderTemplate(
 	outState := buf.String()
 
 	// Render Content template
-	content := stripTemplateVarSpans(docTmpl.GetContent())
+	content, err := stripTemplateActionSpans(docTmpl.GetContent())
+	if err != nil {
+		return "", "", "", err
+	}
 
 	contentTpl, err := template.
 		New("content").

--- a/services/documents/templates_test.go
+++ b/services/documents/templates_test.go
@@ -92,7 +92,29 @@ func TestStripTemplateVarSpansPreservesTrimMarkers(t *testing.T) {
 
 	content := `<p><span class="template-var" data-template-var=".Firstname">{{- .Firstname -}}</span></p>`
 
-	require.Equal(t, `<p>{{- .Firstname -}}</p>`, stripTemplateVarSpans(content))
+	stripped, err := stripTemplateActionSpans(content)
+	require.NoError(t, err)
+	require.Equal(t, `<p>{{- .Firstname -}}</p>`, stripped)
+}
+
+func TestStripTemplateActionSpansPreservesOtherHTMLAttributes(t *testing.T) {
+	t.Parallel()
+
+	content := `<p data-custom="keep"><span data-template-block="if .Active" data-left-trim="true">{{- if .Active -}}</span><span data-template-block-end="end" data-right-trim="true">{{ end }}</span><span data-keep="yes">content</span></p>`
+
+	stripped, err := stripTemplateActionSpans(content)
+	require.NoError(t, err)
+	require.Equal(t, `<p data-custom="keep">{{- if .Active -}}{{ end }}<span data-keep="yes">content</span></p>`, stripped)
+}
+
+func TestStripTemplateActionSpansUnwrapsNestedActions(t *testing.T) {
+	t.Parallel()
+
+	content := `<p><span data-template-var=".Outer">before <span data-template-block="if .Active">{{ if .Active }}</span> after</span></p>`
+
+	stripped, err := stripTemplateActionSpans(content)
+	require.NoError(t, err)
+	require.Equal(t, `<p>before {{ if .Active }} after</p>`, stripped)
 }
 
 func TestValidateTemplateRequirementsAfterResolution(t *testing.T) {

--- a/services/documents/templates_test.go
+++ b/services/documents/templates_test.go
@@ -70,6 +70,31 @@ func TestRenderTemplateUsesColleagueActiveChar(t *testing.T) {
 	require.Equal(t, "/avatars/42.png (42)", content)
 }
 
+func TestRenderTemplateStripsTemplateVarSpan(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	tmpl := &documentstemplates.Template{
+		Content: `<p>Hello <span data-template-var="(index .Users 0).Firstname" class="template-var">{{ (index .Users 0).Firstname }}</span></p>`,
+	}
+	data := &resolvedTemplateData{
+		Users: []*users.User{{Firstname: "Smith"}},
+	}
+
+	_, _, content, err := server.renderTemplate(tmpl, data)
+
+	require.NoError(t, err)
+	require.Equal(t, "<p>Hello Smith</p>", content)
+}
+
+func TestStripTemplateVarSpansPreservesTrimMarkers(t *testing.T) {
+	t.Parallel()
+
+	content := `<p><span class="template-var" data-template-var=".Firstname">{{- .Firstname -}}</span></p>`
+
+	require.Equal(t, `<p>{{- .Firstname -}}</p>`, stripTemplateVarSpans(content))
+}
+
 func TestValidateTemplateRequirementsAfterResolution(t *testing.T) {
 	t.Parallel()
 

--- a/services/documents/templates_test.go
+++ b/services/documents/templates_test.go
@@ -1,0 +1,94 @@
+package documents
+
+import (
+	"testing"
+
+	documentstemplates "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/documents/templates"
+	jobscolleagues "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/jobs/colleagues"
+	users "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users"
+	usersprops "github.com/fivenet-app/fivenet/v2026/gen/go/proto/resources/users/props"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestRenderTemplateUsesResolvedUserProps(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	tmpl := &documentstemplates.Template{
+		ContentTitle: "{{ (index .Users 0).Props.Email }}",
+		State:        "{{ (index .Users 0).Props.OpenFines }}",
+		Content:      "{{ (index .Users 0).Firstname }}",
+	}
+	data := &resolvedTemplateData{
+		Users: []*users.User{
+			{
+				Firstname: "Canonical",
+				Props: &usersprops.UserProps{
+					Email:     stringPtr("canonical@example.test"),
+					OpenFines: int64Ptr(42),
+				},
+			},
+		},
+	}
+
+	title, state, content, err := server.renderTemplate(tmpl, data)
+
+	require.NoError(t, err)
+	require.Equal(t, "canonical@example.test", title)
+	require.Equal(t, "42", state)
+	require.Equal(t, "Canonical", content)
+}
+
+func TestRenderTemplateUsesColleagueActiveChar(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{}
+	tmpl := &documentstemplates.Template{
+		ContentTitle: "{{ .ActiveChar.Props.NamePrefix }} {{ .ActiveChar.Firstname }} {{ .ActiveChar.Lastname }} {{ .ActiveChar.Props.NameSuffix }}",
+		State:        "{{ .ActiveChar.PhoneNumber }}",
+		Content:      "{{ .ActiveChar.ProfilePicture }} ({{ .ActiveChar.ProfilePictureFileId }})",
+	}
+	data := &resolvedTemplateData{ActiveChar: &jobscolleagues.Colleague{
+		Firstname:            "Active",
+		Lastname:             "Colleague",
+		PhoneNumber:          stringPtr("555-0100"),
+		ProfilePicture:       stringPtr("/avatars/42.png"),
+		ProfilePictureFileId: int64Ptr(42),
+		Props: &jobscolleagues.ColleagueProps{
+			NamePrefix: stringPtr("Dr."),
+			NameSuffix: stringPtr("Jr."),
+		},
+	}}
+
+	title, state, content, err := server.renderTemplate(tmpl, data)
+
+	require.NoError(t, err)
+	require.Equal(t, "Dr. Active Colleague Jr.", title)
+	require.Equal(t, "555-0100", state)
+	require.Equal(t, "/avatars/42.png (42)", content)
+}
+
+func TestValidateTemplateRequirementsAfterResolution(t *testing.T) {
+	t.Parallel()
+
+	required := true
+	tmpl := &documentstemplates.Template{
+		Schema: &documentstemplates.TemplateSchema{
+			Requirements: &documentstemplates.TemplateRequirements{
+				Users: &documentstemplates.ObjectSpecs{Required: &required, Min: int32Ptr(2)},
+			},
+		},
+	}
+
+	err := validateTemplateRequirements(tmpl, &resolvedTemplateData{Users: []*users.User{{}}})
+
+	require.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func stringPtr(v string) *string { return &v }
+
+func int32Ptr(v int32) *int32 { return &v }
+
+func int64Ptr(v int64) *int64 { return &v }

--- a/stores/citizens/users.go
+++ b/stores/citizens/users.go
@@ -17,6 +17,7 @@ import (
 )
 
 type ListCitizensOptions struct {
+	UserIDs                        []int32
 	IncludePhoneNumber             bool
 	IncludeWanted                  bool
 	IncludeJob                     bool
@@ -78,6 +79,13 @@ func (s *Store) ListCitizens(
 		s.customDB.Columns.User.GetVisum(tUser.Alias()),
 	}
 	condition := s.customDB.Conditions.User.GetFilter(tUser.Alias())
+	if len(opts.UserIDs) > 0 {
+		ids := make([]mysql.Expression, 0, len(opts.UserIDs))
+		for _, id := range opts.UserIDs {
+			ids = append(ids, mysql.Int32(id))
+		}
+		condition = condition.AND(tUser.ID.IN(ids...))
+	}
 	orderBys := []mysql.OrderByClause{}
 
 	if opts.IncludePhoneNumber {

--- a/stores/settings/laws.go
+++ b/stores/settings/laws.go
@@ -440,9 +440,11 @@ func (s *Store) CreateOrUpdateLaw(
 				tLaws.Hint, tLaws.Fine, tLaws.DetentionTime, tLaws.StvoPoints, tLaws.DeletedAt,
 			).SET(
 				req.GetLaw().GetLawbookId(), mysql.Int32(sortOrder), req.GetLaw().GetName(),
-				dbutils.StringEmpty(req.GetLaw().GetDescription()), dbutils.StringEmpty(req.GetLaw().GetHint()),
+				dbutils.StringEmpty(req.GetLaw().GetDescription()),
+				dbutils.StringEmpty(req.GetLaw().GetHint()),
 				req.GetLaw().Fine, req.GetLaw().DetentionTime, req.GetLaw().StvoPoints, mysql.NULL,
-			).WHERE(tLaws.ID.EQ(mysql.Int64(existing.ID))).LIMIT(1).ExecContext(ctx, tx)
+			).
+				WHERE(tLaws.ID.EQ(mysql.Int64(existing.ID))).LIMIT(1).ExecContext(ctx, tx)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -453,9 +455,11 @@ func (s *Store) CreateOrUpdateLaw(
 				tLaws.Hint, tLaws.Fine, tLaws.DetentionTime, tLaws.StvoPoints,
 			).VALUES(
 				req.GetLaw().GetLawbookId(), mysql.Int32(sortOrder), req.GetLaw().GetName(),
-				dbutils.StringEmpty(req.GetLaw().GetDescription()), dbutils.StringEmpty(req.GetLaw().GetHint()),
+				dbutils.StringEmpty(req.GetLaw().GetDescription()),
+				dbutils.StringEmpty(req.GetLaw().GetHint()),
 				req.GetLaw().Fine, req.GetLaw().DetentionTime, req.GetLaw().StvoPoints,
-			).ExecContext(ctx, tx)
+			).
+				ExecContext(ctx, tx)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/stores/vehicles/vehicles.go
+++ b/stores/vehicles/vehicles.go
@@ -17,6 +17,7 @@ import (
 
 type ListQuery struct {
 	LicensePlate string
+	Plates       []string
 	Model        string
 	UserIDs      []int32
 	Job          string
@@ -331,6 +332,13 @@ func (s *Store) listConditions(
 
 	if search := dbutils.PrepareForLikeSearch(q.LicensePlate); search != "" {
 		condition = mysql.AND(condition, tVehicles.Plate.LIKE(mysql.String(search)))
+	}
+	if len(q.Plates) > 0 {
+		plates := make([]mysql.Expression, 0, len(q.Plates))
+		for _, plate := range q.Plates {
+			plates = append(plates, mysql.String(plate))
+		}
+		condition = mysql.AND(condition, tVehicles.Plate.IN(plates...))
 	}
 
 	modelColumn := s.customDB.Columns.Vehicle.GetModel(tVehicles.Alias())


### PR DESCRIPTION
**Description of changes:**

Switch document templates data to "selection of IDs" instead and improve the TemplateBlock and TemplateVar TipTap editor extensions.

<img width="716" height="825" alt="image" src="https://github.com/user-attachments/assets/9caa35e9-16d8-4835-8876-01a6bf8b3495" />


**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [CONTRIBUTING.md](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Reviewed the contributor guide [here (CONTRIBUTING.md)](https://github.com/fivenet-app/fivenet/blob/main/CONTRIBUTING.md).
- [x] Documentation has been updated, if necessary. Please open a PR in the [website repository](https://github.com/fivenet-app/fivenet-app.github.io) and add a link to the PR here.
- [x] Tests have been added, if necessary.
